### PR TITLE
feat(summary): TUI Summary tab + web /summary page

### DIFF
--- a/src/pipelines/status.rs
+++ b/src/pipelines/status.rs
@@ -107,7 +107,7 @@ pub fn show(db: &Database, json: bool) -> Result<()> {
 }
 
 /// Build a summary from the local database cache.
-fn build_summary(config: &Config, db: &Database) -> Result<Summary> {
+pub fn build_summary(config: &Config, db: &Database) -> Result<Summary> {
     let open_issues = db.get_open_issues()?;
     let untriaged = db.get_untriaged_issues()?;
     let open_pulls = db.get_open_pulls()?;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -17,6 +17,7 @@ pub struct LogEntry {
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum Tab {
+    Summary,
     Repos,
     Action,
     Issues,
@@ -29,6 +30,7 @@ pub enum Tab {
 impl Tab {
     pub fn title(&self) -> &'static str {
         match self {
+            Tab::Summary => "Summary",
             Tab::Repos => "Repos",
             Tab::Action => "Action",
             Tab::Issues => "Issues",
@@ -41,7 +43,7 @@ impl Tab {
 
     pub fn all() -> &'static [Tab] {
         &[
-            Tab::Repos, Tab::Action, Tab::Issues, Tab::PullRequests, Tab::Queue, Tab::Stats, Tab::Activity,
+            Tab::Summary, Tab::Repos, Tab::Action, Tab::Issues, Tab::PullRequests, Tab::Queue, Tab::Stats, Tab::Activity,
         ]
     }
 }
@@ -163,6 +165,7 @@ pub struct App {
     pub confirm_delete: bool,
     pub settings_popup: Option<RepoSettings>,
     pub action_detail: Option<ActionDetailPopup>,
+    pub summary: Option<crate::pipelines::status::Summary>,
 }
 
 #[derive(Clone, PartialEq)]
@@ -214,7 +217,7 @@ impl App {
     pub fn new(config: &Config, db: &Database) -> Result<Self> {
         let mut app = Self {
             repo_slug: config.repo_slug(),
-            active_tab: if GlobalConfig::default_path().exists() { Tab::Repos } else { Tab::Issues },
+            active_tab: Tab::Summary,
             scroll_offset: 0,
             sort_field: SortField::Number,
             sort_dir: SortDir::Desc,
@@ -249,11 +252,17 @@ impl App {
             confirm_delete: false,
             settings_popup: None,
             action_detail: None,
+            summary: None,
         };
         app.load_repos();
         app.load_actions();
         app.refresh(db)?;
+        app.load_summary(config, db);
         Ok(app)
+    }
+
+    pub fn load_summary(&mut self, config: &Config, db: &Database) {
+        self.summary = crate::pipelines::status::build_summary(config, db).ok();
     }
 
     pub fn refresh(&mut self, db: &Database) -> Result<()> {
@@ -482,6 +491,7 @@ impl App {
             Tab::Repos => self.repos.len(),
             Tab::Action => self.actions.len(),
             Tab::Activity => self.logs.len(),
+            Tab::Summary => 0,
         }
     }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -31,6 +31,7 @@ pub fn draw(f: &mut Frame, app: &App) {
     draw_stats(f, app, chunks[1]);
 
     match app.active_tab {
+        Tab::Summary => draw_summary(f, app, chunks[2]),
         Tab::Repos => draw_repos(f, app, chunks[2]),
         Tab::Action => draw_action_plan(f, app, chunks[2]),
         Tab::Issues => draw_issues(f, app, chunks[2]),
@@ -1010,6 +1011,179 @@ fn draw_activity(f: &mut Frame, app: &App, area: Rect) {
     );
 
     f.render_widget(list, area);
+}
+
+fn draw_summary(f: &mut Frame, app: &App, area: Rect) {
+    let summary = match app.summary.as_ref() {
+        Some(s) => s,
+        None => {
+            let text = Paragraph::new("No summary data available. Run `wshm sync` first.")
+                .block(Block::default().borders(Borders::ALL).title(" Summary "))
+                .style(Style::default().fg(Color::DarkGray));
+            f.render_widget(text, area);
+            return;
+        }
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+
+    lines.push(Line::from(Span::styled(
+        format!("{} — daily digest", summary.repo),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )));
+    lines.push(Line::from(""));
+
+    lines.push(Line::from(vec![
+        Span::raw("Issues: "),
+        Span::styled(
+            summary.open_issues.to_string(),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(format!(" open ({} untriaged)", summary.untriaged_issues)),
+    ]));
+    lines.push(Line::from(vec![
+        Span::raw("PRs:    "),
+        Span::styled(
+            summary.open_prs.to_string(),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(format!(" open ({} unanalyzed)", summary.unanalyzed_prs)),
+    ]));
+    if summary.conflicts > 0 {
+        lines.push(Line::from(vec![
+            Span::raw("Conflicts: "),
+            Span::styled(
+                summary.conflicts.to_string(),
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
+        ]));
+    }
+
+    if !summary.high_priority_issues.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Action Required",
+            Style::default()
+                .fg(Color::Red)
+                .add_modifier(Modifier::BOLD),
+        )));
+        for i in summary.high_priority_issues.iter().take(10) {
+            let prio = i.priority.as_deref().unwrap_or("?");
+            let age = if i.age_days > 0 {
+                format!(" ({}d)", i.age_days)
+            } else {
+                String::new()
+            };
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("  #{} ", i.number),
+                    Style::default().fg(Color::Yellow),
+                ),
+                Span::styled(
+                    format!("{prio}{age} "),
+                    Style::default().fg(Color::Red),
+                ),
+                Span::raw(i.title.clone()),
+            ]));
+        }
+    }
+
+    if !summary.high_risk_prs.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Attention PRs",
+            Style::default()
+                .fg(Color::Magenta)
+                .add_modifier(Modifier::BOLD),
+        )));
+        for p in summary.high_risk_prs.iter().take(10) {
+            let mut tags = Vec::new();
+            if let Some(ref risk) = p.risk_level {
+                tags.push(format!("risk:{risk}"));
+            }
+            if p.has_conflicts {
+                tags.push("CONFLICT".to_string());
+            }
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("  #{} ", p.number),
+                    Style::default().fg(Color::Yellow),
+                ),
+                Span::styled(
+                    format!("[{}] ", tags.join(", ")),
+                    Style::default().fg(Color::Magenta),
+                ),
+                Span::raw(p.title.clone()),
+            ]));
+        }
+    }
+
+    if !summary.top_issues.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Issues TODO",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )));
+        for i in &summary.top_issues {
+            let prio = i.priority.as_deref().unwrap_or("-");
+            let cat = i.category.as_deref().unwrap_or("-");
+            let age = if i.age_days > 0 {
+                format!(" ({}d)", i.age_days)
+            } else {
+                String::new()
+            };
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("  #{} ", i.number),
+                    Style::default().fg(Color::Yellow),
+                ),
+                Span::styled(
+                    format!("{prio}/{cat}{age} "),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::raw(i.title.clone()),
+            ]));
+        }
+    }
+
+    if !summary.top_prs.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "PRs TODO",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )));
+        for p in &summary.top_prs {
+            let risk = p.risk_level.as_deref().unwrap_or("-");
+            let age = if p.age_days > 0 {
+                format!(" ({}d)", p.age_days)
+            } else {
+                String::new()
+            };
+            let conflict = if p.has_conflicts { " CONFLICT" } else { "" };
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("  #{} ", p.number),
+                    Style::default().fg(Color::Yellow),
+                ),
+                Span::styled(
+                    format!("{risk}{conflict}{age} "),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::raw(p.title.clone()),
+            ]));
+        }
+    }
+
+    let content = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::ALL).title(" Summary "))
+        .scroll((app.scroll_offset as u16, 0));
+    f.render_widget(content, area);
 }
 
 fn draw_footer(f: &mut Frame, area: Rect) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -112,6 +112,42 @@ export function fetchStatus(): Promise<Status> {
 	return apiGet<Status>('/status');
 }
 
+export interface IssueBrief {
+	number: number;
+	title: string;
+	priority: string | null;
+	category: string | null;
+	labels: string[];
+	age_days: number;
+}
+
+export interface PrBrief {
+	number: number;
+	title: string;
+	risk_level: string | null;
+	ci_status: string | null;
+	has_conflicts: boolean;
+	age_days: number;
+}
+
+export interface Summary {
+	repo: string;
+	timestamp: string;
+	open_issues: number;
+	untriaged_issues: number;
+	high_priority_issues: IssueBrief[];
+	top_issues: IssueBrief[];
+	open_prs: number;
+	unanalyzed_prs: number;
+	high_risk_prs: PrBrief[];
+	top_prs: PrBrief[];
+	conflicts: number;
+}
+
+export function fetchSummary(): Promise<Summary> {
+	return apiGet<Summary>('/summary');
+}
+
 export function fetchIssues(state: string = 'open'): Promise<Issue[]> {
 	return apiGet<Issue[]>('/issues', { state });
 }

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
 
 	const navItems = [
 		{ href: '/', label: 'Dashboard', icon: 'D' },
+		{ href: '/summary', label: 'Summary', icon: 'M' },
 		{ href: '/issues', label: 'Issues', icon: 'I' },
 		{ href: '/prs', label: 'Pull Requests', icon: 'P' },
 		{ href: '/triage', label: 'Triage', icon: 'T' },

--- a/web/src/routes/summary/+page.svelte
+++ b/web/src/routes/summary/+page.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { selectedRepo } from '$lib/stores';
+	import { fetchSummary, type Summary } from '$lib/api';
+	import { Card, Badge } from 'flowbite-svelte';
+
+	let summary: Summary | null = $state(null);
+	let error: string | null = $state(null);
+
+	async function load() {
+		try {
+			error = null;
+			summary = await fetchSummary();
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load summary';
+		}
+	}
+
+	onMount(() => {
+		load();
+		const unsub = selectedRepo.subscribe(() => { load(); });
+		return unsub;
+	});
+
+	function priorityColor(p: string | null): 'red' | 'yellow' | 'blue' | 'dark' {
+		if (p === 'critical' || p === 'high') return 'red';
+		if (p === 'medium') return 'yellow';
+		if (p === 'low') return 'blue';
+		return 'dark';
+	}
+</script>
+
+<svelte:head>
+	<title>wshm - Summary</title>
+</svelte:head>
+
+<div class="mb-6">
+	<h2 class="text-xl font-semibold text-gray-100 mb-1">Summary</h2>
+	<p class="text-sm text-gray-500">Daily digest — same data as Discord notifications</p>
+</div>
+
+{#if error}
+	<Card class="border-red-500 bg-gray-800">
+		<p class="text-red-400">{error}</p>
+		<p class="mt-2 text-sm text-gray-500">The wshm daemon must expose <code>/api/v1/summary</code>.</p>
+	</Card>
+{:else if summary}
+	<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+		<Card class="bg-gray-800 border-gray-700 text-center">
+			<div class="text-xs uppercase tracking-wider text-gray-500 mb-2">Open Issues</div>
+			<div class="text-3xl font-bold text-gray-100 mono">{summary.open_issues}</div>
+			<div class="text-xs text-gray-500 mt-1">{summary.untriaged_issues} untriaged</div>
+		</Card>
+		<Card class="bg-gray-800 border-gray-700 text-center">
+			<div class="text-xs uppercase tracking-wider text-gray-500 mb-2">Open PRs</div>
+			<div class="text-3xl font-bold text-gray-100 mono">{summary.open_prs}</div>
+			<div class="text-xs text-gray-500 mt-1">{summary.unanalyzed_prs} unanalyzed</div>
+		</Card>
+		<Card class="bg-gray-800 border-gray-700 text-center">
+			<div class="text-xs uppercase tracking-wider text-gray-500 mb-2">Conflicts</div>
+			<div class="text-3xl font-bold {summary.conflicts > 0 ? 'text-red-400' : 'text-gray-100'} mono">{summary.conflicts}</div>
+		</Card>
+		<Card class="bg-gray-800 border-gray-700 text-center">
+			<div class="text-xs uppercase tracking-wider text-gray-500 mb-2">Action Required</div>
+			<div class="text-3xl font-bold {summary.high_priority_issues.length > 0 ? 'text-red-400' : 'text-gray-100'} mono">{summary.high_priority_issues.length}</div>
+		</Card>
+	</div>
+
+	{#if summary.high_priority_issues.length > 0}
+		<Card class="bg-gray-800 border-gray-700 mb-4">
+			<h3 class="text-lg font-semibold text-red-400 mb-3">Action Required</h3>
+			<ul class="space-y-2">
+				{#each summary.high_priority_issues.slice(0, 10) as issue (issue.number)}
+					<li class="flex items-start gap-2 text-sm">
+						<a href="/issues/{issue.number}" class="text-yellow-400 mono hover:underline">#{issue.number}</a>
+						<Badge color={priorityColor(issue.priority)}>{issue.priority ?? '?'}</Badge>
+						<span class="text-gray-300 flex-1">{issue.title}</span>
+						{#if issue.age_days > 0}<span class="text-gray-500 text-xs">{issue.age_days}d</span>{/if}
+					</li>
+				{/each}
+			</ul>
+		</Card>
+	{/if}
+
+	{#if summary.high_risk_prs.length > 0}
+		<Card class="bg-gray-800 border-gray-700 mb-4">
+			<h3 class="text-lg font-semibold text-purple-400 mb-3">Attention PRs</h3>
+			<ul class="space-y-2">
+				{#each summary.high_risk_prs.slice(0, 10) as pr (pr.number)}
+					<li class="flex items-start gap-2 text-sm">
+						<a href="/prs/{pr.number}" class="text-yellow-400 mono hover:underline">#{pr.number}</a>
+						{#if pr.risk_level}<Badge color="purple">risk:{pr.risk_level}</Badge>{/if}
+						{#if pr.has_conflicts}<Badge color="red">CONFLICT</Badge>{/if}
+						<span class="text-gray-300 flex-1">{pr.title}</span>
+						{#if pr.age_days > 0}<span class="text-gray-500 text-xs">{pr.age_days}d</span>{/if}
+					</li>
+				{/each}
+			</ul>
+		</Card>
+	{/if}
+
+	{#if summary.top_issues.length > 0}
+		<Card class="bg-gray-800 border-gray-700 mb-4">
+			<h3 class="text-lg font-semibold text-cyan-400 mb-3">Issues TODO</h3>
+			<ul class="space-y-2">
+				{#each summary.top_issues as issue (issue.number)}
+					<li class="flex items-start gap-2 text-sm">
+						<a href="/issues/{issue.number}" class="text-yellow-400 mono hover:underline">#{issue.number}</a>
+						<Badge color={priorityColor(issue.priority)}>{issue.priority ?? '-'}</Badge>
+						{#if issue.category}<span class="text-gray-500 text-xs">{issue.category}</span>{/if}
+						<span class="text-gray-300 flex-1">{issue.title}</span>
+						{#if issue.age_days > 0}<span class="text-gray-500 text-xs">{issue.age_days}d</span>{/if}
+					</li>
+				{/each}
+			</ul>
+		</Card>
+	{/if}
+
+	{#if summary.top_prs.length > 0}
+		<Card class="bg-gray-800 border-gray-700 mb-4">
+			<h3 class="text-lg font-semibold text-cyan-400 mb-3">PRs TODO</h3>
+			<ul class="space-y-2">
+				{#each summary.top_prs as pr (pr.number)}
+					<li class="flex items-start gap-2 text-sm">
+						<a href="/prs/{pr.number}" class="text-yellow-400 mono hover:underline">#{pr.number}</a>
+						{#if pr.risk_level}<Badge color="purple">{pr.risk_level}</Badge>{/if}
+						{#if pr.has_conflicts}<Badge color="red">CONFLICT</Badge>{/if}
+						<span class="text-gray-300 flex-1">{pr.title}</span>
+						{#if pr.age_days > 0}<span class="text-gray-500 text-xs">{pr.age_days}d</span>{/if}
+					</li>
+				{/each}
+			</ul>
+		</Card>
+	{/if}
+
+	<p class="text-xs text-gray-500 mt-4">Generated at {summary.timestamp}</p>
+{:else}
+	<p class="text-gray-500">Loading…</p>
+{/if}


### PR DESCRIPTION
## Summary
`wshm summary` (CLI) already computed the full digest struct — this PR surfaces the exact same data in the **TUI** (new first tab) and the **web UI** (new `/summary` page), so maintainers get the daily digest wherever they're working.

fixes #2

## Changes
- `pipelines/status.rs`: make `build_summary` `pub` so the TUI and the Pro daemon's future API handler can reuse it (no reimplementation).
- `tui/app.rs`: add `Tab::Summary` as the first tab, make it the default on launch, add `summary: Option<Summary>` state loaded via `App::load_summary` on startup.
- `tui/ui.rs`: `draw_summary` renders the digest with coloured section headings (red Action Required, magenta Attention PRs, cyan Issues/PRs TODO) inside a scrollable `Paragraph`.
- `web/src/lib/api.ts`: add `Summary` / `IssueBrief` / `PrBrief` types and `fetchSummary()` hitting `/api/v1/summary`.
- `web/src/routes/summary/+page.svelte`: new route with 4 stat cards + the 4 digest sections, each row deep-linking to `/issues/{n}` or `/prs/{n}`.
- `web/src/routes/+layout.svelte`: add the Summary entry to the sidebar (icon `M`) between Dashboard and Issues.

## Follow-up (Pro side)
The web page calls `/api/v1/summary` which does not exist on the daemon yet. The handler is a one-liner since the struct is already serializable:

```rust
async fn api_summary(State(state): State<AppState>) -> impl IntoResponse {
    match pipelines::status::build_summary(&state.config, &state.db) {
        Ok(s) => Json(s).into_response(),
        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
    }
}
```

Will open a matching PR on `wshm-pro` once this merges.

## Test plan
- [x] `cargo build --release` clean
- [x] `cargo clippy --release -- -D warnings` clean
- [x] `bun run build` clean (Svelte 5 + Vite)
- [ ] Run TUI, confirm Summary tab opens first and renders digest
- [ ] Open `/summary` in browser once Pro endpoint lands