### PR TITLE
feat(repo-features): wire pipelines on flags (Lot C)

### DIFF
--- a/src/daemon/processor.rs
+++ b/src/daemon/processor.rs
@@ -163,10 +163,28 @@ async fn handle_issue(state: &DaemonState, event: &WebhookEvent) -> anyhow::Resu
         }
     }
 
+    let features = state.features();
+    if !features.collect_issues {
+        info!(
+            "[{}] collect_issues disabled — skipping sync for issue {number:?}",
+            state.config.repo_slug()
+        );
+        return Ok(());
+    }
     // Force sync issues (bypass throttle — we know there's a new event)
     gh_sync::sync_issues_now(&state.gh(), &state.db).await?;
 
-    // Run triage pipeline
+    if !features.triage_issues {
+        info!(
+            "[{}] triage_issues disabled — issue {number:?} synced but not triaged",
+            state.config.repo_slug()
+        );
+        return Ok(());
+    }
+
+    // Run triage pipeline. `apply` controls whether wshm posts a triage
+    // comment on GitHub; we keep the legacy semantic (state.apply) here
+    // because triage_issues already gated the AI run itself.
     let args = TriageArgs {
         issue: number,
         apply: state.apply,
@@ -234,8 +252,24 @@ async fn handle_pull_request(state: &DaemonState, event: &WebhookEvent) -> anyho
         }
     }
 
+    let features = state.features();
+    if !features.collect_prs {
+        info!(
+            "[{}] collect_prs disabled — skipping sync for PR {number:?}",
+            state.config.repo_slug()
+        );
+        return Ok(());
+    }
     // Force sync pulls (bypass throttle — we know there's a new event)
     gh_sync::sync_pulls_now(&state.gh(), &state.db).await?;
+
+    if !features.analyze_prs {
+        info!(
+            "[{}] analyze_prs disabled — PR {number:?} synced but not analyzed",
+            state.config.repo_slug()
+        );
+        return Ok(());
+    }
 
     // Run PR analysis pipeline
     let args = PrArgs {

--- a/src/daemon/scheduler.rs
+++ b/src/daemon/scheduler.rs
@@ -48,6 +48,14 @@ pub async fn run(state: Arc<DaemonState>) {
     loop {
         tokio::time::sleep(interval).await;
 
+        let features = state.features();
+        if !features.collect_issues && !features.collect_prs {
+            info!(
+                "[{}] collect_issues and collect_prs both disabled — skipping periodic sync",
+                state.config.repo_slug()
+            );
+            continue;
+        }
         info!("Periodic sync triggered (incremental)");
         match github::sync::incremental_sync_full(&state.gh(), &state.db).await {
             Ok(_) => {
@@ -73,8 +81,10 @@ pub async fn run(state: Arc<DaemonState>) {
             }
         }
 
-        // Triage untriaged issues after sync
-        if state.config.triage.enabled {
+        // Triage untriaged issues after sync. Both the legacy
+        // [triage].enabled config flag AND the per-repo features.triage_issues
+        // toggle must be true.
+        if state.config.triage.enabled && features.triage_issues {
             let args = TriageArgs {
                 issue: None,
                 apply: state.apply,
@@ -114,8 +124,10 @@ pub async fn run(state: Arc<DaemonState>) {
             }
         }
 
-        // Periodic retriage: re-evaluate stale triage results
+        // Periodic retriage: re-evaluate stale triage results. Same dual
+        // gate as the regular triage loop above.
         if state.config.triage.enabled
+            && features.triage_issues
             && retriage_interval_hours > 0
             && last_retriage.elapsed() >= retriage_interval
         {


### PR DESCRIPTION
## Summary

Lot C — wire the pipelines (poller / scheduler / processor) on the per-repo \`RepoFeatures\` flags introduced by #49 (Lot A). Without this, toggles in the UI stored the value but pipelines kept following the legacy \`apply\` flag.

### Wiring
- **handle_issue** (webhook processor): \`collect_issues\` gates the sync; \`triage_issues\` gates the AI triage.
- **handle_pull_request**: \`collect_prs\` gates the sync; \`analyze_prs\` gates the AI analysis.
- **scheduler periodic sync**: skipped when both \`collect_issues\` and \`collect_prs\` are off.
- **scheduler triage + retriage**: dual gate (\`[triage].enabled\` AND \`features.triage_issues\`).

### Not yet gated (follow-ups)
- \`auto_pr\` — auto-fix PR creation (waiting for the auto-fix pipeline to land).
- \`auto_merge\` — merge-on-green.
- \`review_prs\` — Pro inline review (gated in wshm-pro side).

## Test plan
- [ ] Toggle \`collect_issues=false\` for a repo → an issue webhook event logs "collect_issues disabled — skipping sync".
- [ ] Toggle \`triage_issues=false\` → event logs "issue X synced but not triaged".
- [ ] Both \`collect_*\` off → scheduler logs "skipping periodic sync".

🤖 Generated with [Claude Code](https://claude.com/claude-code)