### PR TITLE
feat(config): align multi-repo fallback UX with issue spec

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1233,14 +1233,17 @@ impl Config {
                         } else if enabled_repos.is_empty() {
                             anyhow::bail!("Not inside a git repository and no enabled repos in ~/.wshm/global.toml. Use --repo owner/repo");
                         } else {
-                            // Multiple repos: print list and instructions
-                            eprintln!("Not inside a git repository. Multiple repos found in ~/.wshm/global.toml:");
-                            eprintln!();
-                            for repo in &enabled_repos {
-                                eprintln!("  {}", repo.slug);
+                            eprintln!(
+                                "Found ~/.wshm/global.toml with {} repos:",
+                                enabled_repos.len()
+                            );
+                            for (i, repo) in enabled_repos.iter().enumerate() {
+                                eprintln!("  {}. {}", i + 1, repo.slug);
                             }
                             eprintln!();
-                            eprintln!("Use --repo <slug> to specify which one.");
+                            eprintln!(
+                                "Use --repo <slug> to select, or run all with: wshm run --all"
+                            );
                             anyhow::bail!("Ambiguous repo selection");
                         }
                     } else {


### PR DESCRIPTION
## Summary
The core behaviour requested by #1 — fall back to `~/.wshm/global.toml` when `wshm` runs outside a git repository — has been in place since the initial OSS release (`src/config.rs:1206-1252`). This PR only polishes the multi-repo ambiguity output to match the UX sketched in the issue.

## Before
```
Not inside a git repository. Multiple repos found in ~/.wshm/global.toml:

  rtk-ai/rtk
  rtk-ai/vox
  ...

Use --repo <slug> to specify which one.
```

## After
```
Found ~/.wshm/global.toml with 5 repos:
  1. rtk-ai/rtk
  2. rtk-ai/vox
  3. rtk-ai/icm
  4. pszymkowiak/wshm
  5. pszymkowiak/diskstat

Use --repo <slug> to select, or run all with: wshm run --all
```

Exactly the expected output in the issue body.

## Unchanged
- Single-repo auto-detect (fires when exactly one enabled repo)
- Zero-repo error path
- The original `Not inside a git repository. Use --repo owner/repo` error when no `global.toml` exists

fixes #1

## Test plan
- [ ] From `~`, with multi-repo `global.toml`: verify new banner + numbered list + `--all` hint
- [ ] From `~`, with single-repo `global.toml`: verify auto-select (unchanged)
- [ ] From `~`, with no `global.toml`: verify original error (unchanged)