### PR TITLE
ci: add release workflow with full 5-target build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,131 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.28.0)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            os: macos-13
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            archive: zip
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install Linux deps
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev cmake
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Build Web UI
+        run: cd web && bun install --frozen-lockfile && bun run build
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package (tar.gz)
+        if: matrix.archive == 'tar.gz'
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/wshm dist/wshm
+          cd dist
+          tar -czf wshm-${{ matrix.target }}.tar.gz wshm
+          shasum -a 256 wshm-${{ matrix.target }}.tar.gz > wshm-${{ matrix.target }}.tar.gz.sha256
+          rm wshm
+
+      - name: Package (zip)
+        if: matrix.archive == 'zip'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          Copy-Item target/${{ matrix.target }}/release/wshm.exe dist/wshm.exe
+          Compress-Archive -Path dist/wshm.exe -DestinationPath dist/wshm-${{ matrix.target }}.zip
+          (Get-FileHash dist/wshm-${{ matrix.target }}.zip -Algorithm SHA256).Hash.ToLower() + "  wshm-${{ matrix.target }}.zip" | Out-File -Encoding ascii dist/wshm-${{ matrix.target }}.zip.sha256
+          Remove-Item dist/wshm.exe
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wshm-${{ matrix.target }}
+          path: dist/*
+
+  release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Determine tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Combine checksums
+        run: |
+          cd artifacts
+          cat *.sha256 > checksums-${{ steps.tag.outputs.tag }}.sha256
+          rm -f *.sha256 && mv checksums-${{ steps.tag.outputs.tag }}.sha256 ./
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: ${{ steps.tag.outputs.tag }}
+          generate_release_notes: true
+          files: artifacts/*


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` — tag-triggered release workflow that builds all 5 supported targets in parallel (macOS Intel + ARM, Linux x86_64 + ARM, Windows x86_64) and publishes a GitHub release with binaries + sha256 checksums.
- Unblocks the Homebrew formula's missing `x86_64-apple-darwin` and `aarch64-unknown-linux-gnu` slots.

fixes #14

## Targets
| target | runner | archive |
|---|---|---|
| x86_64-apple-darwin | macos-13 | tar.gz |
| aarch64-apple-darwin | macos-latest | tar.gz |
| x86_64-unknown-linux-gnu | ubuntu-latest | tar.gz |
| aarch64-unknown-linux-gnu | ubuntu-24.04-arm | tar.gz |
| x86_64-pc-windows-msvc | windows-latest | zip |

## Follow-up
Homebrew formula (`wshm-dev/homebrew-tap`) must be updated once v0.28.0 is tagged:
- fill real sha256 for `x86_64-apple-darwin` and `aarch64-apple-darwin`
- add missing `on_arm` block under `on_linux` with real sha256

Kept out of this PR to avoid pointing `brew install` at tarballs that don't exist yet.

## Test plan
- [ ] Dry-run via `workflow_dispatch` with a throwaway tag (`v0.28.0-rc1`) to verify the matrix builds clean.
- [ ] Confirm all 5 archives + combined checksums attach to the GitHub release.
- [ ] `brew install wshm` works on Apple Silicon, Intel Mac, Linux x86_64 after v0.28.0 tag + formula update.