### PR TITLE
fix(daemon): hot-reload GitHub client when github_token secret changes

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -27,9 +27,53 @@ use self::processor::WebhookEvent;
 
 pub struct DaemonState {
     pub db: Arc<Database>,
-    pub gh: Arc<GhClient>,
+    /// Hot-reloadable GitHub client. The inner Arc is swapped under a
+    /// RwLock when a `github_token` secret is added or removed via the
+    /// web UI, so the new token is picked up without a daemon restart.
+    /// Call sites get a snapshot via [`DaemonState::gh()`].
+    gh: std::sync::RwLock<Arc<GhClient>>,
     pub config: Arc<Config>,
     pub apply: bool,
+}
+
+impl DaemonState {
+    pub fn new(
+        db: Arc<Database>,
+        gh: Arc<GhClient>,
+        config: Arc<Config>,
+        apply: bool,
+    ) -> Self {
+        Self {
+            db,
+            gh: std::sync::RwLock::new(gh),
+            config,
+            apply,
+        }
+    }
+
+    /// Snapshot of the current GitHub client. The returned Arc is
+    /// independent of subsequent reloads, so an in-flight call keeps
+    /// using the old client even if the secret changes mid-request.
+    pub fn gh(&self) -> Arc<GhClient> {
+        self.gh.read().expect("gh RwLock poisoned").clone()
+    }
+
+    /// Rebuild the GitHub client from the current config (re-reads the
+    /// secret store) and atomically swap the inner Arc. Called after a
+    /// `github_token` secret is added or removed via the web UI.
+    pub fn reload_github_client(&self) -> anyhow::Result<()> {
+        let new_client = GhClient::new(&self.config)?;
+        let was_authenticated = self.gh().authenticated;
+        let now_authenticated = new_client.authenticated;
+        *self.gh.write().expect("gh RwLock poisoned") = Arc::new(new_client);
+        info!(
+            "[{}] GitHub client reloaded ({} → {})",
+            self.config.repo_slug(),
+            if was_authenticated { "authenticated" } else { "anonymous" },
+            if now_authenticated { "authenticated" } else { "anonymous" }
+        );
+        Ok(())
+    }
 }
 
 /// Runtime context captured at daemon startup so dynamic add_repo can spawn
@@ -110,12 +154,7 @@ impl MultiDaemonState {
 
         let db = Arc::new(Database::open(&config)?);
         let gh = Arc::new(GhClient::new(&config)?);
-        let state = Arc::new(DaemonState {
-            db,
-            gh,
-            config: Arc::new(config),
-            apply: runtime.global_apply,
-        });
+        let state = Arc::new(DaemonState::new(db, gh, Arc::new(config), runtime.global_apply));
 
         // Persist before mutating runtime state so a crash can't lose the
         // user's intent silently.
@@ -191,12 +230,12 @@ pub async fn run(mut config: Config, args: DaemonArgs) -> Result<()> {
 
     let (tx, rx) = mpsc::channel::<WebhookEvent>(WEBHOOK_CHANNEL_CAPACITY);
 
-    let state = Arc::new(DaemonState {
-        db: Arc::clone(&db),
-        gh: Arc::clone(&gh),
-        config: Arc::clone(&config),
+    let state = Arc::new(DaemonState::new(
+        Arc::clone(&db),
+        Arc::clone(&gh),
+        Arc::clone(&config),
         apply,
-    });
+    ));
 
     let mode = if args.poll { "polling" } else { "webhook" };
     info!(
@@ -399,12 +438,7 @@ pub async fn run_multi_with_extensions(
         let gh = Arc::new(GhClient::new(&config)?);
         let apply = entry.apply.unwrap_or(global_apply);
 
-        let state = Arc::new(DaemonState {
-            db,
-            gh,
-            config: Arc::new(config),
-            apply,
-        });
+        let state = Arc::new(DaemonState::new(db, gh, Arc::new(config), apply));
 
         info!(
             "Loaded repo: {} (path={}, apply={})",

--- a/src/daemon/poller.rs
+++ b/src/daemon/poller.rs
@@ -98,9 +98,9 @@ async fn poll_events(
         state.config.repo_owner, state.config.repo_name
     );
 
-    let response = state.gh.octocrab._get(&url).await?;
+    let response = state.gh().octocrab._get(&url).await?;
 
-    let body = state.gh.octocrab.body_to_string(response).await?;
+    let body = state.gh().octocrab.body_to_string(response).await?;
     let events = crate::github::parse_json_array(&body, "events")?;
 
     if events.is_empty() {

--- a/src/daemon/processor.rs
+++ b/src/daemon/processor.rs
@@ -164,7 +164,7 @@ async fn handle_issue(state: &DaemonState, event: &WebhookEvent) -> anyhow::Resu
     }
 
     // Force sync issues (bypass throttle — we know there's a new event)
-    gh_sync::sync_issues_now(&state.gh, &state.db).await?;
+    gh_sync::sync_issues_now(&state.gh(), &state.db).await?;
 
     // Run triage pipeline
     let args = TriageArgs {
@@ -176,7 +176,7 @@ async fn handle_issue(state: &DaemonState, event: &WebhookEvent) -> anyhow::Resu
     pipelines::triage::run(
         &state.config,
         &state.db,
-        &state.gh,
+        &state.gh(),
         &args,
         pipelines::triage::OutputFormat::Text,
         None,
@@ -235,7 +235,7 @@ async fn handle_pull_request(state: &DaemonState, event: &WebhookEvent) -> anyho
     }
 
     // Force sync pulls (bypass throttle — we know there's a new event)
-    gh_sync::sync_pulls_now(&state.gh, &state.db).await?;
+    gh_sync::sync_pulls_now(&state.gh(), &state.db).await?;
 
     // Run PR analysis pipeline
     let args = PrArgs {
@@ -243,7 +243,7 @@ async fn handle_pull_request(state: &DaemonState, event: &WebhookEvent) -> anyho
         apply: state.apply,
     };
 
-    pipelines::pr_analysis::run(&state.config, &state.db, &state.gh, &args, false, None).await?;
+    pipelines::pr_analysis::run(&state.config, &state.db, &state.gh(), &args, false, None).await?;
 
     // Store in ICM if enabled
     if state.config.daemon.icm_enabled {
@@ -319,7 +319,7 @@ async fn handle_comment(state: &DaemonState, event: &WebhookEvent) -> anyhow::Re
         is_pr,
         &state.config,
         &state.db,
-        &state.gh,
+        &state.gh(),
         state.apply,
         Some(triggered_by),
     )
@@ -327,7 +327,7 @@ async fn handle_comment(state: &DaemonState, event: &WebhookEvent) -> anyhow::Re
 
     // Post response as a comment
     if state.apply {
-        state.gh.comment_issue(number, &response).await?;
+        state.gh().comment_issue(number, &response).await?;
         info!("Posted slash command response on #{number}");
     } else {
         info!("Dry-run slash command response for #{number}: {response}");

--- a/src/daemon/scheduler.rs
+++ b/src/daemon/scheduler.rs
@@ -49,7 +49,7 @@ pub async fn run(state: Arc<DaemonState>) {
         tokio::time::sleep(interval).await;
 
         info!("Periodic sync triggered (incremental)");
-        match github::sync::incremental_sync_full(&state.gh, &state.db).await {
+        match github::sync::incremental_sync_full(&state.gh(), &state.db).await {
             Ok(_) => {
                 info!("Periodic sync complete");
 
@@ -84,7 +84,7 @@ pub async fn run(state: Arc<DaemonState>) {
             match pipelines::triage::run(
                 &state.config,
                 &state.db,
-                &state.gh,
+                &state.gh(),
                 &args,
                 pipelines::triage::OutputFormat::Text,
                 None,
@@ -131,7 +131,7 @@ pub async fn run(state: Arc<DaemonState>) {
             match pipelines::triage::run(
                 &state.config,
                 &state.db,
-                &state.gh,
+                &state.gh(),
                 &args,
                 pipelines::triage::OutputFormat::Text,
                 None,

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -1510,9 +1510,9 @@ async fn run_sync(state: &WebState, repo_filter: Option<&str>, full: bool) -> Re
     let mut errors = Vec::new();
     for (slug, daemon) in targets {
         let result = if full {
-            crate::github::sync::full_sync(&daemon.gh, &daemon.db).await
+            crate::github::sync::full_sync(&daemon.gh(), &daemon.db).await
         } else {
-            crate::github::sync::incremental_sync_full(&daemon.gh, &daemon.db).await
+            crate::github::sync::incremental_sync_full(&daemon.gh(), &daemon.db).await
         };
         match result {
             Ok(()) => synced.push(slug),
@@ -2163,12 +2163,46 @@ async fn api_secrets_put(
         .put(scope, effective_slug, key.trim(), value, Some(admin.id))
         .await
     {
-        Ok(id) => (StatusCode::CREATED, Json(json!({ "id": id }))).into_response(),
+        Ok(id) => {
+            // Hot-reload affected daemon clients so the new token / API key
+            // takes effect without a restart. Only github_token reloads the
+            // GhClient today; other keys are read on-demand by the relevant
+            // pipeline so no reload is needed.
+            if key.trim() == "github_token" {
+                reload_github_clients(&state, scope, effective_slug).await;
+            }
+            (StatusCode::CREATED, Json(json!({ "id": id }))).into_response()
+        }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({"error": format!("{e}")})),
         )
             .into_response(),
+    }
+}
+
+/// Rebuild the GitHub client of every running per-repo daemon whose scope
+/// matches the secret that was just written or removed. Errors are logged
+/// but never propagate — a failed reload doesn't mean the secret write
+/// itself failed.
+async fn reload_github_clients(
+    state: &WebState,
+    scope: crate::secrets::Scope,
+    slug: Option<&str>,
+) {
+    let repos_guard = state.multi.repos.read().await;
+    for (repo_slug, ds) in repos_guard.iter() {
+        // global secret affects every repo; repo-scoped only affects its owner.
+        let matches = match scope {
+            crate::secrets::Scope::Global => true,
+            crate::secrets::Scope::Repo => slug == Some(repo_slug.as_str()),
+        };
+        if !matches {
+            continue;
+        }
+        if let Err(e) = ds.reload_github_client() {
+            tracing::warn!("[{repo_slug}] reload_github_client failed: {e:#}");
+        }
     }
 }
 
@@ -2228,7 +2262,13 @@ async fn api_secrets_delete(
         }
     };
     match store.delete(id, Some(admin.id)).await {
-        Ok(true) => Json(json!({"status": "ok"})).into_response(),
+        Ok(true) => {
+            // Blanket-reload — we don't know if the deleted secret was a
+            // github_token without looking it up first. Rebuilding a few
+            // GhClients is cheap; deletes are rare admin actions.
+            reload_github_clients(&state, crate::secrets::Scope::Global, None).await;
+            Json(json!({"status": "ok"})).into_response()
+        }
         Ok(false) => (StatusCode::NOT_FOUND, Json(json!({"error": "not found"}))).into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
## Summary

Fixes the symptom you saw on K8s: you added a \`github_token\` via Settings → Secrets but the daemon stayed in anonymous mode (\"public repos read-only\") until a pod restart. Cause: \`Client::new\` reads the token once at boot and bakes it into octocrab. Subsequent secret writes had no effect.

This PR makes the GH client hot-reloadable so adding/removing a \`github_token\` takes effect immediately.

### Changes
- \`DaemonState.gh\` is now \`std::sync::RwLock<Arc<GhClient>>\` (private). Pipelines call \`state.gh()\` to get a cheap snapshot \`Arc<GhClient>\`.
- New \`DaemonState::reload_github_client()\`: rebuilds the client from the current config (re-reads the secret store) and atomically swaps the Arc. Logs the auth state transition.
- \`api_secrets_put\`: when the written key is \`github_token\`, calls a new \`reload_github_clients()\` helper that iterates the affected repos:
  - Global scope → reloads all
  - Repo scope → reloads only the matching slug
- \`api_secrets_delete\`: blanket reload (we don't lookup the deleted secret's key first — cheap operation, rare admin action).
- All 13 call sites updated from \`&state.gh\` to \`&state.gh()\` (or \`state.gh().octocrab\`).
- 3 DaemonState struct-literal constructions use the new \`DaemonState::new\` constructor.

### Testing
- \`cargo check\`: clean.
- Logical correctness: in-flight requests on the old client finish unaffected; new requests after the swap use the new client.

### Test plan post-merge
- [ ] Boot daemon with no token → see \`anonymous mode\` warn.
- [ ] Add a github_token via Settings → Secrets → see \`GitHub client reloaded (anonymous → authenticated)\` info log immediately.
- [ ] Click Sync → no rate-limit error, sync succeeds.
- [ ] Delete the secret → \`reloaded (authenticated → anonymous)\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)