### PR TITLE
chore(release): bump 0.28.3 + drop unpublished cargo install references (closes part of #22)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wshm-core"
-version = "0.28.2"
+version = "0.28.3"
 edition = "2021"
 description = "Core library for wshm"
 license = "SSPL-1.0"

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ brew tap wshm-dev/tap
 brew install wshm
 ```
 
-The Homebrew formula currently ships Linux bottles only (x86_64 + arm64); macOS users should use `cargo install wshm-core` until darwin builds are added.
+The Homebrew formula currently ships Linux bottles only (x86_64 + arm64); macOS support is tracked in [#22](https://github.com/wshm-dev/wshm/issues/22).
 
 #### Linux — install script (SHA256-verified)
 
@@ -262,7 +262,7 @@ The Homebrew formula currently ships Linux bottles only (x86_64 + arm64); macOS 
 curl -fsSL https://raw.githubusercontent.com/wshm-dev/wshm/main/install.sh | sh
 ```
 
-Re-run to upgrade. Pin a version with `sh -s -- --version v0.28.2`. Every download is verified against the release's `checksums.txt`.
+Re-run to upgrade. Pin a version with `sh -s -- --version v0.28.3`. Every download is verified against the release's `checksums.txt`.
 
 #### Linux — .deb (amd64 / arm64)
 
@@ -585,7 +585,8 @@ jobs:
 ## Deploy on a VM
 
 ```bash
-cargo install wshm
+# Install via Homebrew, the SHA256-verified script, or the .deb package — see Quick Start above.
+brew tap wshm-dev/tap && brew install wshm
 wshm login
 wshm config init
 wshm daemon --apply --poll

--- a/deploy/helm/wshm/Chart.yaml
+++ b/deploy/helm/wshm/Chart.yaml
@@ -5,8 +5,8 @@ description: |
   This chart focuses on Job/CronJob patterns for periodic triage runs.
   The persistent daemon + Web UI lives in the wshm-pro chart.
 type: application
-version: 0.1.0
-appVersion: "0.28.2"
+version: 0.1.1
+appVersion: "0.28.3"
 kubeVersion: ">=1.21.0-0"
 keywords:
   - github

--- a/deploy/k8s/cronjob.yaml
+++ b/deploy/k8s/cronjob.yaml
@@ -36,7 +36,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: wshm
-              image: innovtech/wshm:0.28.2
+              image: innovtech/wshm:0.28.3
               imagePullPolicy: IfNotPresent
               args:
                 - --config

--- a/deploy/k8s/job.yaml
+++ b/deploy/k8s/job.yaml
@@ -25,7 +25,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: wshm
-          image: innovtech/wshm:0.28.2
+          image: innovtech/wshm:0.28.3
           imagePullPolicy: IfNotPresent
           args:
             - --config

--- a/deploy/kustomize/base/cronjob.yaml
+++ b/deploy/kustomize/base/cronjob.yaml
@@ -26,7 +26,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: wshm
-              image: innovtech/wshm:0.28.2
+              image: innovtech/wshm:0.28.3
               imagePullPolicy: IfNotPresent
               args:
                 - --config

--- a/deploy/kustomize/base/kustomization.yaml
+++ b/deploy/kustomize/base/kustomization.yaml
@@ -19,4 +19,4 @@ labels:
 
 images:
   - name: innovtech/wshm
-    newTag: 0.28.2
+    newTag: 0.28.3

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@ curl -fsSL https://raw.githubusercontent.com/wshm-dev/wshm/main/install.sh | sh
 Re-run the same command to upgrade. Pin a specific version with:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/wshm-dev/wshm/main/install.sh | sh -s -- --version v0.28.2
+curl -fsSL https://raw.githubusercontent.com/wshm-dev/wshm/main/install.sh | sh -s -- --version v0.28.3
 ```
 
 Every download is verified against the release's `checksums.txt`.
@@ -30,14 +30,6 @@ brew install wshm
 curl -LO https://github.com/wshm-dev/wshm/releases/latest/download/wshm_$(curl -s https://api.github.com/repos/wshm-dev/wshm/releases/latest | grep tag_name | cut -d'"' -f4 | tr -d v)_amd64.deb
 sudo dpkg -i wshm_*_amd64.deb
 ```
-
-### Cargo
-
-```bash
-cargo install wshm-core
-```
-
-The crate is `wshm-core`; it ships the `wshm` binary.
 
 ### Docker (Docker Hub)
 

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 #   curl -fsSL https://raw.githubusercontent.com/wshm-dev/wshm/main/install.sh | sh
 #
 # Re-run to upgrade. Pass flags via `sh -s --`:
-#   curl -fsSL https://raw.githubusercontent.com/wshm-dev/wshm/main/install.sh | sh -s -- --version v0.28.2
+#   curl -fsSL https://raw.githubusercontent.com/wshm-dev/wshm/main/install.sh | sh -s -- --version v0.28.3
 #   curl -fsSL https://raw.githubusercontent.com/wshm-dev/wshm/main/install.sh | sh -s -- --dir /usr/local/bin
 #
 # Every download is verified against the release's checksums.txt (SHA256).
@@ -14,8 +14,8 @@
 #   - Linux x86_64  (x86_64-unknown-linux-gnu)
 #   - Linux aarch64 (aarch64-unknown-linux-gnu)
 #   - Windows x86_64 via Git Bash / MSYS / Cygwin (x86_64-pc-windows-msvc)
-# macOS is not currently published as a binary release — install via Homebrew
-# (`brew tap wshm-dev/tap && brew install wshm`) or `cargo install wshm-core`.
+# macOS is not currently published as a binary release — see
+# https://github.com/wshm-dev/wshm/issues/22 for tracking.
 
 set -eu
 
@@ -41,7 +41,7 @@ Usage: install.sh [--dir <path>] [--version <tag>] [--help]
 
 Options:
   --dir <path>      Install directory (default: \$HOME/.local/bin)
-  --version <tag>   Release tag to install (default: latest, e.g. v0.28.2)
+  --version <tag>   Release tag to install (default: latest, e.g. v0.28.3)
   -h, --help        Show this help
 
 Re-running this script upgrades an existing installation in place.
@@ -77,7 +77,7 @@ detect_os() {
     case "$(uname -s)" in
         Linux*)  OS="linux";   TARGET_SUFFIX="unknown-linux-gnu";;
         MINGW*|MSYS*|CYGWIN*) OS="windows"; TARGET_SUFFIX="pc-windows-msvc";;
-        Darwin*) error "macOS is not published as a binary release. Install via Homebrew: 'brew tap wshm-dev/tap && brew install wshm', or 'cargo install wshm-core'.";;
+        Darwin*) error "macOS is not published as a binary release yet. Track https://github.com/wshm-dev/wshm/issues/22 for updates.";;
         *)       error "Unsupported OS: $(uname -s). wshm supports Linux and Windows binary releases.";;
     esac
 }


### PR DESCRIPTION
## Summary

Bumps the project to **0.28.3** and removes the broken `cargo install wshm-core` claim that survived the recent docs cleanup. `wshm-core` is **not** on crates.io (`https://crates.io/api/v1/crates/wshm-core` returns 404), so the snippet was misleading users.

## Changes

- `Cargo.toml`: `0.28.2` → `0.28.3`
- `deploy/helm/wshm/Chart.yaml`: chart `0.1.0` → `0.1.1`, appVersion `0.28.2` → `0.28.3`
- `deploy/{k8s,kustomize}/...`: `innovtech/wshm:0.28.2` → `innovtech/wshm:0.28.3` (4 files)
- `install.sh`, `README.md`, `docs/getting-started.md`: pinned-version examples bumped, removed all `cargo install wshm-core` / `cargo install wshm` references and macOS \"use cargo\" fallbacks.

Issue [#22](https://github.com/wshm-dev/wshm/issues/22) updated with the new state — the `cargo install` checkbox stays open until release-please publishes the crate.

## Test plan

- [x] `helm lint deploy/helm/wshm/` → 0 failures
- [x] `kubectl kustomize deploy/kustomize/base` → green
- [x] `kubectl apply --dry-run=client -f deploy/k8s/{cronjob,job}.yaml` → green
- [x] `sh -n install.sh` → no syntax errors
- [ ] Tag `v0.28.3` will trigger the release workflow (Docker push + Homebrew tap update + checksums.txt) on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)