### PR TITLE
feat(tui): Logs tab tailing the in-memory tracing buffer

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -25,6 +25,8 @@ pub enum Tab {
     Queue,
     Stats,
     Activity,
+    Triage,
+    Changelog,
 }
 
 impl Tab {
@@ -38,6 +40,8 @@ impl Tab {
             Tab::Queue => "Merge Queue",
             Tab::Stats => "Stats",
             Tab::Activity => "Activity",
+            Tab::Triage => "Triage",
+            Tab::Changelog => "Changelog",
         }
     }
 
@@ -51,6 +55,8 @@ impl Tab {
             Tab::Queue,
             Tab::Stats,
             Tab::Activity,
+            Tab::Triage,
+            Tab::Changelog,
         ]
     }
 }
@@ -160,6 +166,8 @@ pub struct App {
     pub conflict_count: usize,
     pub stats: Stats,
     pub activity: Vec<TriageResultRow>,
+    pub triage_all: Vec<TriageResultRow>,
+    pub changelog: Vec<ChangelogEntry>,
     pub logs: Vec<LogEntry>,
     pub actions: Vec<ActionItem>,
     pub repos: Vec<RepoRow>,
@@ -211,6 +219,16 @@ pub enum SettingKind {
     Label,  // read-only info
 }
 
+/// One entry in the Changelog tab — a closed pull request.
+#[derive(Clone)]
+pub struct ChangelogEntry {
+    pub section: &'static str,
+    pub number: u64,
+    pub title: String,
+    pub author: Option<String>,
+    pub merged_at: String,
+}
+
 #[derive(Clone)]
 pub struct RepoRow {
     pub slug: String,
@@ -252,6 +270,8 @@ impl App {
                 avg_pr_age_days: 0,
             },
             activity: Vec::new(),
+            triage_all: Vec::new(),
+            changelog: Vec::new(),
             logs: Vec::new(),
             actions: Vec::new(),
             repos: Vec::new(),
@@ -272,7 +292,70 @@ impl App {
         app.load_actions();
         app.refresh(db)?;
         app.load_summary(config, db);
+        app.load_triage_all(db);
+        app.load_changelog(db);
         Ok(app)
+    }
+
+    /// Load all triage results, most recent first. Used by the Triage tab.
+    pub fn load_triage_all(&mut self, db: &Database) {
+        match db.recent_activity(500) {
+            Ok(rows) => self.triage_all = rows,
+            Err(_) => self.triage_all = Vec::new(),
+        }
+    }
+
+    /// Load closed pull requests, group them by conventional-commit section.
+    /// Same logic as the web /api/v1/changelog endpoint.
+    pub fn load_changelog(&mut self, db: &Database) {
+        let rows = db
+            .with_conn(|conn| {
+                let mut stmt = conn.prepare(
+                    "SELECT number, title, author, updated_at
+                     FROM pull_requests WHERE state = 'closed'
+                     ORDER BY updated_at DESC LIMIT 100",
+                )?;
+                let rows = stmt
+                    .query_map([], |row| {
+                        Ok((
+                            row.get::<_, u64>(0)?,
+                            row.get::<_, String>(1)?,
+                            row.get::<_, Option<String>>(2)?,
+                            row.get::<_, String>(3)?,
+                        ))
+                    })?
+                    .collect::<std::result::Result<Vec<_>, _>>()?;
+                Ok(rows)
+            })
+            .unwrap_or_default();
+
+        self.changelog = rows
+            .into_iter()
+            .map(|(number, title, author, merged_at)| {
+                let section = if title.starts_with("feat") {
+                    "Features"
+                } else if title.starts_with("fix") {
+                    "Bug Fixes"
+                } else if title.starts_with("docs") {
+                    "Documentation"
+                } else if title.starts_with("chore") || title.starts_with("ci") {
+                    "Chores"
+                } else if title.starts_with("refactor") {
+                    "Refactoring"
+                } else if title.starts_with("test") {
+                    "Tests"
+                } else {
+                    "Other"
+                };
+                ChangelogEntry {
+                    section,
+                    number,
+                    title,
+                    author,
+                    merged_at,
+                }
+            })
+            .collect();
     }
 
     pub fn load_summary(&mut self, config: &Config, db: &Database) {
@@ -549,6 +632,8 @@ impl App {
             Tab::Repos => self.repos.len(),
             Tab::Action => self.actions.len(),
             Tab::Activity => self.logs.len(),
+            Tab::Triage => self.triage_all.len(),
+            Tab::Changelog => self.changelog.len(),
             Tab::Summary => 0,
         }
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -27,6 +27,7 @@ pub enum Tab {
     Activity,
     Triage,
     Changelog,
+    Logs,
 }
 
 impl Tab {
@@ -42,6 +43,7 @@ impl Tab {
             Tab::Activity => "Activity",
             Tab::Triage => "Triage",
             Tab::Changelog => "Changelog",
+            Tab::Logs => "Logs",
         }
     }
 
@@ -57,6 +59,7 @@ impl Tab {
             Tab::Activity,
             Tab::Triage,
             Tab::Changelog,
+            Tab::Logs,
         ]
     }
 }
@@ -168,6 +171,7 @@ pub struct App {
     pub activity: Vec<TriageResultRow>,
     pub triage_all: Vec<TriageResultRow>,
     pub changelog: Vec<ChangelogEntry>,
+    pub process_logs: Vec<crate::daemon::log_buffer::LogEntry>,
     pub logs: Vec<LogEntry>,
     pub actions: Vec<ActionItem>,
     pub repos: Vec<RepoRow>,
@@ -272,6 +276,7 @@ impl App {
             activity: Vec::new(),
             triage_all: Vec::new(),
             changelog: Vec::new(),
+            process_logs: Vec::new(),
             logs: Vec::new(),
             actions: Vec::new(),
             repos: Vec::new(),
@@ -634,8 +639,24 @@ impl App {
             Tab::Activity => self.logs.len(),
             Tab::Triage => self.triage_all.len(),
             Tab::Changelog => self.changelog.len(),
+            Tab::Logs => self.process_logs.len(),
             Tab::Summary => 0,
         }
+    }
+
+    /// Snapshot the in-memory tracing log buffer (populated by main.rs's
+    /// LogLayer). Available because the TUI runs through the same process
+    /// init that sets up the buffer for the daemon.
+    pub fn load_process_logs(&mut self) {
+        let buf = match crate::daemon::log_buffer::global() {
+            Some(b) => b,
+            None => {
+                self.process_logs = Vec::new();
+                return;
+            }
+        };
+        let handle = tokio::runtime::Handle::current();
+        self.process_logs = handle.block_on(buf.snapshot(Some(500), None, None));
     }
 
     /// Load action items across all repos (prioritized TODO list)

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -135,6 +135,14 @@ fn run_loop(
                         KeyCode::Char('5') => app.active_tab = app::Tab::Queue,
                         KeyCode::Char('6') => app.active_tab = app::Tab::Stats,
                         KeyCode::Char('7') => app.active_tab = app::Tab::Activity,
+                        KeyCode::Char('8') => {
+                            app.load_triage_all(db);
+                            app.active_tab = app::Tab::Triage;
+                        }
+                        KeyCode::Char('9') => {
+                            app.load_changelog(db);
+                            app.active_tab = app::Tab::Changelog;
+                        }
                         KeyCode::Enter => {
                             if app.active_tab == app::Tab::Repos {
                                 app.open_settings();
@@ -153,6 +161,8 @@ fn run_loop(
                             app.refresh(db)?;
                             app.load_repos();
                             app.load_actions();
+                            app.load_triage_all(db);
+                            app.load_changelog(db);
                         }
                         KeyCode::Char('n') if app.active_tab == app::Tab::Repos => {
                             app.start_add_repo();

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -50,11 +50,18 @@ fn run_loop(
     loop {
         terminal.draw(|f| ui::draw(f, app))?;
 
-        // Auto-refresh logs every 5 seconds when on Activity tab
+        // Auto-refresh: Activity tab pulls journalctl every 5s; Logs tab
+        // re-snapshots the in-memory tracing buffer every 1s for liveness.
         if app.active_tab == app::Tab::Activity
             && last_log_refresh.elapsed() > std::time::Duration::from_secs(5)
         {
             app.refresh_logs();
+            *last_log_refresh = std::time::Instant::now();
+        }
+        if app.active_tab == app::Tab::Logs
+            && last_log_refresh.elapsed() > std::time::Duration::from_secs(1)
+        {
+            app.load_process_logs();
             *last_log_refresh = std::time::Instant::now();
         }
 
@@ -142,6 +149,10 @@ fn run_loop(
                         KeyCode::Char('9') => {
                             app.load_changelog(db);
                             app.active_tab = app::Tab::Changelog;
+                        }
+                        KeyCode::Char('0') => {
+                            app.load_process_logs();
+                            app.active_tab = app::Tab::Logs;
                         }
                         KeyCode::Enter => {
                             if app.active_tab == app::Tab::Repos {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -39,6 +39,8 @@ pub fn draw(f: &mut Frame, app: &App) {
         Tab::Queue => draw_queue(f, app, chunks[2]),
         Tab::Stats => draw_stats_tab(f, app, chunks[2]),
         Tab::Activity => draw_activity(f, app, chunks[2]),
+        Tab::Triage => draw_triage(f, app, chunks[2]),
+        Tab::Changelog => draw_changelog(f, app, chunks[2]),
     }
 
     // Action detail popup
@@ -1361,9 +1363,151 @@ fn draw_summary(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(content, area);
 }
 
+fn priority_color(p: Option<&str>) -> Color {
+    match p {
+        Some("critical") | Some("high") => Color::Red,
+        Some("medium") => Color::Yellow,
+        Some("low") => Color::Blue,
+        _ => Color::DarkGray,
+    }
+}
+
+fn category_short(c: &str) -> &str {
+    match c {
+        "bug" => "BUG",
+        "feature" => "FEAT",
+        "duplicate" => "DUP",
+        "wontfix" => "WONT",
+        "needs-info" => "INFO",
+        "question" => "Q",
+        "docs" => "DOCS",
+        _ => c,
+    }
+}
+
+fn draw_triage(f: &mut Frame, app: &App, area: Rect) {
+    let header = Row::new(vec![
+        Cell::from("#"),
+        Cell::from("Cat"),
+        Cell::from("Prio"),
+        Cell::from("Conf"),
+        Cell::from("Summary"),
+        Cell::from("Acted"),
+    ])
+    .style(
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    let rows: Vec<Row> = app
+        .triage_all
+        .iter()
+        .skip(app.scroll_offset)
+        .take(area.height.saturating_sub(3) as usize)
+        .map(|t| {
+            let summary = t
+                .summary
+                .as_deref()
+                .unwrap_or("")
+                .lines()
+                .next()
+                .unwrap_or("")
+                .to_string();
+            Row::new(vec![
+                Cell::from(format!("#{}", t.issue_number)).style(Style::default().fg(Color::Cyan)),
+                Cell::from(category_short(&t.category)),
+                Cell::from(t.priority.as_deref().unwrap_or("-").to_string())
+                    .style(Style::default().fg(priority_color(t.priority.as_deref()))),
+                Cell::from(format!("{:.0}%", t.confidence * 100.0)),
+                Cell::from(truncate(&summary, 70)),
+                Cell::from(t.acted_at.chars().take(10).collect::<String>())
+                    .style(Style::default().fg(Color::DarkGray)),
+            ])
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(7),
+        Constraint::Length(5),
+        Constraint::Length(6),
+        Constraint::Length(5),
+        Constraint::Min(20),
+        Constraint::Length(11),
+    ];
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .block(Block::default().borders(Borders::ALL).title(format!(
+            " Triage Results ({} total) ",
+            app.triage_all.len()
+        )));
+    f.render_widget(table, area);
+}
+
+fn draw_changelog(f: &mut Frame, app: &App, area: Rect) {
+    let mut lines: Vec<Line> = Vec::new();
+
+    if app.changelog.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "No closed PRs yet.",
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        // Group by section, preserving the order the sections appear in.
+        let mut sections: Vec<(&'static str, Vec<&crate::tui::app::ChangelogEntry>)> = Vec::new();
+        for entry in &app.changelog {
+            if let Some(s) = sections.iter_mut().find(|(name, _)| *name == entry.section) {
+                s.1.push(entry);
+            } else {
+                sections.push((entry.section, vec![entry]));
+            }
+        }
+
+        for (section, entries) in sections {
+            lines.push(Line::from(Span::styled(
+                section,
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )));
+            for e in entries {
+                let author = e
+                    .author
+                    .as_deref()
+                    .map(|a| format!(" — @{a}"))
+                    .unwrap_or_default();
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        format!("  #{} ", e.number),
+                        Style::default().fg(Color::Yellow),
+                    ),
+                    Span::raw(truncate(&e.title, 80)),
+                    Span::styled(author, Style::default().fg(Color::DarkGray)),
+                    Span::styled(
+                        format!("  {}", e.merged_at.chars().take(10).collect::<String>()),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                ]));
+            }
+            lines.push(Line::from(""));
+        }
+    }
+
+    let total = app.changelog.len();
+    let para = Paragraph::new(lines)
+        .scroll((app.scroll_offset as u16, 0))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!(" Changelog ({total} closed PRs) ")),
+        );
+    f.render_widget(para, area);
+}
+
 fn draw_footer(f: &mut Frame, app: &App, area: Rect) {
     let mut spans = vec![
-        Span::styled(" 1-5 ", Style::default().fg(Color::Cyan)),
+        Span::styled(" 1-9 ", Style::default().fg(Color::Cyan)),
         Span::raw("tabs  "),
         Span::styled("j/k ", Style::default().fg(Color::Cyan)),
         Span::raw("scroll  "),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -41,6 +41,7 @@ pub fn draw(f: &mut Frame, app: &App) {
         Tab::Activity => draw_activity(f, app, chunks[2]),
         Tab::Triage => draw_triage(f, app, chunks[2]),
         Tab::Changelog => draw_changelog(f, app, chunks[2]),
+        Tab::Logs => draw_logs(f, app, chunks[2]),
     }
 
     // Action detail popup
@@ -1505,9 +1506,74 @@ fn draw_changelog(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(para, area);
 }
 
+fn level_color(level: &str) -> Color {
+    match level {
+        "ERROR" => Color::Red,
+        "WARN" => Color::Yellow,
+        "INFO" => Color::Cyan,
+        "DEBUG" => Color::Gray,
+        _ => Color::DarkGray,
+    }
+}
+
+fn draw_logs(f: &mut Frame, app: &App, area: Rect) {
+    if app.process_logs.is_empty() {
+        let text = Paragraph::new(
+            "No log entries yet.\n\nLogs from this TUI process and any spawned async tasks \
+             land here. Run a sync (F5) or wait for periodic activity.",
+        )
+        .block(Block::default().borders(Borders::ALL).title(" Logs "))
+        .style(Style::default().fg(Color::DarkGray));
+        f.render_widget(text, area);
+        return;
+    }
+
+    let visible_rows = area.height.saturating_sub(2) as usize;
+    let total = app.process_logs.len();
+    let start = total.saturating_sub(visible_rows + app.scroll_offset);
+    let end = total.saturating_sub(app.scroll_offset);
+
+    let lines: Vec<Line> = app.process_logs[start..end]
+        .iter()
+        .map(|e| {
+            let time = e
+                .at
+                .split('T')
+                .nth(1)
+                .and_then(|s| s.split('.').next())
+                .unwrap_or(&e.at)
+                .to_string();
+            Line::from(vec![
+                Span::styled(time, Style::default().fg(Color::DarkGray)),
+                Span::raw(" "),
+                Span::styled(
+                    format!("{:5}", e.level),
+                    Style::default()
+                        .fg(level_color(e.level))
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(" "),
+                Span::styled(
+                    truncate(&e.target, 32),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::raw(" "),
+                Span::raw(truncate(&e.message, 200)),
+            ])
+        })
+        .collect();
+
+    let para = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(format!(" Logs ({total} entries, j/k to scroll) ")),
+    );
+    f.render_widget(para, area);
+}
+
 fn draw_footer(f: &mut Frame, app: &App, area: Rect) {
     let mut spans = vec![
-        Span::styled(" 1-9 ", Style::default().fg(Color::Cyan)),
+        Span::styled(" 1-9,0 ", Style::default().fg(Color::Cyan)),
         Span::raw("tabs  "),
         Span::styled("j/k ", Style::default().fg(Color::Cyan)),
         Span::raw("scroll  "),


### PR DESCRIPTION
## Summary

Add a **Logs** tab (key \`0\`) that snapshots the process-wide \`log_buffer::LogBuffer\` populated by \`main.rs\`'s \`LogLayer\`. Same buffer the daemon uses for \`/api/v1/logs\`; the TUI process feeds it too, so the tab shows live tracing events from the TUI itself (sync, refresh, repo loads…).

- \`App::load_process_logs()\` snapshots via \`buf.snapshot(Some(500), None, None)\` (block_on).
- Auto-refresh every 1 s while Logs tab is active (Activity tab keeps polling journalctl every 5 s, unchanged).
- Render: HH:MM:SS time + colored level (ERROR red / WARN yellow / INFO cyan / DEBUG gray) + target + message, scrollable with j/k.
- Footer help: "1-9,0 tabs".

## Test plan
- [ ] \`cargo run -- tui\` → key \`0\` → Logs tab shows recent INFO lines.
- [ ] Hit F5 → new sync log lines appear within ~1 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)