### PR TITLE
feat(docker): add docker-compose.yml + .env.example for local self-host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Copy to .env and fill in. Used by `docker compose up`.
+
+# GitHub PAT — https://github.com/settings/tokens (scope: repo)
+GITHUB_TOKEN=
+
+# Pick ONE Anthropic credential:
+ANTHROPIC_API_KEY=
+# or, if you have a Claude Pro/Max subscription, paste the OAuth token
+# from `claude /token` in Claude Code:
+ANTHROPIC_OAUTH_TOKEN=
+
+# Optional. Set this to enable the encrypted secret store (AES-256-GCM)
+# instead of plaintext credentials in the data volume.
+# Generate with:  openssl rand -hex 32
+WSHM_MASTER_KEY=
+
+# Adjust if you want quieter / chattier logs.
+RUST_LOG=info,wshm_core=info

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ web/build/
 .wshm/
 *.log
 
+# Local docker-compose secrets
+.env
+
 # OS
 .DS_Store
 *.swp

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ One static binary. No SaaS dependency. Runs where your code lives.
 |----------------|------------------------------------------------------------------|
 | **VM / VPS**   | systemd service, auto-update via Homebrew, any Linux             |
 | **Docker**     | `docker run innovtech/wshm:latest` — multi-arch (amd64 + arm64)  |
+| **Compose**    | `cp .env.example .env && docker compose up -d` — dashboard on `:3000` |
 | **Kubernetes** | Helm chart, Kustomize overlays, or raw `Job`/`CronJob` manifests under [`deploy/`](./deploy) |
 | **Local dev**  | `wshm tui` / `wshm triage` — works offline with Ollama           |
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+# wshm — self-hosted GitHub agent
+#
+# Quick start:
+#   1. cp .env.example .env       and fill in your tokens
+#   2. docker compose up -d
+#   3. Open http://localhost:3000
+#
+# Defaults are deliberately safe:
+#   - polling mode (no public IP / webhook needed)
+#   - no --apply (dry-run; wshm observes but does not post comments,
+#     labels, or merges). Add --apply to the command list once you've
+#     reviewed the dashboard and trust the pipelines.
+#
+# Data lives in the wshm-data volume (SQLite DB, credentials, config).
+# Snapshot it with `docker compose cp wshm:/home/wshm/.wshm ./backup`.
+
+services:
+  wshm:
+    image: innovtech/wshm:latest
+    container_name: wshm
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:3000:3000"
+    volumes:
+      - wshm-data:/home/wshm/.wshm
+    environment:
+      # GitHub PAT with `repo` scope — required.
+      GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+      # One of the two — needed for triage and PR analysis.
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      ANTHROPIC_OAUTH_TOKEN: ${ANTHROPIC_OAUTH_TOKEN:-}
+      # Optional: 32-byte hex key to enable the encrypted secret store
+      # (otherwise tokens stay in ~/.wshm/credentials in plaintext).
+      # Generate with: openssl rand -hex 32
+      WSHM_MASTER_KEY: ${WSHM_MASTER_KEY:-}
+      RUST_LOG: ${RUST_LOG:-info,wshm_core=info}
+    command:
+      - daemon
+      - --bind=0.0.0.0:3000
+      - --poll
+      - --poll-interval=60
+      # Uncomment to let wshm post comments, set labels, merge PRs, …
+      # - --apply
+
+volumes:
+  wshm-data:


### PR DESCRIPTION
## Summary

- Adds a turn-key \`docker-compose.yml\` so users can self-host wshm with the web dashboard without writing a long \`docker run -p ... -v ... -e ...\` line.
- Pairs with \`.env.example\` documenting GitHub PAT, Anthropic OAuth/API key, and the optional \`WSHM_MASTER_KEY\` (32-byte hex) that flips the credential store from plaintext to AES-256-GCM.
- Conservative defaults: polling mode, no \`--apply\`, bind to \`127.0.0.1:3000\` only — users review the dashboard before letting wshm post anything.
- README gains a "Compose" row under **Deploy anywhere**.
- \`.env\` is gitignored so a fresh clone won't trip on stale tokens.

## Test plan

- [ ] \`cp .env.example .env\` and fill in a PAT + Anthropic key.
- [ ] \`docker compose up -d\` → \`http://localhost:3000\` shows the dashboard.
- [ ] \`docker compose down\` and back up → SQLite DB survives via the named volume.
- [ ] Set \`WSHM_MASTER_KEY=\$(openssl rand -hex 32)\`, save a token in Settings → response says \`"encrypted store"\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)