### PR TITLE
feat(tui): Triage and Changelog tabs

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -25,6 +25,8 @@ pub enum Tab {
     Queue,
     Stats,
     Activity,
+    Triage,
+    Changelog,
 }
 
 impl Tab {
@@ -38,6 +40,8 @@ impl Tab {
             Tab::Queue => "Merge Queue",
             Tab::Stats => "Stats",
             Tab::Activity => "Activity",
+            Tab::Triage => "Triage",
+            Tab::Changelog => "Changelog",
         }
     }
 
@@ -51,6 +55,8 @@ impl Tab {
             Tab::Queue,
             Tab::Stats,
             Tab::Activity,
+            Tab::Triage,
+            Tab::Changelog,
         ]
     }
 }
@@ -160,6 +166,8 @@ pub struct App {
     pub conflict_count: usize,
     pub stats: Stats,
     pub activity: Vec<TriageResultRow>,
+    pub triage_all: Vec<TriageResultRow>,
+    pub changelog: Vec<ChangelogEntry>,
     pub logs: Vec<LogEntry>,
     pub actions: Vec<ActionItem>,
     pub repos: Vec<RepoRow>,
@@ -211,6 +219,16 @@ pub enum SettingKind {
     Label,  // read-only info
 }
 
+/// One entry in the Changelog tab — a closed pull request.
+#[derive(Clone)]
+pub struct ChangelogEntry {
+    pub section: &'static str,
+    pub number: u64,
+    pub title: String,
+    pub author: Option<String>,
+    pub merged_at: String,
+}
+
 #[derive(Clone)]
 pub struct RepoRow {
     pub slug: String,
@@ -252,6 +270,8 @@ impl App {
                 avg_pr_age_days: 0,
             },
             activity: Vec::new(),
+            triage_all: Vec::new(),
+            changelog: Vec::new(),
             logs: Vec::new(),
             actions: Vec::new(),
             repos: Vec::new(),
@@ -272,7 +292,70 @@ impl App {
         app.load_actions();
         app.refresh(db)?;
         app.load_summary(config, db);
+        app.load_triage_all(db);
+        app.load_changelog(db);
         Ok(app)
+    }
+
+    /// Load all triage results, most recent first. Used by the Triage tab.
+    pub fn load_triage_all(&mut self, db: &Database) {
+        match db.recent_activity(500) {
+            Ok(rows) => self.triage_all = rows,
+            Err(_) => self.triage_all = Vec::new(),
+        }
+    }
+
+    /// Load closed pull requests, group them by conventional-commit section.
+    /// Same logic as the web /api/v1/changelog endpoint.
+    pub fn load_changelog(&mut self, db: &Database) {
+        let rows = db
+            .with_conn(|conn| {
+                let mut stmt = conn.prepare(
+                    "SELECT number, title, author, updated_at
+                     FROM pull_requests WHERE state = 'closed'
+                     ORDER BY updated_at DESC LIMIT 100",
+                )?;
+                let rows = stmt
+                    .query_map([], |row| {
+                        Ok((
+                            row.get::<_, u64>(0)?,
+                            row.get::<_, String>(1)?,
+                            row.get::<_, Option<String>>(2)?,
+                            row.get::<_, String>(3)?,
+                        ))
+                    })?
+                    .collect::<std::result::Result<Vec<_>, _>>()?;
+                Ok(rows)
+            })
+            .unwrap_or_default();
+
+        self.changelog = rows
+            .into_iter()
+            .map(|(number, title, author, merged_at)| {
+                let section = if title.starts_with("feat") {
+                    "Features"
+                } else if title.starts_with("fix") {
+                    "Bug Fixes"
+                } else if title.starts_with("docs") {
+                    "Documentation"
+                } else if title.starts_with("chore") || title.starts_with("ci") {
+                    "Chores"
+                } else if title.starts_with("refactor") {
+                    "Refactoring"
+                } else if title.starts_with("test") {
+                    "Tests"
+                } else {
+                    "Other"
+                };
+                ChangelogEntry {
+                    section,
+                    number,
+                    title,
+                    author,
+                    merged_at,
+                }
+            })
+            .collect();
     }
 
     pub fn load_summary(&mut self, config: &Config, db: &Database) {
@@ -549,6 +632,8 @@ impl App {
             Tab::Repos => self.repos.len(),
             Tab::Action => self.actions.len(),
             Tab::Activity => self.logs.len(),
+            Tab::Triage => self.triage_all.len(),
+            Tab::Changelog => self.changelog.len(),
             Tab::Summary => 0,
         }
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -135,6 +135,14 @@ fn run_loop(
                         KeyCode::Char('5') => app.active_tab = app::Tab::Queue,
                         KeyCode::Char('6') => app.active_tab = app::Tab::Stats,
                         KeyCode::Char('7') => app.active_tab = app::Tab::Activity,
+                        KeyCode::Char('8') => {
+                            app.load_triage_all(db);
+                            app.active_tab = app::Tab::Triage;
+                        }
+                        KeyCode::Char('9') => {
+                            app.load_changelog(db);
+                            app.active_tab = app::Tab::Changelog;
+                        }
                         KeyCode::Enter => {
                             if app.active_tab == app::Tab::Repos {
                                 app.open_settings();
@@ -153,6 +161,8 @@ fn run_loop(
                             app.refresh(db)?;
                             app.load_repos();
                             app.load_actions();
+                            app.load_triage_all(db);
+                            app.load_changelog(db);
                         }
                         KeyCode::Char('n') if app.active_tab == app::Tab::Repos => {
                             app.start_add_repo();

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -39,6 +39,8 @@ pub fn draw(f: &mut Frame, app: &App) {
         Tab::Queue => draw_queue(f, app, chunks[2]),
         Tab::Stats => draw_stats_tab(f, app, chunks[2]),
         Tab::Activity => draw_activity(f, app, chunks[2]),
+        Tab::Triage => draw_triage(f, app, chunks[2]),
+        Tab::Changelog => draw_changelog(f, app, chunks[2]),
     }
 
     // Action detail popup
@@ -1361,9 +1363,151 @@ fn draw_summary(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(content, area);
 }
 
+fn priority_color(p: Option<&str>) -> Color {
+    match p {
+        Some("critical") | Some("high") => Color::Red,
+        Some("medium") => Color::Yellow,
+        Some("low") => Color::Blue,
+        _ => Color::DarkGray,
+    }
+}
+
+fn category_short(c: &str) -> &str {
+    match c {
+        "bug" => "BUG",
+        "feature" => "FEAT",
+        "duplicate" => "DUP",
+        "wontfix" => "WONT",
+        "needs-info" => "INFO",
+        "question" => "Q",
+        "docs" => "DOCS",
+        _ => c,
+    }
+}
+
+fn draw_triage(f: &mut Frame, app: &App, area: Rect) {
+    let header = Row::new(vec![
+        Cell::from("#"),
+        Cell::from("Cat"),
+        Cell::from("Prio"),
+        Cell::from("Conf"),
+        Cell::from("Summary"),
+        Cell::from("Acted"),
+    ])
+    .style(
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    let rows: Vec<Row> = app
+        .triage_all
+        .iter()
+        .skip(app.scroll_offset)
+        .take(area.height.saturating_sub(3) as usize)
+        .map(|t| {
+            let summary = t
+                .summary
+                .as_deref()
+                .unwrap_or("")
+                .lines()
+                .next()
+                .unwrap_or("")
+                .to_string();
+            Row::new(vec![
+                Cell::from(format!("#{}", t.issue_number)).style(Style::default().fg(Color::Cyan)),
+                Cell::from(category_short(&t.category)),
+                Cell::from(t.priority.as_deref().unwrap_or("-").to_string())
+                    .style(Style::default().fg(priority_color(t.priority.as_deref()))),
+                Cell::from(format!("{:.0}%", t.confidence * 100.0)),
+                Cell::from(truncate(&summary, 70)),
+                Cell::from(t.acted_at.chars().take(10).collect::<String>())
+                    .style(Style::default().fg(Color::DarkGray)),
+            ])
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(7),
+        Constraint::Length(5),
+        Constraint::Length(6),
+        Constraint::Length(5),
+        Constraint::Min(20),
+        Constraint::Length(11),
+    ];
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .block(Block::default().borders(Borders::ALL).title(format!(
+            " Triage Results ({} total) ",
+            app.triage_all.len()
+        )));
+    f.render_widget(table, area);
+}
+
+fn draw_changelog(f: &mut Frame, app: &App, area: Rect) {
+    let mut lines: Vec<Line> = Vec::new();
+
+    if app.changelog.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "No closed PRs yet.",
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        // Group by section, preserving the order the sections appear in.
+        let mut sections: Vec<(&'static str, Vec<&crate::tui::app::ChangelogEntry>)> = Vec::new();
+        for entry in &app.changelog {
+            if let Some(s) = sections.iter_mut().find(|(name, _)| *name == entry.section) {
+                s.1.push(entry);
+            } else {
+                sections.push((entry.section, vec![entry]));
+            }
+        }
+
+        for (section, entries) in sections {
+            lines.push(Line::from(Span::styled(
+                section,
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )));
+            for e in entries {
+                let author = e
+                    .author
+                    .as_deref()
+                    .map(|a| format!(" — @{a}"))
+                    .unwrap_or_default();
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        format!("  #{} ", e.number),
+                        Style::default().fg(Color::Yellow),
+                    ),
+                    Span::raw(truncate(&e.title, 80)),
+                    Span::styled(author, Style::default().fg(Color::DarkGray)),
+                    Span::styled(
+                        format!("  {}", e.merged_at.chars().take(10).collect::<String>()),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                ]));
+            }
+            lines.push(Line::from(""));
+        }
+    }
+
+    let total = app.changelog.len();
+    let para = Paragraph::new(lines)
+        .scroll((app.scroll_offset as u16, 0))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!(" Changelog ({total} closed PRs) ")),
+        );
+    f.render_widget(para, area);
+}
+
 fn draw_footer(f: &mut Frame, app: &App, area: Rect) {
     let mut spans = vec![
-        Span::styled(" 1-5 ", Style::default().fg(Color::Cyan)),
+        Span::styled(" 1-9 ", Style::default().fg(Color::Cyan)),
         Span::raw("tabs  "),
         Span::styled("j/k ", Style::default().fg(Color::Cyan)),
         Span::raw("scroll  "),


### PR DESCRIPTION
## Summary

Two new read-only tabs in the TUI for parity with the web. Both read directly from local SQLite — no daemon required.

### Tab Triage (key \`8\`)
- Lists every \`triage_results\` row, most recent first.
- Columns: #, category (short code), priority (color-coded), confidence %, summary (first line truncated), acted-at date.
- Backed by \`db.recent_activity(500)\`.

### Tab Changelog (key \`9\`)
- Closed PRs (last 100) grouped by conventional-commit prefix: Features / Bug Fixes / Documentation / Chores / Refactoring / Tests / Other.
- Each line: # (yellow), title, @author (dim), merged date.
- SQL + grouping logic mirrors web \`/api/v1/changelog\`.

### Wiring
- \`Tab\` enum + \`current_list_len()\` + main UI match arm updated.
- Footer help: "1-9 tabs" (was "1-5").
- Pressing \`r\` reloads triage + changelog as well.

## Phase plan
This is **PR A** of the TUI parity-with-web sprint. **PR B** will add Tab Secrets + Tab Logs. **PR C** will extend the Settings popup with GitHub token / AI provider / License.

## Test plan
- [ ] \`cargo run -- tui\` → press \`8\` → Triage tab populated.
- [ ] Press \`9\` → Changelog grouped by section.
- [ ] Press \`r\` → both reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)