### PR TITLE
fix(secrets,auth): unambiguous AAD + multi-repo web auth gate

### DIFF
--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -270,22 +270,33 @@ async fn auth_middleware(
     req.extensions_mut()
         .insert(None as Option<crate::auth::User>);
 
+    // Multi-repo: gather every repo's [web] credential. The previous
+    // code picked an arbitrary repo via `repos.values().next()`, which
+    // made auth non-deterministic when two repos had different
+    // `[web].password` values — the gate behaved as one or the other
+    // depending on HashMap iteration order.
+    //
+    // New behavior: a Basic Auth pair / signed cookie is accepted when
+    // it matches ANY configured repo's [web] block. Empty credential
+    // lists (no [web] anywhere) keep "auth disabled" semantics.
     let repos = state.multi.repos.read().await;
-    let web_cfg = match repos.values().next() {
-        Some(ds) => ds.config.web.clone(),
-        None => {
-            drop(repos);
-            return next.run(req).await;
-        }
-    };
+    let web_cfgs: Vec<(String, String)> = repos
+        .values()
+        .filter_map(|ds| {
+            ds.config
+                .web
+                .password
+                .as_ref()
+                .map(|p| (ds.config.web.username.clone(), p.clone()))
+        })
+        .collect();
     drop(repos);
 
-    // No password configured → auth disabled (single-user dev mode).
-    let required_password = match &web_cfg.password {
-        Some(p) => p.clone(),
-        None => return next.run(req).await,
-    };
-    let expected_username = web_cfg.username.clone();
+    // No password configured anywhere → auth disabled (single-user dev mode).
+    if web_cfgs.is_empty() {
+        return next.run(req).await;
+    }
+    let valid_passwords: Vec<String> = web_cfgs.iter().map(|(_, p)| p.clone()).collect();
 
     // 1) Trust oauth2-proxy headers when explicitly enabled. Looking for
     //    X-Forwarded-User / X-Forwarded-Email / X-Auth-Request-Email which
@@ -306,16 +317,24 @@ async fn auth_middleware(
 
     // 2) Signed session cookie set by /api/v1/auth/login. Skipped in RBAC
     //    mode — there the user-id cookie is the canonical session and was
-    //    already tried above via current_user().
+    //    already tried above via current_user(). The cookie is HMAC-signed
+    //    with one of the configured passwords; accept any match across
+    //    repos (rotation of one repo's password doesn't invalidate the
+    //    other's outstanding sessions).
     if state.users.is_none() {
         if let Some(cookie_val) = read_cookie(req.headers(), "wshm_session") {
-            if verify_session_cookie(&required_password, cookie_val) {
+            if valid_passwords
+                .iter()
+                .any(|p| verify_session_cookie(p, cookie_val))
+            {
                 return next.run(req).await;
             }
         }
     }
 
-    // 3) Basic Auth fallback (CLI / curl).
+    // 3) Basic Auth fallback (CLI / curl). Match against ANY configured
+    //    repo's (username, password) pair so a single CI script can hit
+    //    a multi-repo daemon without picking the "right" repo's creds.
     let basic_ok = req
         .headers()
         .get(header::AUTHORIZATION)
@@ -325,7 +344,7 @@ async fn auth_middleware(
         .and_then(|bytes| String::from_utf8(bytes).ok())
         .map(|decoded| {
             if let Some((user, pass)) = decoded.split_once(':') {
-                user == expected_username && pass == required_password
+                web_cfgs.iter().any(|(u, p)| user == u && pass == p)
             } else {
                 false
             }

--- a/src/secrets/cipher.rs
+++ b/src/secrets/cipher.rs
@@ -80,12 +80,58 @@ impl Cipher {
             .decrypt(n, Payload { msg: ciphertext, aad })
             .map_err(|e| anyhow!("AES-GCM decrypt failed: {e}"))
     }
+
+    /// Decrypt with one or more candidate AADs — first one that
+    /// validates wins. Used by [`SecretStore::get`] to roll forward
+    /// ciphertexts that were sealed with the legacy `"scope|slug|key"`
+    /// AAD format (replaced by length-prefixed segments). Callers
+    /// should re-seal the row with the canonical AAD on the next
+    /// write so the legacy fallback eventually disappears.
+    pub fn open_with_aads(
+        &self,
+        nonce: &[u8],
+        ciphertext: &[u8],
+        aads: &[&[u8]],
+    ) -> Result<Vec<u8>> {
+        let mut last_err: Option<anyhow::Error> = None;
+        for aad in aads {
+            match self.open(nonce, ciphertext, aad) {
+                Ok(pt) => return Ok(pt),
+                Err(e) => last_err = Some(e),
+            }
+        }
+        Err(last_err.unwrap_or_else(|| anyhow!("no AAD candidates supplied")))
+    }
+}
+
+/// Legacy AAD shape `"scope|slug|key"` — only used as a fallback when
+/// decrypting rows sealed before the length-prefixed format landed.
+/// Do NOT use for new writes (ambiguous; see `aad_for` doc).
+pub fn aad_for_legacy(scope: &str, slug: Option<&str>, key: &str) -> Vec<u8> {
+    let s = format!("{}|{}|{}", scope, slug.unwrap_or(""), key);
+    s.into_bytes()
 }
 
 /// Build the AAD bytes for a given record from its logical identity.
+///
+/// Each segment is length-prefixed (4-byte big-endian) so that no
+/// combination of scope/slug/key collides with any other. The previous
+/// `"{scope}|{slug}|{key}"` shape was ambiguous (e.g. `slug="a|b"
+/// key="c"` and `slug="a" key="b|c"` produced identical AAD), letting
+/// an attacker with raw DB write access swap ciphertexts between two
+/// rows whose AAD coincidentally matched.
 pub fn aad_for(scope: &str, slug: Option<&str>, key: &str) -> Vec<u8> {
-    let s = format!("{}|{}|{}", scope, slug.unwrap_or(""), key);
-    s.into_bytes()
+    let scope_b = scope.as_bytes();
+    let slug_b = slug.unwrap_or("").as_bytes();
+    let key_b = key.as_bytes();
+    let mut out = Vec::with_capacity(12 + scope_b.len() + slug_b.len() + key_b.len());
+    out.extend_from_slice(&(scope_b.len() as u32).to_be_bytes());
+    out.extend_from_slice(scope_b);
+    out.extend_from_slice(&(slug_b.len() as u32).to_be_bytes());
+    out.extend_from_slice(slug_b);
+    out.extend_from_slice(&(key_b.len() as u32).to_be_bytes());
+    out.extend_from_slice(key_b);
+    out
 }
 
 #[cfg(test)]
@@ -111,5 +157,15 @@ mod tests {
         // Different AAD must fail (defends against row-substitution attack).
         let bad_aad = aad_for("global", None, "anthropic_key");
         assert!(c.open(&nonce, &ct, &bad_aad).is_err());
+    }
+
+    /// Regression test for the unescaped-`|` substitution attack: the
+    /// AAD format must distinguish `slug="a|b"` from `slug="a"` even
+    /// when the trailing key includes a `|`.
+    #[test]
+    fn aad_segments_are_unambiguous() {
+        let a = aad_for("repo", Some("a|b"), "key");
+        let b = aad_for("repo", Some("a"), "b|key");
+        assert_ne!(a, b, "AAD must not collide across segment splits");
     }
 }

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -20,7 +20,7 @@ use std::sync::{Arc, OnceLock};
 mod cipher;
 mod store;
 
-pub use cipher::{aad_for, Cipher, MasterKey};
+pub use cipher::{aad_for, aad_for_legacy, Cipher, MasterKey};
 pub use store::{SecretRecord, SqliteSecretStore};
 
 /// Backend-agnostic interface for the encrypted secret store.

--- a/src/secrets/store.rs
+++ b/src/secrets/store.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-use super::cipher::{aad_for, Cipher, MasterKey};
+use super::cipher::{aad_for, aad_for_legacy, Cipher, MasterKey};
 use super::{Scope, SecretStore};
 
 /// One row of the secrets table — values are returned masked unless the
@@ -79,8 +79,10 @@ impl SqliteSecretStore {
             .optional()?;
         match row {
             Some((nonce, ciphertext)) => {
-                let aad = aad_for(scope.as_str(), slug, key);
-                let plaintext = cipher.open(&nonce, &ciphertext, &aad)?;
+                let aad_new = aad_for(scope.as_str(), slug, key);
+                let aad_legacy = aad_for_legacy(scope.as_str(), slug, key);
+                let plaintext =
+                    cipher.open_with_aads(&nonce, &ciphertext, &[&aad_new, &aad_legacy])?;
                 let s = String::from_utf8(plaintext)
                     .context("decrypted secret is not valid UTF-8")?;
                 Ok(Some(s))
@@ -181,8 +183,11 @@ impl SecretStore for SqliteSecretStore {
             .optional()?;
         match row {
             Some((scope, slug, key, nonce, ct)) => {
-                let aad = aad_for(&scope, slug.as_deref(), &key);
-                let pt = self.cipher.open(&nonce, &ct, &aad)?;
+                let aad_new = aad_for(&scope, slug.as_deref(), &key);
+                let aad_legacy = aad_for_legacy(&scope, slug.as_deref(), &key);
+                let pt = self
+                    .cipher
+                    .open_with_aads(&nonce, &ct, &[&aad_new, &aad_legacy])?;
                 let s = String::from_utf8(pt).context("not utf-8")?;
                 let _ = conn.execute(
                     "INSERT INTO secrets_audit (scope, slug, key, action, user_id)


### PR DESCRIPTION
## Summary

Two P1 findings from the audit, bundled.

### M-2 — AAD collision (\`src/secrets/cipher.rs\`)

The old \`\"{scope}|{slug}|{key}\"\` AAD let \`slug=\"a|b\" key=\"c\"\` and \`slug=\"a\" key=\"b|c\"\` resolve to identical AAD bytes. With raw DB write access, an attacker could swap ciphertexts between two such rows and the GCM tag would still validate. New encoding is length-prefixed segments — no escape rules, no collision.

Backward compat: existing rows keep working via \`aad_for_legacy\` fallback in \`open_with_aads\`; they get re-sealed with the new AAD on the next write.

### M-4 — auth_middleware non-deterministic in multi-repo

\`repos.values().next()\` picked an arbitrary repo's \`[web].password\`; auth behaved differently across restarts when configs diverged. Now any configured (username, password) pair is accepted (cookie + Basic Auth).

## Test plan

- [ ] \`cargo test secrets::\` (3 unit tests — green locally)
- [ ] Existing secrets in K8s Postgres still decrypt after Pro deploys (legacy AAD fallback)
- [ ] Configure 2 repos with different passwords; cookie minted under one is accepted by both
- [ ] Companion Pro PR re-uses the same fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)