### PR TITLE
feat: Docker image on Docker Hub (innovtech/wshm)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,3 +194,45 @@ jobs:
               -f message="chore: update wshm formula to ${VERSION}" \
               -f content="$CONTENT"
           fi
+
+  docker:
+    name: Build and push Docker image
+    needs: [build-linux-x86, build-linux-arm]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version
+        id: version
+        run: |
+          TAG="${{ github.ref_name || github.event.inputs.tag }}"
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            innovtech/wshm:${{ steps.version.outputs.version }}
+            innovtech/wshm:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/wshm-dev/wshm
+            org.opencontainers.image.description=wshm — AI-powered GitHub agent
+            org.opencontainers.image.licenses=SSPL-1.0
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1.7
+
+# ────────────────────────────────────────────────────────────────
+# Stage 1 — builder
+# ────────────────────────────────────────────────────────────────
+FROM rust:1-bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      pkg-config cmake ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+COPY . .
+RUN cargo build --release --bin wshm && strip target/release/wshm
+
+# ────────────────────────────────────────────────────────────────
+# Stage 2 — runtime
+# ────────────────────────────────────────────────────────────────
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates git \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --create-home --home-dir /home/wshm --shell /usr/sbin/nologin wshm
+
+COPY --from=builder /build/target/release/wshm /usr/local/bin/wshm
+
+USER wshm
+WORKDIR /home/wshm
+
+ENV WSHM_HOME=/home/wshm/.wshm
+
+ENTRYPOINT ["/usr/local/bin/wshm"]

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ One static binary. No SaaS dependency. Runs where your code lives.
 | Platform       | How                                                              |
 |----------------|------------------------------------------------------------------|
 | **VM / VPS**   | systemd service, auto-update via Homebrew, any Linux             |
-| **Docker**     | `docker run ghcr.io/wshm-dev/wshm:latest` — multi-arch (amd64 + arm64), ships with v0.28.0 |
+| **Docker**     | `docker run innovtech/wshm:latest` — multi-arch (amd64 + arm64)                            |
 | **Local dev**  | `wshm tui` / `wshm triage` — works offline with Ollama           |
 
 Kubernetes manifests and a GitHub Action are planned — follow [#22](https://github.com/wshm-dev/wshm/issues/22).


### PR DESCRIPTION
## Summary

- Add `Dockerfile` (multi-stage, `debian:bookworm-slim` runtime, cmake for static git2)
- Add `docker:` job in `release.yml` — builds `linux/amd64` + `linux/arm64`, pushes `innovtech/wshm:latest` and `innovtech/wshm:<version>` to Docker Hub on every release tag
- Fix README line that referenced a non-existent `ghcr.io/wshm-dev/wshm:latest`

## Secrets required

Add to repo secrets before tagging a release:
- `DOCKERHUB_USERNAME` — Docker Hub org/user (e.g. `innovtech`)
- `DOCKERHUB_TOKEN` — Docker Hub access token

## Test plan

- [ ] `docker build -t wshm-test .` builds locally without error
- [ ] Tag a release → docker job appears and pushes to Docker Hub
- [ ] `docker pull innovtech/wshm:latest` works after first release

🤖 Generated with [Claude Code](https://claude.com/claude-code)