### PR TITLE
feat(deploy): Helm chart, Kustomize overlays, raw k8s manifests

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,46 @@
+# Deployment artifacts
+
+This directory holds packaging for the various places `wshm` (OSS) can run.
+The persistent daemon + Web UI is a Pro feature and lives in the `wshm-pro`
+repo, so the OSS chart focuses on `Job` / `CronJob` patterns suitable for
+periodic triage.
+
+## Layout
+
+| Path | Method | Use when |
+|------|--------|---------|
+| [`helm/wshm/`](helm/wshm/) | Helm chart | Templated install with values overrides; multi-env via separate releases |
+| [`kustomize/`](kustomize/) | Kustomize base + `prod`/`staging` overlays | GitOps with environment overlays |
+| [`k8s/`](k8s/) | Raw manifests | Quickest path to a working CronJob; no extra tools |
+
+All three deploy the same shape: `CronJob` (default `*/30 * * * *`) running
+`wshm run --apply` against a config mounted from a `ConfigMap`, with
+credentials sourced from a `Secret`, and `.wshm/state.db` cached on a `PVC`.
+
+## Common shape
+
+- Image: `innovtech/wshm:<appVersion>` (multi-arch `linux/amd64` + `linux/arm64`)
+- Working directory: `/data` (PVC, holds `.wshm/state.db` between runs)
+- Config: `/etc/wshm/config.toml` (ConfigMap, optional in Helm)
+- Secret keys read at runtime: `GITHUB_TOKEN` (required), `ANTHROPIC_API_KEY` (or other provider), `WSHM_LICENSE_KEY` (Pro only)
+- Pod runs non-root (`65532`), read-only rootfs, all caps dropped
+
+## Choosing between the three
+
+- **Just want to try it on a cluster?** Use `k8s/` — three `kubectl apply` calls.
+- **Multiple environments, GitOps?** Use `kustomize/` — base + overlays, no templating.
+- **Configurable install for downstream users?** Use `helm/wshm/` — `values.yaml` exposes everything.
+
+## Secrets
+
+None of the artifacts ship real credentials. Provision `wshm-secrets`
+out-of-band using whichever pattern your cluster already uses:
+[external-secrets-operator](https://external-secrets.io/),
+[sealed-secrets](https://github.com/bitnami-labs/sealed-secrets), or your
+cloud KMS. The Helm chart can also materialise a Secret from values
+(`secrets.create=true`) — convenient for local testing, **never** for prod.
+
+## Pro
+
+For the persistent daemon (`Deployment` + `Service` + `Ingress`, Web UI,
+webhook server, multi-repo runtime), use the `wshm-pro` chart.

--- a/deploy/helm/wshm/.helmignore
+++ b/deploy/helm/wshm/.helmignore
@@ -1,0 +1,17 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.hg/
+.hgignore
+.svn/
+*.swp
+*.tmp
+*.bak
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/wshm/Chart.yaml
+++ b/deploy/helm/wshm/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: wshm
+description: |
+  AI-powered GitHub agent — triage, PR analysis, merge queue.
+  This chart focuses on Job/CronJob patterns for periodic triage runs.
+  The persistent daemon + Web UI lives in the wshm-pro chart.
+type: application
+version: 0.1.0
+appVersion: "0.28.2"
+kubeVersion: ">=1.21.0-0"
+keywords:
+  - github
+  - ai
+  - triage
+  - pull-requests
+  - automation
+  - cronjob
+home: https://wshm.dev
+sources:
+  - https://github.com/wshm-dev/wshm
+maintainers:
+  - name: wshm-dev
+    email: contact@wshm.dev
+icon: https://raw.githubusercontent.com/wshm-dev/wshm/main/assets/logo.png
+annotations:
+  category: DevOps
+  licenses: SSPL-1.0

--- a/deploy/helm/wshm/templates/NOTES.txt
+++ b/deploy/helm/wshm/templates/NOTES.txt
@@ -1,0 +1,44 @@
+wshm has been installed.
+
+Release: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Chart: {{ .Chart.Name }}-{{ .Chart.Version }} (app {{ .Chart.AppVersion }})
+
+Resources created:
+{{- if .Values.cronjob.enabled }}
+  - CronJob {{ include "wshm.fullname" . }} (schedule: {{ .Values.cronjob.schedule }})
+{{- end }}
+{{- if .Values.job.enabled }}
+  - Job {{ include "wshm.fullname" . }}-oneshot
+{{- end }}
+{{- if .Values.persistence.enabled }}
+{{- if not .Values.persistence.existingClaim }}
+  - PersistentVolumeClaim {{ include "wshm.pvcName" . }} ({{ .Values.persistence.size }})
+{{- end }}
+{{- end }}
+{{- if .Values.config.enabled }}
+  - ConfigMap {{ include "wshm.fullname" . }}-config
+{{- end }}
+{{- if and .Values.secrets.create (not .Values.secrets.existingSecret) }}
+  - Secret {{ include "wshm.fullname" . }}
+
+  WARNING: secrets.create=true stores credentials in plaintext values.
+  For production, use secrets.existingSecret with external-secrets-operator,
+  sealed-secrets, or your cloud KMS.
+{{- end }}
+
+Useful commands:
+
+  # Inspect the next scheduled run
+  kubectl get cronjobs -n {{ .Release.Namespace }} {{ include "wshm.fullname" . }}
+
+  # Trigger an ad-hoc run from the CronJob
+  kubectl create job -n {{ .Release.Namespace }} \
+    --from=cronjob/{{ include "wshm.fullname" . }} \
+    {{ include "wshm.fullname" . }}-manual-$(date +%s)
+
+  # Tail the latest run
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --tail=200 -f
+
+This chart only ships Job/CronJob patterns (OSS surface). For the persistent
+daemon + Web UI, install the wshm-pro chart from the Pro repo.

--- a/deploy/helm/wshm/templates/_helpers.tpl
+++ b/deploy/helm/wshm/templates/_helpers.tpl
@@ -1,0 +1,168 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "wshm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this.
+*/}}
+{{- define "wshm.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart name and version (label).
+*/}}
+{{- define "wshm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "wshm.labels" -}}
+helm.sh/chart: {{ include "wshm.chart" . }}
+{{ include "wshm.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: wshm
+{{- end -}}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "wshm.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "wshm.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Service account name.
+*/}}
+{{- define "wshm.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "wshm.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Image reference (repository:tag).
+*/}}
+{{- define "wshm.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/*
+Secret name to read credentials from (existing or chart-managed).
+*/}}
+{{- define "wshm.secretName" -}}
+{{- if .Values.secrets.existingSecret -}}
+{{- .Values.secrets.existingSecret -}}
+{{- else -}}
+{{- include "wshm.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+PVC name (existing or chart-managed).
+*/}}
+{{- define "wshm.pvcName" -}}
+{{- if .Values.persistence.existingClaim -}}
+{{- .Values.persistence.existingClaim -}}
+{{- else -}}
+{{- include "wshm.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common pod spec snippets shared by Job and CronJob.
+Renders the container env (secret refs + repo + extras), volume mounts,
+and command args.
+*/}}
+{{- define "wshm.containerEnv" -}}
+{{- $secretName := include "wshm.secretName" . -}}
+- name: GITHUB_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: GITHUB_TOKEN
+      optional: true
+- name: ANTHROPIC_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: ANTHROPIC_API_KEY
+      optional: true
+- name: WSHM_LICENSE_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: WSHM_LICENSE_KEY
+      optional: true
+{{- if .Values.repo }}
+- name: WSHM_REPO
+  value: {{ .Values.repo | quote }}
+{{- end }}
+{{- with .Values.extraEnv }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "wshm.volumeMounts" -}}
+- name: data
+  mountPath: /data
+{{- if .Values.config.enabled }}
+- name: config
+  mountPath: /etc/wshm
+  readOnly: true
+{{- end }}
+- name: tmp
+  mountPath: /tmp
+{{- end -}}
+
+{{- define "wshm.volumes" -}}
+- name: data
+  {{- if .Values.persistence.enabled }}
+  persistentVolumeClaim:
+    claimName: {{ include "wshm.pvcName" . }}
+  {{- else }}
+  emptyDir: {}
+  {{- end }}
+{{- if .Values.config.enabled }}
+- name: config
+  configMap:
+    name: {{ include "wshm.fullname" . }}-config
+{{- end }}
+- name: tmp
+  emptyDir: {}
+{{- end -}}
+
+{{/*
+Final command args, prepending --config when a ConfigMap is mounted.
+*/}}
+{{- define "wshm.args" -}}
+{{- $args := list -}}
+{{- if .Values.config.enabled -}}
+{{- $args = append $args "--config" -}}
+{{- $args = append $args "/etc/wshm/config.toml" -}}
+{{- end -}}
+{{- range .userArgs -}}
+{{- $args = append $args . -}}
+{{- end -}}
+{{- toYaml $args -}}
+{{- end -}}

--- a/deploy/helm/wshm/templates/configmap.yaml
+++ b/deploy/helm/wshm/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.config.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "wshm.fullname" . }}-config
+  labels:
+    {{- include "wshm.labels" . | nindent 4 }}
+data:
+  config.toml: |-
+    {{- .Values.config.content | nindent 4 }}
+{{- end }}

--- a/deploy/helm/wshm/templates/cronjob.yaml
+++ b/deploy/helm/wshm/templates/cronjob.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.cronjob.enabled -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "wshm.fullname" . }}
+  labels:
+    {{- include "wshm.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.cronjob.schedule | quote }}
+  concurrencyPolicy: {{ .Values.cronjob.concurrencyPolicy | default "Forbid" }}
+  successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit | default 3 }}
+  failedJobsHistoryLimit: {{ .Values.cronjob.failedJobsHistoryLimit | default 1 }}
+  startingDeadlineSeconds: {{ .Values.cronjob.startingDeadlineSeconds | default 300 }}
+  suspend: {{ .Values.cronjob.suspend | default false }}
+  jobTemplate:
+    metadata:
+      labels:
+        {{- include "wshm.selectorLabels" . | nindent 8 }}
+    spec:
+      backoffLimit: {{ .Values.cronjob.backoffLimit | default 2 }}
+      activeDeadlineSeconds: {{ .Values.cronjob.activeDeadlineSeconds | default 1800 }}
+      ttlSecondsAfterFinished: {{ .Values.cronjob.ttlSecondsAfterFinished | default 86400 }}
+      template:
+        metadata:
+          labels:
+            {{- include "wshm.selectorLabels" . | nindent 12 }}
+            {{- with .Values.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        spec:
+          serviceAccountName: {{ include "wshm.serviceAccountName" . }}
+          restartPolicy: {{ .Values.restartPolicy | default "OnFailure" }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.priorityClassName }}
+          priorityClassName: {{ . }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          containers:
+            - name: wshm
+              image: {{ include "wshm.image" . }}
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              args:
+                {{- include "wshm.args" (dict "userArgs" .Values.cronjob.args "Values" .Values) | nindent 16 }}
+              workingDir: /data
+              env:
+                {{- include "wshm.containerEnv" . | nindent 16 }}
+              volumeMounts:
+                {{- include "wshm.volumeMounts" . | nindent 16 }}
+              securityContext:
+                {{- toYaml .Values.containerSecurityContext | nindent 16 }}
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}
+          volumes:
+            {{- include "wshm.volumes" . | nindent 12 }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/deploy/helm/wshm/templates/job.yaml
+++ b/deploy/helm/wshm/templates/job.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.job.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "wshm.fullname" . }}-oneshot
+  labels:
+    {{- include "wshm.labels" . | nindent 4 }}
+spec:
+  backoffLimit: {{ .Values.job.backoffLimit | default 1 }}
+  activeDeadlineSeconds: {{ .Values.job.activeDeadlineSeconds | default 1800 }}
+  ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished | default 3600 }}
+  template:
+    metadata:
+      labels:
+        {{- include "wshm.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "wshm.serviceAccountName" . }}
+      restartPolicy: {{ .Values.restartPolicy | default "OnFailure" }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: wshm
+          image: {{ include "wshm.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            {{- include "wshm.args" (dict "userArgs" .Values.job.args "Values" .Values) | nindent 12 }}
+          workingDir: /data
+          env:
+            {{- include "wshm.containerEnv" . | nindent 12 }}
+          volumeMounts:
+            {{- include "wshm.volumeMounts" . | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        {{- include "wshm.volumes" . | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/helm/wshm/templates/pvc.yaml
+++ b/deploy/helm/wshm/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "wshm.pvcName" . }}
+  labels:
+    {{- include "wshm.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | default "ReadWriteOnce" | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/wshm/templates/secret.yaml
+++ b/deploy/helm/wshm/templates/secret.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.secrets.create (not .Values.secrets.existingSecret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "wshm.fullname" . }}
+  labels:
+    {{- include "wshm.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- with .Values.secrets.githubToken }}
+  GITHUB_TOKEN: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.secrets.anthropicApiKey }}
+  ANTHROPIC_API_KEY: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.secrets.licenseKey }}
+  WSHM_LICENSE_KEY: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/wshm/templates/serviceaccount.yaml
+++ b/deploy/helm/wshm/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "wshm.serviceAccountName" . }}
+  labels:
+    {{- include "wshm.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/deploy/helm/wshm/values.yaml
+++ b/deploy/helm/wshm/values.yaml
@@ -1,0 +1,130 @@
+# Default values for wshm.
+# This chart focuses on Job/CronJob patterns. For the persistent daemon +
+# web UI, use the wshm-pro chart.
+
+image:
+  repository: innovtech/wshm
+  # Defaults to .Chart.AppVersion when empty.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Repo target. Either set this (rendered as --repo flag) or rely on a
+# config.toml / WSHM_REPO env in extraEnv.
+repo: ""  # e.g. "myorg/myrepo"
+
+# CronJob: scheduled triage / full-cycle runs.
+cronjob:
+  enabled: true
+  schedule: "*/30 * * * *"
+  # Args passed to the wshm binary. Common: ["run", "--apply"], ["triage", "--apply"], ["sync"].
+  args:
+    - run
+    - --apply
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 300
+  backoffLimit: 2
+  activeDeadlineSeconds: 1800
+  ttlSecondsAfterFinished: 86400
+  suspend: false
+
+# Job: optional one-shot run (e.g. initial sync). Disabled by default.
+job:
+  enabled: false
+  args:
+    - sync
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
+  ttlSecondsAfterFinished: 3600
+
+# Persistence for .wshm/state.db across runs.
+persistence:
+  enabled: true
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 1Gi
+  # Set to use a pre-existing PVC instead of creating one.
+  existingClaim: ""
+  annotations: {}
+
+# Secrets — STRONGLY prefer existingSecret in production
+# (use external-secrets-operator, sealed-secrets, or vault).
+secrets:
+  # Existing Secret containing keys: GITHUB_TOKEN, ANTHROPIC_API_KEY, WSHM_LICENSE_KEY (optional)
+  existingSecret: ""
+  # Or let the chart create one from these values (NOT for prod).
+  create: false
+  githubToken: ""
+  anthropicApiKey: ""
+  licenseKey: ""
+
+# Extra environment variables (raw env entries — supports value or valueFrom).
+extraEnv: []
+  # - name: WSHM_LOG
+  #   value: info
+  # - name: OPENAI_API_KEY
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: my-openai-secret
+  #       key: api-key
+
+# config.toml mounted at /etc/wshm/config.toml. When enabled, the binary is
+# launched with --config /etc/wshm/config.toml.
+config:
+  enabled: false
+  # Inline content. See docs/configuration.md for the schema.
+  content: |
+    # [github]
+    # repo = "owner/repo"
+    #
+    # [ai]
+    # provider = "anthropic"
+    # model = "claude-sonnet-4-6"
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  automountServiceAccountToken: false
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Optional: top-level priority class for the CronJob/Job pods.
+priorityClassName: ""
+
+# Restart policy applied to the Job/CronJob pod template.
+restartPolicy: OnFailure

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,36 @@
+# Raw Kubernetes manifests
+
+Apply order:
+
+```bash
+kubectl apply -f configmap.yaml          # creates namespace + config
+# Provision wshm-secrets out-of-band (external-secrets / sealed-secrets / KMS).
+# For a quick test only, edit secret.example.yaml then:
+#   kubectl apply -f secret.example.yaml
+kubectl apply -f cronjob.yaml            # CronJob + ServiceAccount + PVC
+```
+
+Trigger an ad-hoc run from the CronJob:
+
+```bash
+kubectl -n wshm create job --from=cronjob/wshm wshm-manual-$(date +%s)
+kubectl -n wshm logs -l app.kubernetes.io/name=wshm --tail=200 -f
+```
+
+Run a one-shot sync (e.g. on first install):
+
+```bash
+kubectl apply -f job.yaml
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `configmap.yaml` | Namespace + `wshm-config` ConfigMap (config.toml) |
+| `secret.example.yaml` | Template for `wshm-secrets` — **do not commit real values** |
+| `cronjob.yaml` | CronJob + ServiceAccount + PVC for periodic `wshm run --apply` |
+| `job.yaml` | One-shot Job (initial sync / smoke test) |
+
+These are minimal, opinionated manifests. For parameterized installs use
+`deploy/helm/wshm/` (Helm) or `deploy/kustomize/` (Kustomize) instead.

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: wshm
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wshm-config
+  namespace: wshm
+data:
+  config.toml: |
+    # See docs/configuration.md for the full schema.
+    [github]
+    repo = "owner/repo"
+
+    [ai]
+    provider = "anthropic"
+    model = "claude-sonnet-4-6"
+
+    [triage]
+    auto_apply_high_confidence = true
+
+    [merge_queue]
+    auto_merge_threshold = 80

--- a/deploy/k8s/cronjob.yaml
+++ b/deploy/k8s/cronjob.yaml
@@ -1,0 +1,113 @@
+# Standalone CronJob for wshm. Apply with:
+#   kubectl apply -f deploy/k8s/configmap.yaml
+#   kubectl apply -f deploy/k8s/secret.example.yaml   # edit first
+#   kubectl apply -f deploy/k8s/cronjob.yaml
+#
+# Runs `wshm run --apply` every 30 minutes against the repo configured
+# in the wshm-config ConfigMap (or set via WSHM_REPO env).
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: wshm
+  namespace: wshm
+  labels:
+    app.kubernetes.io/name: wshm
+spec:
+  schedule: "*/30 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 1800
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: wshm
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: wshm
+              image: innovtech/wshm:0.28.2
+              imagePullPolicy: IfNotPresent
+              args:
+                - --config
+                - /etc/wshm/config.toml
+                - run
+                - --apply
+              workingDir: /data
+              env:
+                - name: GITHUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: wshm-secrets
+                      key: GITHUB_TOKEN
+                - name: ANTHROPIC_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: wshm-secrets
+                      key: ANTHROPIC_API_KEY
+                      optional: true
+                - name: WSHM_LICENSE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: wshm-secrets
+                      key: WSHM_LICENSE_KEY
+                      optional: true
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+                - name: config
+                  mountPath: /etc/wshm
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: wshm-data
+            - name: config
+              configMap:
+                name: wshm-config
+            - name: tmp
+              emptyDir: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: wshm
+  namespace: wshm
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wshm-data
+  namespace: wshm
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/deploy/k8s/job.yaml
+++ b/deploy/k8s/job.yaml
@@ -1,0 +1,70 @@
+# One-shot Job — useful for an initial sync or to test credentials.
+#   kubectl apply -f deploy/k8s/job.yaml
+#   kubectl logs -n wshm -l job-name=wshm-oneshot -f
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wshm-oneshot
+  namespace: wshm
+  labels:
+    app.kubernetes.io/name: wshm
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: wshm
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: wshm
+          image: innovtech/wshm:0.28.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config
+            - /etc/wshm/config.toml
+            - sync
+          workingDir: /data
+          env:
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: wshm-secrets
+                  key: GITHUB_TOKEN
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /etc/wshm
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: wshm-data
+        - name: config
+          configMap:
+            name: wshm-config
+        - name: tmp
+          emptyDir: {}

--- a/deploy/k8s/secret.example.yaml
+++ b/deploy/k8s/secret.example.yaml
@@ -1,0 +1,14 @@
+# EXAMPLE — do NOT commit real credentials.
+# In production, use external-secrets-operator, sealed-secrets, or your
+# cloud KMS to materialize this Secret. Required keys: GITHUB_TOKEN.
+# Optional keys: ANTHROPIC_API_KEY (or other provider key), WSHM_LICENSE_KEY.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wshm-secrets
+  namespace: wshm
+type: Opaque
+stringData:
+  GITHUB_TOKEN: "ghp_replace_me"
+  ANTHROPIC_API_KEY: "sk-ant-replace_me"
+  # WSHM_LICENSE_KEY: "wshm_pro_replace_me"

--- a/deploy/kustomize/base/configmap.yaml
+++ b/deploy/kustomize/base/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wshm-config
+data:
+  config.toml: |
+    # See docs/configuration.md for the full schema.
+    # Override this ConfigMap in your overlay.
+    #
+    # [github]
+    # repo = "owner/repo"
+    #
+    # [ai]
+    # provider = "anthropic"
+    # model = "claude-sonnet-4-6"

--- a/deploy/kustomize/base/cronjob.yaml
+++ b/deploy/kustomize/base/cronjob.yaml
@@ -1,0 +1,85 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: wshm
+spec:
+  schedule: "*/30 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 1800
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          serviceAccountName: wshm
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: wshm
+              image: innovtech/wshm:0.28.2
+              imagePullPolicy: IfNotPresent
+              args:
+                - --config
+                - /etc/wshm/config.toml
+                - run
+                - --apply
+              workingDir: /data
+              env:
+                - name: GITHUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: wshm-secrets
+                      key: GITHUB_TOKEN
+                      optional: true
+                - name: ANTHROPIC_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: wshm-secrets
+                      key: ANTHROPIC_API_KEY
+                      optional: true
+                - name: WSHM_LICENSE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: wshm-secrets
+                      key: WSHM_LICENSE_KEY
+                      optional: true
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+                - name: config
+                  mountPath: /etc/wshm
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: wshm-data
+            - name: config
+              configMap:
+                name: wshm-config
+            - name: tmp
+              emptyDir: {}

--- a/deploy/kustomize/base/kustomization.yaml
+++ b/deploy/kustomize/base/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: wshm
+
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - configmap.yaml
+  - pvc.yaml
+  - cronjob.yaml
+
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: wshm
+      app.kubernetes.io/managed-by: kustomize
+      app.kubernetes.io/part-of: wshm
+
+images:
+  - name: innovtech/wshm
+    newTag: 0.28.2

--- a/deploy/kustomize/base/namespace.yaml
+++ b/deploy/kustomize/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: wshm

--- a/deploy/kustomize/base/pvc.yaml
+++ b/deploy/kustomize/base/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wshm-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/deploy/kustomize/base/serviceaccount.yaml
+++ b/deploy/kustomize/base/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: wshm
+automountServiceAccountToken: false

--- a/deploy/kustomize/overlays/prod/files/config.prod.toml
+++ b/deploy/kustomize/overlays/prod/files/config.prod.toml
@@ -1,0 +1,15 @@
+# Production wshm config (Kustomize overlay).
+# See docs/configuration.md for the full schema.
+
+[github]
+# repo = "myorg/myrepo"
+
+[ai]
+provider = "anthropic"
+model = "claude-sonnet-4-6"
+
+[triage]
+auto_apply_high_confidence = true
+
+[merge_queue]
+auto_merge_threshold = 80

--- a/deploy/kustomize/overlays/prod/kustomization.yaml
+++ b/deploy/kustomize/overlays/prod/kustomization.yaml
@@ -1,0 +1,47 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: wshm-prod
+
+resources:
+  - ../../base
+
+namePrefix: prod-
+
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/instance: wshm-prod
+      environment: production
+
+# Hourly cadence + bigger storage in prod.
+patches:
+  - target:
+      kind: CronJob
+      name: wshm
+    patch: |-
+      - op: replace
+        path: /spec/schedule
+        value: "0 * * * *"
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/containers/0/resources/limits/memory
+        value: 1Gi
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/containers/0/resources/requests/memory
+        value: 256Mi
+  - target:
+      kind: PersistentVolumeClaim
+      name: wshm-data
+    patch: |-
+      - op: replace
+        path: /spec/resources/requests/storage
+        value: 5Gi
+
+# In prod, point at an external Secret managed by external-secrets-operator
+# or sealed-secrets. The CronJob references "wshm-secrets" — provision it
+# out-of-band; do not commit credentials here.
+configMapGenerator:
+  - name: wshm-config
+    behavior: replace
+    files:
+      - config.toml=files/config.prod.toml

--- a/deploy/kustomize/overlays/staging/kustomization.yaml
+++ b/deploy/kustomize/overlays/staging/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: wshm-staging
+
+resources:
+  - ../../base
+
+namePrefix: staging-
+
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/instance: wshm-staging
+      environment: staging
+
+# Faster cadence for staging — useful to surface regressions early.
+patches:
+  - target:
+      kind: CronJob
+      name: wshm
+    patch: |-
+      - op: replace
+        path: /spec/schedule
+        value: "*/15 * * * *"
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/containers/0/args
+        value:
+          - --config
+          - /etc/wshm/config.toml
+          - run

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -19,11 +19,12 @@ All deployment artifacts live under `deploy/` in this repo, one subdirectory per
 
 ```
 deploy/
-  helm/           # Helm chart for Kubernetes
-  kustomize/      # Kustomize base + overlays
-  compose/        # docker-compose.yml for single-host
-  ansible/        # Ansible role for VM/bare-metal
-  cloud-init/     # cloud-init snippets for cloud VMs
+  helm/wshm/      # Helm chart for Kubernetes (Job/CronJob)
+  kustomize/      # Kustomize base + prod/staging overlays
+  k8s/            # Raw manifests (CronJob, Job, ConfigMap, Secret example)
+  compose/        # docker-compose.yml for single-host        (planned)
+  ansible/        # Ansible role for VM/bare-metal            (planned)
+  cloud-init/     # cloud-init snippets for cloud VMs         (planned)
 ```
 
 ## Status
@@ -34,8 +35,9 @@ deploy/
 | `.deb`        | Debian/Ubuntu                    | Shipped  |
 | Homebrew      | macOS, Linux                     | Shipped  |
 | Docker        | Any Docker host                  | Shipped  |
-| Helm          | Kubernetes                       | Planned  |
-| Kustomize     | Kubernetes                       | Planned  |
+| Helm          | Kubernetes (`Job`/`CronJob`)     | Shipped  |
+| Kustomize     | Kubernetes (base + prod/staging) | Shipped  |
+| Raw manifests | Kubernetes                       | Shipped  |
 | docker-compose| Single-host self-hosted          | Planned  |
 | Ansible role  | VM / bare-metal                  | Planned  |
 | cloud-init    | AWS/GCP/Azure/Hetzner VMs        | Planned  |


### PR DESCRIPTION
## Summary

OSS chart focused on `Job`/`CronJob` patterns, per the strategy in `docs/deployment.md` (the persistent daemon + Web UI variant lives in `wshm-pro`).

- **`deploy/helm/wshm/`** — full Helm chart: CronJob (default `*/30 * * * *`, runs `wshm run --apply`), optional one-shot Job, PVC for `.wshm/state.db`, optional ConfigMap for `config.toml`, Secret create-or-existing pattern, ServiceAccount, secure pod context (non-root uid 65532, readOnlyRootFilesystem, all caps dropped, RuntimeDefault seccomp), templated env from secret keys (`GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, `WSHM_LICENSE_KEY`).
- **`deploy/kustomize/`** — base + `prod` (hourly cadence, 5Gi PVC, prod config.toml) + `staging` (15 min cadence, dry-run) overlays. Uses the modern `labels:` field (no `commonLabels` deprecation).
- **`deploy/k8s/`** — copy-paste raw manifests: `cronjob.yaml`, `job.yaml`, `configmap.yaml` (namespace + ConfigMap), `secret.example.yaml`, `README.md`.
- **`deploy/README.md`** — picks-which guide between the three.
- **`docs/deployment.md`** updated: Helm/Kustomize/Raw → **Shipped**, layout reflects what actually ships.

## Test plan

- [x] `helm lint deploy/helm/wshm/` → 0 failures
- [x] `helm template ... --set repo=foo/bar --set config.enabled=true --set secrets.create=true` renders all resources
- [x] `kubectl kustomize deploy/kustomize/{base,overlays/prod,overlays/staging}` all green
- [x] `kubectl apply --dry-run=client -f deploy/k8s/*.yaml` all green
- [ ] End-to-end install on a real cluster (kind/k3d) with a real GitHub token

🤖 Generated with [Claude Code](https://claude.com/claude-code)