### PR TITLE
docs: make install section match reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,9 @@ One static binary. No SaaS dependency. Runs where your code lives.
 | Platform       | How                                                              |
 |----------------|------------------------------------------------------------------|
 | **VM / VPS**   | systemd service, auto-update via Homebrew, any Linux             |
-| **Docker**     | `docker run ghcr.io/wshm-dev/wshm:latest daemon`, rootless Podman OK |
-| **Kubernetes** | Single-pod deployment, ConfigMap for `config.toml`               |
-| **GitHub Action** | No server needed, runs on every `issues` / `pull_request` event |
 | **Local dev**  | `wshm tui` / `wshm triage` — works offline with Ollama           |
+
+Docker images, Kubernetes manifests, and a GitHub Action are planned — follow [#22](https://github.com/wshm-dev/wshm/issues/22).
 
 Forge support: **GitHub** (personal + org), **GitLab** (.com + self-managed), **Gitea / Forgejo / Codeberg**, **Azure DevOps** (Services + Server).
 
@@ -243,52 +242,37 @@ wshm daemon --config /etc/wshm/global.toml --poll
 
 ### Install
 
-#### Homebrew (macOS + Linux)
+> **Heads up** — the current release (`v0.27.0`) only ships prebuilt binaries for **Linux x86_64** and **Windows x86_64**. Full coverage (Intel Mac, Apple Silicon, ARM Linux) arrives with the next tagged release once the 5-target build matrix runs. Track [#22](https://github.com/wshm-dev/wshm/issues/22).
+
+#### Linux x86_64 — Homebrew
 
 ```bash
 brew tap wshm-dev/tap
 brew install wshm
 ```
 
-#### Shell installer (macOS + Linux)
-
-```bash
-curl -fsSL https://wshm.dev/install.sh | sh
-```
-
-#### Cargo (any platform with a Rust toolchain)
-
-```bash
-cargo install wshm-core --bin wshm
-```
-
-#### Docker
-
-```bash
-docker pull ghcr.io/wshm-dev/wshm:latest
-```
-
-#### Windows
+#### Windows x86_64 — direct download
 
 ```powershell
-# PowerShell — download and extract the latest release
-Invoke-WebRequest -Uri https://github.com/wshm-dev/wshm/releases/latest/download/wshm-x86_64-pc-windows-msvc.zip -OutFile wshm.zip
+Invoke-WebRequest -Uri https://github.com/wshm-dev/wshm/releases/download/v0.27.0/wshm-x86_64-pc-windows-msvc.zip -OutFile wshm.zip
 Expand-Archive wshm.zip -DestinationPath $env:USERPROFILE\.wshm\bin
+# then add %USERPROFILE%\.wshm\bin to your PATH
 ```
 
-Or install from source with `cargo install wshm-core --bin wshm` (requires the [Rust toolchain](https://rustup.rs)).
+#### Everything else
 
-Native Scoop / winget manifests are not yet published — follow [#TBD](https://github.com/wshm-dev/wshm/issues) for updates.
+- **Intel Mac, Apple Silicon, ARM Linux** — arriving with the next release; `brew install wshm` will work on all of them once v0.28.0 ships.
+- **`cargo install`, install.sh, Docker, Scoop/winget** — not yet published, tracked in [#22](https://github.com/wshm-dev/wshm/issues/22).
 
-#### Supported platforms
+#### Release pipeline
 
-| OS      | Architectures         | Install methods                         |
-|---------|-----------------------|-----------------------------------------|
-| macOS   | x86_64 (Intel), aarch64 (Apple Silicon) | Homebrew, shell installer, Cargo, Docker |
-| Linux   | x86_64, aarch64 (GNU) | Homebrew, shell installer, Cargo, Docker |
-| Windows | x86_64                | GitHub Releases (zip), Cargo            |
-
-Windows is a fully supported tier-1 target: CI builds and tests every commit on `windows-latest`, and every release ships a `wshm-x86_64-pc-windows-msvc.zip`. Homebrew and the `install.sh` shell script are macOS/Linux only by design.
+| Target                       | Prebuilt today | After v0.28.0 |
+|------------------------------|----------------|---------------|
+| `x86_64-unknown-linux-gnu`   | ✓              | ✓             |
+| `x86_64-pc-windows-msvc`     | ✓              | ✓             |
+| `x86_64-apple-darwin`        | ✗              | ✓             |
+| `aarch64-apple-darwin`       | ✗              | ✓             |
+| `aarch64-unknown-linux-gnu`  | ✗              | ✓             |
 
 ### Configure
 


### PR DESCRIPTION
## Summary
The install section listed channels that **do not exist today** — I hit this while smoke-testing what a user would actually run:

| Command in old README | Reality |
|---|---|
| \`cargo install wshm-core --bin wshm\` | \`wshm-core\` not on crates.io, and it's a library-only crate (no bin target) |
| \`curl https://wshm.dev/install.sh \| sh\` | URL returns 404 |
| \`docker pull ghcr.io/wshm-dev/wshm:latest\` | Image does not exist on GHCR |
| \`brew install wshm\` on Intel Mac / Apple Silicon | Formula has empty sha256 for both Mac rows — \`brew install\` aborts |
| \`brew install wshm\` on ARM Linux | Formula has no \`on_arm\` block under \`on_linux\` |
| Windows download via \`homebrew-tap/releases/latest/...\` | 404; the actual zip lives under \`wshm-dev/wshm/releases/v0.27.0\` |

## What this PR changes
- Replace the install section with the two channels that actually work **today** (v0.27.0): Homebrew on Linux x86_64, direct zip download on Windows x86_64.
- Add a clear "heads up" banner that full multi-platform Homebrew coverage lands with **v0.28.0** (the 5-target release matrix in \`wshm-pro#5\` merged earlier — no changes here, just waiting for the next tag).
- Link all missing channels to the tracking issue **#22** (\`cargo install\`, \`install.sh\`, Docker, Scoop/winget).
- Add a release-pipeline matrix table showing which targets are prebuilt today vs after v0.28.0.
- Trim the Deploy table to drop the Docker / Kubernetes / GitHub Action rows which had no corresponding artifact.

## Verification (ran before committing)
\`\`\`
Linux v0.27.0 tarball          200
Windows v0.27.0 zip            200
brew tap repo root             200
tracking issue #22             200
\`\`\`

Also checked \`src/git_provider/\` to confirm the GitLab / Gitea / Azure DevOps claims in the Forge support line are backed by actual modules, and \`src/ai/client.rs\` for the 14 AI providers listed in the README (all 14 present: Anthropic, OpenAI, Google, Mistral, Groq, DeepSeek, xAI, Together, Fireworks, Perplexity, Cohere, OpenRouter, Ollama, Azure).

## Test plan
- [ ] \`brew tap wshm-dev/tap && brew install wshm\` on a Linux x86_64 box → binary in PATH.
- [ ] PowerShell snippet on a Windows box → binary in \`%USERPROFILE%\\.wshm\\bin\`.
- [ ] After v0.28.0 tag lands and the matrix runs, come back here and flip the "After v0.28.0" column of the matrix table into the "today" column.