### PR TITLE
docs(readme): add Going Pro CTA explaining how to upgrade from OSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,25 @@ Token-heavy AI features and enterprise integrations layered on top of the OSS da
 - **SAML SSO** — Okta, Azure AD, custom IdP
 - **RBAC + Audit log** — organizations, roles, action audit trail
 
+#### Going Pro
+
+`wshm-pro` is a separate binary that drops in alongside `wshm` and reuses
+the same `~/.wshm/` data directory — your repos, credentials, and config
+carry over with zero migration.
+
+```bash
+# 1. Get a license at https://wshm.dev/pro
+# 2. Install — Docker, Homebrew, or tarball:
+brew install wshm-dev/tap/wshm-pro
+# or: docker pull innovtech/wshm-pro:latest
+# 3. Activate:
+wshm-pro login --license   # paste the key from your purchase email
+wshm-pro daemon            # boots with Pro features unlocked
+```
+
+Both binaries can coexist. Full install + upgrade guide:
+[`wshm-dev/wshm-pro`](https://github.com/wshm-dev/wshm-pro#upgrading-from-wshm-oss).
+
 ---
 
 ## Interfaces


### PR DESCRIPTION
## Summary

The Features → Pro section listed what wshm-pro adds but never told the reader **how to actually go Pro**: install command, where to put the license key, what happens to existing repos/credentials. Add a 3-step block with a link out to the full upgrade guide in wshm-dev/wshm-pro.

## Test plan

- [x] Verified ~/.wshm/ data dir is shared between wshm and wshm-pro (both export WSHM_HOME=/home/wshm/.wshm in their Dockerfiles)
- [x] Verified `wshm-pro login --license` is a real CLI flag (wshm/src/cli.rs:219-220)
- [x] Verified \`brew install wshm-dev/tap/wshm-pro\` resolves to v0.31.5-pro (homebrew tap formula auto-bumped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)