### PR TITLE
ci: run CI on the develop branch and its PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Problem

`ci.yml` only triggered on `main`:

```yaml
on:
  push:        { branches: [main] }
  pull_request: { branches: [main] }
```

In a `feature → develop → main` flow this means **PRs into `develop` run no CI at all** — they are merged untested.

## Fix

Add `develop` to the `push` and `pull_request` branch filters.

Release automation (`release-please`, `dispatch-pro`, `release`, `oss-rebuild`) is **left main-only on purpose** — releases and the production `:latest` image are cut from `main`, not `develop`.

> Note: for PRs into `develop` to pick up this trigger, the change must land **on `develop`** (GitHub reads the `pull_request` trigger from the base branch). Merge this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)