### PR TITLE
feat(retry): centralized configurable HTTP retry

### DIFF
--- a/src/ai/client.rs
+++ b/src/ai/client.rs
@@ -323,26 +323,28 @@ impl AiClient {
             ]
         });
 
-        let req = self
-            .http
-            .post(&self.provider.api_url)
-            .header("anthropic-version", "2023-06-01")
-            .header("content-type", "application/json")
-            .header("x-api-key", self.provider.api_key.as_str());
+        let text = crate::retry::with_retry("AI: Anthropic", || async {
+            let response = self
+                .http
+                .post(&self.provider.api_url)
+                .header("anthropic-version", "2023-06-01")
+                .header("content-type", "application/json")
+                .header("x-api-key", self.provider.api_key.as_str())
+                .json(&body)
+                .send()
+                .await
+                .context("Failed to call Anthropic API")?;
 
-        let response = req
-            .json(&body)
-            .send()
-            .await
-            .context("Failed to call Anthropic API")?;
+            let status = response.status();
+            let text = response.text().await?;
 
-        let status = response.status();
-        let text = response.text().await?;
-
-        if !status.is_success() {
-            let safe_text = truncate_error_body(&text);
-            anyhow::bail!("Anthropic API error ({status}): {safe_text}");
-        }
+            if !status.is_success() {
+                let safe_text = truncate_error_body(&text);
+                anyhow::bail!("Anthropic API error ({status}): {safe_text}");
+            }
+            Ok::<_, anyhow::Error>(text)
+        })
+        .await?;
 
         let resp: serde_json::Value = serde_json::from_str(&text)?;
         let content = resp["content"][0]["text"]
@@ -363,34 +365,38 @@ impl AiClient {
             "temperature": 0.1
         });
 
-        let mut req = self
-            .http
-            .post(&self.provider.api_url)
-            .header("content-type", "application/json");
+        let text = crate::retry::with_retry("AI: OpenAI-compatible", || async {
+            let mut req = self
+                .http
+                .post(&self.provider.api_url)
+                .header("content-type", "application/json");
 
-        // Azure uses api-key header, others use Bearer token
-        if self.provider.api_url.contains("openai.azure.com") {
-            req = req.header("api-key", self.provider.api_key.as_str());
-        } else if !self.provider.api_key.is_empty() {
-            req = req.header(
-                "Authorization",
-                format!("Bearer {}", self.provider.api_key.as_str()),
-            );
-        }
+            // Azure uses api-key header, others use Bearer token
+            if self.provider.api_url.contains("openai.azure.com") {
+                req = req.header("api-key", self.provider.api_key.as_str());
+            } else if !self.provider.api_key.is_empty() {
+                req = req.header(
+                    "Authorization",
+                    format!("Bearer {}", self.provider.api_key.as_str()),
+                );
+            }
 
-        let response = req
-            .json(&body)
-            .send()
-            .await
-            .context("Failed to call AI API")?;
+            let response = req
+                .json(&body)
+                .send()
+                .await
+                .context("Failed to call AI API")?;
 
-        let status = response.status();
-        let text = response.text().await?;
+            let status = response.status();
+            let text = response.text().await?;
 
-        if !status.is_success() {
-            let safe_text = truncate_error_body(&text);
-            anyhow::bail!("AI API error ({status}): {safe_text}");
-        }
+            if !status.is_success() {
+                let safe_text = truncate_error_body(&text);
+                anyhow::bail!("AI API error ({status}): {safe_text}");
+            }
+            Ok::<_, anyhow::Error>(text)
+        })
+        .await?;
 
         let resp: serde_json::Value = serde_json::from_str(&text)?;
         let content = resp["choices"][0]["message"]["content"]
@@ -414,23 +420,27 @@ impl AiClient {
             }
         });
 
-        let response = self
-            .http
-            .post(&self.provider.api_url)
-            .header("content-type", "application/json")
-            .header("x-goog-api-key", self.provider.api_key.as_str())
-            .json(&body)
-            .send()
-            .await
-            .context("Failed to call Google Gemini API")?;
+        let text = crate::retry::with_retry("AI: Google Gemini", || async {
+            let response = self
+                .http
+                .post(&self.provider.api_url)
+                .header("content-type", "application/json")
+                .header("x-goog-api-key", self.provider.api_key.as_str())
+                .json(&body)
+                .send()
+                .await
+                .context("Failed to call Google Gemini API")?;
 
-        let status = response.status();
-        let text = response.text().await?;
+            let status = response.status();
+            let text = response.text().await?;
 
-        if !status.is_success() {
-            let safe_text = truncate_error_body(&text);
-            anyhow::bail!("Google Gemini API error ({status}): {safe_text}");
-        }
+            if !status.is_success() {
+                let safe_text = truncate_error_body(&text);
+                anyhow::bail!("Google Gemini API error ({status}): {safe_text}");
+            }
+            Ok::<_, anyhow::Error>(text)
+        })
+        .await?;
 
         let resp: serde_json::Value = serde_json::from_str(&text)?;
         let content = resp["candidates"][0]["content"]["parts"][0]["text"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1318,6 +1318,12 @@ pub struct GlobalConfig {
     #[serde(default)]
     pub update: UpdateConfig,
 
+    /// Transient-HTTP-error retry policy, shared by every outbound HTTP
+    /// call (poller, git providers, AI, self-update). Editable live from
+    /// Settings -> Reliability.
+    #[serde(default)]
+    pub retry: crate::retry::RetryConfig,
+
     #[serde(default)]
     pub repos: Vec<RepoEntry>,
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -418,6 +418,11 @@ pub async fn run_multi_with_extensions(
         extensions.logs = log_buffer::global();
     }
 
+    // Install the retry policy process-wide so every outbound HTTP call
+    // (poller, git providers, AI, self-update) honors it. The Settings UI
+    // re-installs it on save, so this is just the boot-time default.
+    crate::retry::set_global(global.retry.clone());
+
     // Open a default UserStore on ~/.wshm/users.db when the caller didn't
     // provide one, so OSS gets a working RBAC + login flow out of the box.
     // The Pro binary still passes its own (possibly Postgres-backed) store

--- a/src/daemon/poller.rs
+++ b/src/daemon/poller.rs
@@ -123,14 +123,23 @@ async fn poll_events(
         state.config.repo_owner, state.config.repo_name
     );
 
-    let response = state.gh().octocrab._get(&url).await?;
+    // The GitHub events fetch is retried on transient transport failures
+    // (premature connection EOF from a dropped keep-alive, 5xx, 429). Both
+    // the GET and the body read share one retried closure so a mid-body
+    // EOF re-issues the whole request.
+    let (headers, body) = crate::retry::with_retry("poller: github events", || async {
+        let response = state.gh().octocrab._get(&url).await?;
+        let headers = response.headers().clone();
+        let body = state.gh().octocrab.body_to_string(response).await?;
+        Ok::<_, anyhow::Error>((headers, body))
+    })
+    .await?;
 
-    // Surface rate-limit pressure before consuming the body. Headers
-    // we care about: `x-ratelimit-remaining` (drops as we burn quota)
-    // and `x-ratelimit-reset` (unix epoch seconds when it refills).
-    // Logging at warn! when remaining < 100 lets the operator see
-    // they're about to get throttled, well before it fires.
-    let headers = response.headers().clone();
+    // Surface rate-limit pressure. Headers we care about:
+    // `x-ratelimit-remaining` (drops as we burn quota) and
+    // `x-ratelimit-reset` (unix epoch seconds when it refills). Logging at
+    // warn! when remaining < 100 lets the operator see they're about to
+    // get throttled, well before it fires.
     if let Some(remaining) = headers
         .get("x-ratelimit-remaining")
         .and_then(|v| v.to_str().ok())
@@ -150,7 +159,6 @@ async fn poll_events(
         }
     }
 
-    let body = state.gh().octocrab.body_to_string(response).await?;
     let events = crate::github::parse_json_array(&body, "events")?;
 
     if events.is_empty() {

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -2065,6 +2065,57 @@ async fn api_repo_features_patch(
     Json(resp).into_response()
 }
 
+/// GET /api/v1/config/retry -- read the live HTTP retry policy.
+async fn api_retry_get() -> Response {
+    Json(crate::retry::global()).into_response()
+}
+
+/// PATCH /api/v1/config/retry -- update the HTTP retry policy. Body is a
+/// partial RetryConfig JSON (any subset of fields). Applies live without a
+/// daemon restart and persists to ~/.wshm/global.toml.
+async fn api_retry_patch(
+    State(state): State<Arc<WebState>>,
+    user: axum::Extension<Option<crate::auth::User>>,
+    Json(body): Json<serde_json::Value>,
+) -> Response {
+    if state.users.is_some() {
+        if let Err(e) = require_admin(&user) {
+            return e;
+        }
+    }
+
+    // Merge the partial body over the current live policy.
+    let mut cfg = crate::retry::global();
+    if let Some(v) = body.get("enabled").and_then(|v| v.as_bool()) {
+        cfg.enabled = v;
+    }
+    if let Some(v) = body.get("max_attempts").and_then(|v| v.as_u64()) {
+        cfg.max_attempts = v as u32;
+    }
+    if let Some(v) = body.get("initial_backoff_ms").and_then(|v| v.as_u64()) {
+        cfg.initial_backoff_ms = v;
+    }
+    if let Some(v) = body.get("max_backoff_ms").and_then(|v| v.as_u64()) {
+        cfg.max_backoff_ms = v;
+    }
+    // sanitized() clamps to safe ranges so a bad entry can't wedge retries.
+    let cfg = cfg.sanitized();
+
+    // Apply live, then persist so the policy survives a restart.
+    crate::retry::set_global(cfg.clone());
+    let global_path = crate::config::GlobalConfig::default_path();
+    if global_path.exists() {
+        if let Ok(mut global) = crate::config::GlobalConfig::load(&global_path) {
+            global.retry = cfg.clone();
+            if let Err(e) = global.save(&global_path) {
+                tracing::warn!("Failed to persist retry config to global.toml: {e}");
+            }
+        }
+    }
+
+    Json(cfg).into_response()
+}
+
 /// POST /api/v1/repos -- add a repo at runtime (multi-repo mode only).
 /// Body: {"slug": "owner/repo", "path": "/optional/abs/path"}
 /// Requires `admin` role.
@@ -2952,6 +3003,10 @@ pub fn oss_api_routes() -> Router<Arc<WebState>> {
         .route("/api/v1/license", get(api_license))
         .route("/api/v1/license/activate", post(api_license_activate))
         .route("/api/v1/repos", get(api_list_repos).post(api_add_repo))
+        .route(
+            "/api/v1/config/retry",
+            get(api_retry_get).patch(api_retry_patch),
+        )
         .route(
             "/api/v1/repos/{slug}/features",
             get(api_repo_features_get).patch(api_repo_features_patch),

--- a/src/git_provider/azure_devops.rs
+++ b/src/git_provider/azure_devops.rs
@@ -72,60 +72,69 @@ impl AzureDevOpsProvider {
     }
 
     async fn get(&self, url: &str) -> Result<serde_json::Value> {
-        let resp = self
-            .http
-            .get(url)
-            .basic_auth("", Some(&self.token))
-            .send()
-            .await
-            .context("Azure DevOps GET")?;
-        let status = resp.status();
-        let text = resp.text().await?;
-        if !status.is_success() {
-            anyhow::bail!(
-                "Azure DevOps API error ({status}): {}",
-                &text[..text.len().min(200)]
-            );
-        }
-        Ok(serde_json::from_str(&text)?)
+        crate::retry::with_retry("Azure DevOps GET", || async {
+            let resp = self
+                .http
+                .get(url)
+                .basic_auth("", Some(&self.token))
+                .send()
+                .await
+                .context("Azure DevOps GET")?;
+            let status = resp.status();
+            let text = resp.text().await?;
+            if !status.is_success() {
+                anyhow::bail!(
+                    "Azure DevOps API error ({status}): {}",
+                    &text[..text.len().min(200)]
+                );
+            }
+            Ok(serde_json::from_str(&text)?)
+        })
+        .await
     }
 
     async fn post(&self, url: &str, body: &serde_json::Value) -> Result<serde_json::Value> {
-        let resp = self
-            .http
-            .post(url)
-            .basic_auth("", Some(&self.token))
-            .json(body)
-            .send()
-            .await?;
-        let status = resp.status();
-        let text = resp.text().await?;
-        if !status.is_success() {
-            anyhow::bail!(
-                "Azure DevOps API error ({status}): {}",
-                &text[..text.len().min(200)]
-            );
-        }
-        Ok(serde_json::from_str(&text).unwrap_or(serde_json::Value::Null))
+        crate::retry::with_retry("Azure DevOps POST", || async {
+            let resp = self
+                .http
+                .post(url)
+                .basic_auth("", Some(&self.token))
+                .json(body)
+                .send()
+                .await?;
+            let status = resp.status();
+            let text = resp.text().await?;
+            if !status.is_success() {
+                anyhow::bail!(
+                    "Azure DevOps API error ({status}): {}",
+                    &text[..text.len().min(200)]
+                );
+            }
+            Ok(serde_json::from_str(&text).unwrap_or(serde_json::Value::Null))
+        })
+        .await
     }
 
     async fn patch(&self, url: &str, body: &serde_json::Value) -> Result<serde_json::Value> {
-        let resp = self
-            .http
-            .patch(url)
-            .basic_auth("", Some(&self.token))
-            .json(body)
-            .send()
-            .await?;
-        let status = resp.status();
-        let text = resp.text().await?;
-        if !status.is_success() {
-            anyhow::bail!(
-                "Azure DevOps API error ({status}): {}",
-                &text[..text.len().min(200)]
-            );
-        }
-        Ok(serde_json::from_str(&text).unwrap_or(serde_json::Value::Null))
+        crate::retry::with_retry("Azure DevOps PATCH", || async {
+            let resp = self
+                .http
+                .patch(url)
+                .basic_auth("", Some(&self.token))
+                .json(body)
+                .send()
+                .await?;
+            let status = resp.status();
+            let text = resp.text().await?;
+            if !status.is_success() {
+                anyhow::bail!(
+                    "Azure DevOps API error ({status}): {}",
+                    &text[..text.len().min(200)]
+                );
+            }
+            Ok(serde_json::from_str(&text).unwrap_or(serde_json::Value::Null))
+        })
+        .await
     }
 }
 

--- a/src/git_provider/gitea.rs
+++ b/src/git_provider/gitea.rs
@@ -54,77 +54,89 @@ impl GiteaProvider {
 
     async fn get(&self, path: &str) -> Result<serde_json::Value> {
         let url = self.api_url(path);
-        let resp = self
-            .http
-            .get(&url)
-            .header("Authorization", format!("token {}", self.token))
-            .send()
-            .await
-            .with_context(|| format!("Gitea GET {path}"))?;
-        let status = resp.status();
-        let text = resp.text().await?;
-        if !status.is_success() {
-            anyhow::bail!(
-                "Gitea API error ({status}): {}",
-                &text[..text.len().min(200)]
-            );
-        }
-        Ok(serde_json::from_str(&text)?)
+        crate::retry::with_retry("Gitea GET", || async {
+            let resp = self
+                .http
+                .get(&url)
+                .header("Authorization", format!("token {}", self.token))
+                .send()
+                .await
+                .with_context(|| format!("Gitea GET {path}"))?;
+            let status = resp.status();
+            let text = resp.text().await?;
+            if !status.is_success() {
+                anyhow::bail!(
+                    "Gitea API error ({status}): {}",
+                    &text[..text.len().min(200)]
+                );
+            }
+            Ok(serde_json::from_str(&text)?)
+        })
+        .await
     }
 
     async fn post_json(&self, path: &str, body: &serde_json::Value) -> Result<serde_json::Value> {
         let url = self.api_url(path);
-        let resp = self
-            .http
-            .post(&url)
-            .header("Authorization", format!("token {}", self.token))
-            .json(body)
-            .send()
-            .await?;
-        let status = resp.status();
-        let text = resp.text().await?;
-        if !status.is_success() {
-            anyhow::bail!(
-                "Gitea API error ({status}): {}",
-                &text[..text.len().min(200)]
-            );
-        }
-        Ok(serde_json::from_str(&text).unwrap_or(serde_json::Value::Null))
+        crate::retry::with_retry("Gitea POST", || async {
+            let resp = self
+                .http
+                .post(&url)
+                .header("Authorization", format!("token {}", self.token))
+                .json(body)
+                .send()
+                .await?;
+            let status = resp.status();
+            let text = resp.text().await?;
+            if !status.is_success() {
+                anyhow::bail!(
+                    "Gitea API error ({status}): {}",
+                    &text[..text.len().min(200)]
+                );
+            }
+            Ok(serde_json::from_str(&text).unwrap_or(serde_json::Value::Null))
+        })
+        .await
     }
 
     async fn patch(&self, path: &str, body: &serde_json::Value) -> Result<serde_json::Value> {
         let url = self.api_url(path);
-        let resp = self
-            .http
-            .patch(&url)
-            .header("Authorization", format!("token {}", self.token))
-            .json(body)
-            .send()
-            .await?;
-        let status = resp.status();
-        let text = resp.text().await?;
-        if !status.is_success() {
-            anyhow::bail!(
-                "Gitea API error ({status}): {}",
-                &text[..text.len().min(200)]
-            );
-        }
-        Ok(serde_json::from_str(&text).unwrap_or(serde_json::Value::Null))
+        crate::retry::with_retry("Gitea PATCH", || async {
+            let resp = self
+                .http
+                .patch(&url)
+                .header("Authorization", format!("token {}", self.token))
+                .json(body)
+                .send()
+                .await?;
+            let status = resp.status();
+            let text = resp.text().await?;
+            if !status.is_success() {
+                anyhow::bail!(
+                    "Gitea API error ({status}): {}",
+                    &text[..text.len().min(200)]
+                );
+            }
+            Ok(serde_json::from_str(&text).unwrap_or(serde_json::Value::Null))
+        })
+        .await
     }
 
     async fn delete_req(&self, path: &str) -> Result<()> {
         let url = self.api_url(path);
-        let resp = self
-            .http
-            .delete(&url)
-            .header("Authorization", format!("token {}", self.token))
-            .send()
-            .await?;
-        if !resp.status().is_success() && resp.status().as_u16() != 404 {
-            let text = resp.text().await?;
-            anyhow::bail!("Gitea DELETE error: {}", &text[..text.len().min(200)]);
-        }
-        Ok(())
+        crate::retry::with_retry("Gitea DELETE", || async {
+            let resp = self
+                .http
+                .delete(&url)
+                .header("Authorization", format!("token {}", self.token))
+                .send()
+                .await?;
+            if !resp.status().is_success() && resp.status().as_u16() != 404 {
+                let text = resp.text().await?;
+                anyhow::bail!("Gitea DELETE error: {}", &text[..text.len().min(200)]);
+            }
+            Ok(())
+        })
+        .await
     }
 }
 

--- a/src/git_provider/gitlab.rs
+++ b/src/git_provider/gitlab.rs
@@ -50,76 +50,88 @@ impl GitLabProvider {
 
     async fn get(&self, path: &str) -> Result<serde_json::Value> {
         let url = self.api_url(path);
-        let resp = self
-            .http
-            .get(&url)
-            .header("PRIVATE-TOKEN", &self.token)
-            .send()
-            .await
-            .with_context(|| format!("GitLab API GET {path}"))?;
-        let status = resp.status();
-        let text = resp.text().await?;
-        if !status.is_success() {
-            anyhow::bail!(
-                "GitLab API error ({status}): {}",
-                &text[..text.len().min(200)]
-            );
-        }
-        Ok(serde_json::from_str(&text)?)
+        crate::retry::with_retry("GitLab GET", || async {
+            let resp = self
+                .http
+                .get(&url)
+                .header("PRIVATE-TOKEN", &self.token)
+                .send()
+                .await
+                .with_context(|| format!("GitLab API GET {path}"))?;
+            let status = resp.status();
+            let text = resp.text().await?;
+            if !status.is_success() {
+                anyhow::bail!(
+                    "GitLab API error ({status}): {}",
+                    &text[..text.len().min(200)]
+                );
+            }
+            Ok(serde_json::from_str(&text)?)
+        })
+        .await
     }
 
     async fn post(&self, path: &str, body: &serde_json::Value) -> Result<serde_json::Value> {
         let url = self.api_url(path);
-        let resp = self
-            .http
-            .post(&url)
-            .header("PRIVATE-TOKEN", &self.token)
-            .json(body)
-            .send()
-            .await
-            .with_context(|| format!("GitLab API POST {path}"))?;
-        let status = resp.status();
-        let text = resp.text().await?;
-        if !status.is_success() {
-            anyhow::bail!(
-                "GitLab API error ({status}): {}",
-                &text[..text.len().min(200)]
-            );
-        }
-        Ok(serde_json::from_str(&text).unwrap_or(serde_json::Value::Null))
+        crate::retry::with_retry("GitLab POST", || async {
+            let resp = self
+                .http
+                .post(&url)
+                .header("PRIVATE-TOKEN", &self.token)
+                .json(body)
+                .send()
+                .await
+                .with_context(|| format!("GitLab API POST {path}"))?;
+            let status = resp.status();
+            let text = resp.text().await?;
+            if !status.is_success() {
+                anyhow::bail!(
+                    "GitLab API error ({status}): {}",
+                    &text[..text.len().min(200)]
+                );
+            }
+            Ok(serde_json::from_str(&text).unwrap_or(serde_json::Value::Null))
+        })
+        .await
     }
 
     async fn put(&self, path: &str, body: &serde_json::Value) -> Result<()> {
         let url = self.api_url(path);
-        let resp = self
-            .http
-            .put(&url)
-            .header("PRIVATE-TOKEN", &self.token)
-            .json(body)
-            .send()
-            .await
-            .with_context(|| format!("GitLab API PUT {path}"))?;
-        if !resp.status().is_success() {
-            let text = resp.text().await?;
-            anyhow::bail!("GitLab API error: {}", &text[..text.len().min(200)]);
-        }
-        Ok(())
+        crate::retry::with_retry("GitLab PUT", || async {
+            let resp = self
+                .http
+                .put(&url)
+                .header("PRIVATE-TOKEN", &self.token)
+                .json(body)
+                .send()
+                .await
+                .with_context(|| format!("GitLab API PUT {path}"))?;
+            if !resp.status().is_success() {
+                let text = resp.text().await?;
+                anyhow::bail!("GitLab API error: {}", &text[..text.len().min(200)]);
+            }
+            Ok(())
+        })
+        .await
     }
 
     async fn delete(&self, path: &str) -> Result<()> {
         let url = self.api_url(path);
-        let resp = self
-            .http
-            .delete(&url)
-            .header("PRIVATE-TOKEN", &self.token)
-            .send()
-            .await?;
-        let status = resp.status();
-        if !status.is_success() && status.as_u16() != 404 {
-            let text = resp.text().await?;
-            anyhow::bail!("GitLab API DELETE error: {}", &text[..text.len().min(200)]);
-        }
-        Ok(())
+        crate::retry::with_retry("GitLab DELETE", || async {
+            let resp = self
+                .http
+                .delete(&url)
+                .header("PRIVATE-TOKEN", &self.token)
+                .send()
+                .await?;
+            let status = resp.status();
+            if !status.is_success() && status.as_u16() != 404 {
+                let text = resp.text().await?;
+                anyhow::bail!("GitLab API DELETE error: {}", &text[..text.len().min(200)]);
+            }
+            Ok(())
+        })
+        .await
     }
 }
 

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -80,18 +80,17 @@ impl Client {
             self.owner, self.repo, username
         );
 
-        let response = self.octocrab._get(&url).await;
+        // Retry transient transport failures; a 404 (not a collaborator)
+        // is classified as permanent and falls through to the match below.
+        let response = crate::retry::with_retry("github: collaborator check", || async {
+            let resp = self.octocrab._get(&url).await?;
+            let body = self.octocrab.body_to_string(resp).await?;
+            Ok::<_, anyhow::Error>(body)
+        })
+        .await;
 
         match response {
-            Ok(resp) => {
-                let body = self
-                    .octocrab
-                    .body_to_string(resp)
-                    .await
-                    .unwrap_or_else(|e| {
-                        tracing::warn!("Failed to read collaborator response: {e}");
-                        String::new()
-                    });
+            Ok(body) => {
                 let json: serde_json::Value = serde_json::from_str(&body).unwrap_or_else(|e| {
                     tracing::warn!("Failed to parse collaborator JSON: {e}");
                     serde_json::Value::default()
@@ -136,17 +135,18 @@ impl Client {
             self.owner, self.repo
         );
 
-        let response = self
-            .octocrab
-            ._post(&url, Some(&pr_body))
-            .await
-            .context("Failed to create draft pull request")?;
-
-        let response_body = self
-            .octocrab
-            .body_to_string(response)
-            .await
-            .context("Failed to read create PR response")?;
+        let response_body = crate::retry::with_retry("github: create draft PR", || async {
+            let response = self
+                .octocrab
+                ._post(&url, Some(&pr_body))
+                .await
+                .context("Failed to create draft pull request")?;
+            self.octocrab
+                .body_to_string(response)
+                .await
+                .context("Failed to read create PR response")
+        })
+        .await?;
 
         let pr_json: serde_json::Value =
             serde_json::from_str(&response_body).context("Failed to parse create PR response")?;

--- a/src/github/issues.rs
+++ b/src/github/issues.rs
@@ -35,17 +35,18 @@ impl Client {
                 url.push_str(&format!("&since={since}"));
             }
 
-            let response = self
-                .octocrab
-                ._get(&url)
-                .await
-                .context("Failed to fetch issues")?;
-
-            let body = self
-                .octocrab
-                .body_to_string(response)
-                .await
-                .context("Failed to read issues response body")?;
+            let body = crate::retry::with_retry("github: fetch issues", || async {
+                let response = self
+                    .octocrab
+                    ._get(&url)
+                    .await
+                    .context("Failed to fetch issues")?;
+                self.octocrab
+                    .body_to_string(response)
+                    .await
+                    .context("Failed to read issues response body")
+            })
+            .await?;
 
             let items = super::parse_json_array(&body, "issues")?;
 
@@ -97,12 +98,15 @@ impl Client {
     }
 
     pub async fn label_issue(&self, number: u64, labels: &[String]) -> Result<()> {
-        self.octocrab
-            .issues(&self.owner, &self.repo)
-            .add_labels(number, labels)
-            .await
-            .with_context(|| format!("Failed to label issue #{number}"))?;
-        Ok(())
+        crate::retry::with_retry("github: label issue", || async {
+            self.octocrab
+                .issues(&self.owner, &self.repo)
+                .add_labels(number, labels)
+                .await
+                .with_context(|| format!("Failed to label issue #{number}"))?;
+            Ok::<_, anyhow::Error>(())
+        })
+        .await
     }
 
     /// Add assignees to an issue or PR (GitHub uses the same endpoint).
@@ -113,19 +117,21 @@ impl Client {
         );
         let body = serde_json::json!({ "assignees": assignees });
 
-        let response = self
-            .octocrab
-            ._post(&url, Some(&body))
-            .await
-            .with_context(|| format!("Failed to assign {assignees:?} to #{number}"))?;
+        crate::retry::with_retry("github: add assignees", || async {
+            let response = self
+                .octocrab
+                ._post(&url, Some(&body))
+                .await
+                .with_context(|| format!("Failed to assign {assignees:?} to #{number}"))?;
 
-        let status = response.status();
-        if !status.is_success() {
-            let resp_body = self.octocrab.body_to_string(response).await?;
-            anyhow::bail!("Failed to assign #{number}: {status} {resp_body}");
-        }
-
-        Ok(())
+            let status = response.status();
+            if !status.is_success() {
+                let resp_body = self.octocrab.body_to_string(response).await?;
+                anyhow::bail!("Failed to assign #{number}: {status} {resp_body}");
+            }
+            Ok::<_, anyhow::Error>(())
+        })
+        .await
     }
 
     /// Post or update a wshm comment on an issue.
@@ -138,11 +144,15 @@ impl Client {
             self.update_comment(comment_id, &body_with_marker).await?;
         } else {
             debug!("Creating new wshm comment on issue #{number}");
-            self.octocrab
-                .issues(&self.owner, &self.repo)
-                .create_comment(number, &body_with_marker)
-                .await
-                .with_context(|| format!("Failed to comment on issue #{number}"))?;
+            crate::retry::with_retry("github: create comment", || async {
+                self.octocrab
+                    .issues(&self.owner, &self.repo)
+                    .create_comment(number, &body_with_marker)
+                    .await
+                    .with_context(|| format!("Failed to comment on issue #{number}"))?;
+                Ok::<_, anyhow::Error>(())
+            })
+            .await?;
         }
         Ok(())
     }
@@ -159,17 +169,20 @@ impl Client {
                 self.owner, self.repo, pp = super::GITHUB_PER_PAGE
             );
 
-            let response = self
-                .octocrab
-                ._get(&url)
-                .await
-                .with_context(|| format!("Failed to fetch comments for issue #{number}"))?;
-
-            let body = self
-                .octocrab
-                .body_to_string(response)
-                .await
-                .with_context(|| format!("Failed to read comments response for issue #{number}"))?;
+            let body = crate::retry::with_retry("github: fetch comments", || async {
+                let response = self
+                    .octocrab
+                    ._get(&url)
+                    .await
+                    .with_context(|| format!("Failed to fetch comments for issue #{number}"))?;
+                self.octocrab
+                    .body_to_string(response)
+                    .await
+                    .with_context(|| {
+                        format!("Failed to read comments response for issue #{number}")
+                    })
+            })
+            .await?;
 
             let comments = super::parse_json_array(&body, "comments")?;
 
@@ -203,19 +216,21 @@ impl Client {
             self.owner, self.repo
         );
 
-        let response = self
-            .octocrab
-            ._delete(&url, None::<&()>)
-            .await
-            .with_context(|| format!("Failed to delete comment {comment_id}"))?;
+        crate::retry::with_retry("github: delete comment", || async {
+            let response = self
+                .octocrab
+                ._delete(&url, None::<&()>)
+                .await
+                .with_context(|| format!("Failed to delete comment {comment_id}"))?;
 
-        let status = response.status();
-        if !status.is_success() && status.as_u16() != 404 {
-            let resp_body = self.octocrab.body_to_string(response).await?;
-            anyhow::bail!("Failed to delete comment {comment_id}: {status} {resp_body}");
-        }
-
-        Ok(())
+            let status = response.status();
+            if !status.is_success() && status.as_u16() != 404 {
+                let resp_body = self.octocrab.body_to_string(response).await?;
+                anyhow::bail!("Failed to delete comment {comment_id}: {status} {resp_body}");
+            }
+            Ok::<_, anyhow::Error>(())
+        })
+        .await
     }
 
     /// Update an existing comment by ID.
@@ -227,19 +242,21 @@ impl Client {
 
         let patch_body = serde_json::json!({ "body": body });
 
-        let response = self
-            .octocrab
-            ._patch(&url, Some(&patch_body))
-            .await
-            .with_context(|| format!("Failed to update comment {comment_id}"))?;
+        crate::retry::with_retry("github: update comment", || async {
+            let response = self
+                .octocrab
+                ._patch(&url, Some(&patch_body))
+                .await
+                .with_context(|| format!("Failed to update comment {comment_id}"))?;
 
-        let status = response.status();
-        if !status.is_success() {
-            let resp_body = self.octocrab.body_to_string(response).await?;
-            anyhow::bail!("Failed to update comment {comment_id}: {status} {resp_body}");
-        }
-
-        Ok(())
+            let status = response.status();
+            if !status.is_success() {
+                let resp_body = self.octocrab.body_to_string(response).await?;
+                anyhow::bail!("Failed to update comment {comment_id}: {status} {resp_body}");
+            }
+            Ok::<_, anyhow::Error>(())
+        })
+        .await
     }
 
     pub async fn remove_label(&self, number: u64, label: &str) -> Result<()> {
@@ -249,32 +266,38 @@ impl Client {
             self.owner, self.repo
         );
 
-        let response = self
-            .octocrab
-            ._delete(&url, None::<&()>)
-            .await
-            .with_context(|| format!("Failed to remove label '{label}' from #{number}"))?;
+        crate::retry::with_retry("github: remove label", || async {
+            let response = self
+                .octocrab
+                ._delete(&url, None::<&()>)
+                .await
+                .with_context(|| format!("Failed to remove label '{label}' from #{number}"))?;
 
-        let status = response.status();
-        if !status.is_success() && status.as_u16() != 404 {
-            let resp_body = self.octocrab.body_to_string(response).await?;
-            anyhow::bail!("Failed to remove label '{label}' from #{number}: {status} {resp_body}");
-        }
-
-        Ok(())
+            let status = response.status();
+            if !status.is_success() && status.as_u16() != 404 {
+                let resp_body = self.octocrab.body_to_string(response).await?;
+                anyhow::bail!(
+                    "Failed to remove label '{label}' from #{number}: {status} {resp_body}"
+                );
+            }
+            Ok::<_, anyhow::Error>(())
+        })
+        .await
     }
 
     pub async fn create_issue(&self, title: &str, body: &str, labels: &[String]) -> Result<u64> {
         let body = ensure_comment_marker(body, &self.comment_marker);
-        let issue = self
-            .octocrab
-            .issues(&self.owner, &self.repo)
-            .create(title)
-            .body(&body)
-            .labels(labels.to_vec())
-            .send()
-            .await
-            .with_context(|| format!("Failed to create issue: {title}"))?;
+        let issue = crate::retry::with_retry("github: create issue", || async {
+            self.octocrab
+                .issues(&self.owner, &self.repo)
+                .create(title)
+                .body(&body)
+                .labels(labels.to_vec())
+                .send()
+                .await
+                .with_context(|| format!("Failed to create issue: {title}"))
+        })
+        .await?;
         Ok(issue.number)
     }
 

--- a/src/github/pulls.rs
+++ b/src/github/pulls.rs
@@ -28,17 +28,18 @@ impl Client {
                 self.owner, self.repo, pp = super::GITHUB_PER_PAGE
             );
 
-            let response = self
-                .octocrab
-                ._get(&url)
-                .await
-                .context("Failed to fetch closed pull requests")?;
-
-            let body = self
-                .octocrab
-                .body_to_string(response)
-                .await
-                .context("Failed to read closed pulls response body")?;
+            let body = crate::retry::with_retry("github: list closed PRs", || async {
+                let response = self
+                    .octocrab
+                    ._get(&url)
+                    .await
+                    .context("Failed to fetch closed pull requests")?;
+                self.octocrab
+                    .body_to_string(response)
+                    .await
+                    .context("Failed to read closed pulls response body")
+            })
+            .await?;
 
             let items = super::parse_json_array(&body, "closed pulls")?;
 
@@ -113,17 +114,18 @@ impl Client {
                 self.owner, self.repo, pp = super::GITHUB_PER_PAGE
             );
 
-            let response = self
-                .octocrab
-                ._get(&url)
-                .await
-                .context("Failed to fetch pull requests")?;
-
-            let body = self
-                .octocrab
-                .body_to_string(response)
-                .await
-                .context("Failed to read pulls response body")?;
+            let body = crate::retry::with_retry("github: list PRs", || async {
+                let response = self
+                    .octocrab
+                    ._get(&url)
+                    .await
+                    .context("Failed to fetch pull requests")?;
+                self.octocrab
+                    .body_to_string(response)
+                    .await
+                    .context("Failed to read pulls response body")
+            })
+            .await?;
 
             let items = super::parse_json_array(&body, "pulls")?;
 
@@ -195,17 +197,18 @@ impl Client {
             "https://api.github.com/repos/{}/{}/pulls/{number}",
             self.owner, self.repo
         );
-        let response = self
-            .octocrab
-            ._get(&url)
-            .await
-            .with_context(|| format!("Failed to fetch PR #{number} details"))?;
-
-        let body = self
-            .octocrab
-            .body_to_string(response)
-            .await
-            .with_context(|| format!("Failed to read PR #{number} body"))?;
+        let body = crate::retry::with_retry("github: fetch PR mergeable", || async {
+            let response = self
+                .octocrab
+                ._get(&url)
+                .await
+                .with_context(|| format!("Failed to fetch PR #{number} details"))?;
+            self.octocrab
+                .body_to_string(response)
+                .await
+                .with_context(|| format!("Failed to read PR #{number} body"))
+        })
+        .await?;
 
         let pr_json: serde_json::Value =
             serde_json::from_str(&body).context("Failed to parse PR JSON")?;
@@ -226,24 +229,26 @@ impl Client {
             self.owner, self.repo
         );
 
-        let response = self
-            .http
-            .get(&url)
-            .send()
-            .await
-            .with_context(|| format!("Failed to fetch raw diff for PR #{number}"))?;
+        crate::retry::with_retry("github: fetch PR diff", || async {
+            let response = self
+                .http
+                .get(&url)
+                .send()
+                .await
+                .with_context(|| format!("Failed to fetch raw diff for PR #{number}"))?;
 
-        let status = response.status();
-        let text = response
-            .text()
-            .await
-            .with_context(|| format!("Failed to read raw diff for PR #{number}"))?;
+            let status = response.status();
+            let text = response
+                .text()
+                .await
+                .with_context(|| format!("Failed to read raw diff for PR #{number}"))?;
 
-        if !status.is_success() {
-            anyhow::bail!("Failed to fetch diff for PR #{number}: HTTP {status}");
-        }
-
-        Ok(text)
+            if !status.is_success() {
+                anyhow::bail!("Failed to fetch diff for PR #{number}: HTTP {status}");
+            }
+            Ok(text)
+        })
+        .await
     }
 
     /// Submit a review with inline comments on a PR
@@ -277,19 +282,21 @@ impl Client {
             self.owner, self.repo
         );
 
-        let response = self
-            .octocrab
-            ._post(&url, Some(&review_body))
-            .await
-            .with_context(|| format!("Failed to submit review on PR #{number}"))?;
+        crate::retry::with_retry("github: submit review", || async {
+            let response = self
+                .octocrab
+                ._post(&url, Some(&review_body))
+                .await
+                .with_context(|| format!("Failed to submit review on PR #{number}"))?;
 
-        let status = response.status();
-        if !status.is_success() {
-            let body = self.octocrab.body_to_string(response).await?;
-            anyhow::bail!("Failed to submit review on PR #{number}: {status} {body}");
-        }
-
-        Ok(())
+            let status = response.status();
+            if !status.is_success() {
+                let body = self.octocrab.body_to_string(response).await?;
+                anyhow::bail!("Failed to submit review on PR #{number}: {status} {body}");
+            }
+            Ok::<_, anyhow::Error>(())
+        })
+        .await
     }
 
     /// Create a new pull request, returns the PR number
@@ -306,17 +313,18 @@ impl Client {
             self.owner, self.repo
         );
 
-        let response = self
-            .octocrab
-            ._post(&url, Some(&pr_body))
-            .await
-            .context("Failed to create pull request")?;
-
-        let response_body = self
-            .octocrab
-            .body_to_string(response)
-            .await
-            .context("Failed to read create PR response")?;
+        let response_body = crate::retry::with_retry("github: create PR", || async {
+            let response = self
+                .octocrab
+                ._post(&url, Some(&pr_body))
+                .await
+                .context("Failed to create pull request")?;
+            self.octocrab
+                .body_to_string(response)
+                .await
+                .context("Failed to read create PR response")
+        })
+        .await?;
 
         let pr_json: serde_json::Value =
             serde_json::from_str(&response_body).context("Failed to parse create PR response")?;
@@ -329,12 +337,15 @@ impl Client {
     }
 
     pub async fn label_pr(&self, number: u64, labels: &[String]) -> Result<()> {
-        self.octocrab
-            .issues(&self.owner, &self.repo)
-            .add_labels(number, labels)
-            .await
-            .with_context(|| format!("Failed to label PR #{number}"))?;
-        Ok(())
+        crate::retry::with_retry("github: label PR", || async {
+            self.octocrab
+                .issues(&self.owner, &self.repo)
+                .add_labels(number, labels)
+                .await
+                .with_context(|| format!("Failed to label PR #{number}"))?;
+            Ok::<_, anyhow::Error>(())
+        })
+        .await
     }
 
     /// Post or update a wshm comment on a PR.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod license;
 pub mod login;
 pub mod pipelines;
 pub mod pro_hooks;
+pub mod retry;
 pub mod run;
 pub mod secrets;
 pub mod telemetry;

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,0 +1,258 @@
+//! Centralized, configurable retry for transient HTTP failures.
+//!
+//! A single helper, [`with_retry`], wraps any fallible async operation and
+//! re-issues it on transient errors (premature connection EOF, resets,
+//! timeouts, HTTP 5xx / 429) using exponential backoff with jitter.
+//!
+//! The policy is process-global and live-updatable: the daemon installs it
+//! at startup via [`set_global`], and the Settings UI re-installs it on
+//! every save, so a change takes effect without a daemon restart.
+
+use std::future::Future;
+use std::sync::RwLock;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+/// Retry policy. Persisted in the global config (`~/.wshm/global.toml`,
+/// `[retry]` table) and editable live from Settings -> Reliability.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RetryConfig {
+    /// Master switch. When false, [`with_retry`] runs the operation once.
+    #[serde(default = "default_retry_enabled")]
+    pub enabled: bool,
+
+    /// Total attempts including the first one. Clamped to `1..=10`.
+    #[serde(default = "default_max_attempts")]
+    pub max_attempts: u32,
+
+    /// Delay before the first retry, in milliseconds. Doubles each attempt.
+    #[serde(default = "default_initial_backoff_ms")]
+    pub initial_backoff_ms: u64,
+
+    /// Upper bound on any single backoff delay, in milliseconds.
+    #[serde(default = "default_max_backoff_ms")]
+    pub max_backoff_ms: u64,
+}
+
+fn default_retry_enabled() -> bool {
+    true
+}
+fn default_max_attempts() -> u32 {
+    3
+}
+fn default_initial_backoff_ms() -> u64 {
+    500
+}
+fn default_max_backoff_ms() -> u64 {
+    5_000
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_retry_enabled(),
+            max_attempts: default_max_attempts(),
+            initial_backoff_ms: default_initial_backoff_ms(),
+            max_backoff_ms: default_max_backoff_ms(),
+        }
+    }
+}
+
+impl RetryConfig {
+    /// Clamp user-supplied values into safe ranges. Applied before the
+    /// policy is installed so a bad Settings entry can never wedge the
+    /// daemon (e.g. zero attempts, or an hours-long backoff).
+    pub fn sanitized(&self) -> Self {
+        Self {
+            enabled: self.enabled,
+            max_attempts: self.max_attempts.clamp(1, 10),
+            initial_backoff_ms: self.initial_backoff_ms.clamp(50, 60_000),
+            max_backoff_ms: self.max_backoff_ms.clamp(50, 120_000),
+        }
+    }
+}
+
+/// Process-wide policy. `None` until [`set_global`] runs; callers fall back
+/// to [`RetryConfig::default`] so retry works even before the daemon boots.
+static GLOBAL: RwLock<Option<RetryConfig>> = RwLock::new(None);
+
+/// Install the process-wide retry policy. Called at daemon startup and
+/// again whenever Settings -> Reliability is saved.
+pub fn set_global(cfg: RetryConfig) {
+    if let Ok(mut guard) = GLOBAL.write() {
+        *guard = Some(cfg.sanitized());
+    }
+}
+
+/// Current retry policy (sanitized defaults if never installed).
+pub fn global() -> RetryConfig {
+    GLOBAL
+        .read()
+        .ok()
+        .and_then(|guard| guard.clone())
+        .unwrap_or_default()
+}
+
+/// Decide whether an error is worth retrying.
+///
+/// Call sites hand us `anyhow::Error` that has already lost its concrete
+/// `reqwest` / `octocrab` / `hyper` type, so we classify on the rendered
+/// error chain. Only transport-level failures and server-side 5xx / 429
+/// are retried; 4xx (auth, not-found, validation) and parse errors are not.
+pub fn is_transient(err: &anyhow::Error) -> bool {
+    let msg = format!("{err:#}").to_lowercase();
+    const TRANSIENT: &[&str] = &[
+        // hyper: keep-alive connection closed by the peer mid-response.
+        "end of file before message length reached",
+        "incompletemessage",
+        "connection closed before message completed",
+        // transport-level resets and drops.
+        "connection reset",
+        "connection closed",
+        "connection refused",
+        "connection aborted",
+        "broken pipe",
+        "error sending request",
+        "error reading a body",
+        "tls handshake",
+        // timeouts and name resolution.
+        "timed out",
+        "operation timed out",
+        "dns error",
+        "failed to lookup address",
+        // retryable server-side responses.
+        "(500 ",
+        "(502 ",
+        "(503 ",
+        "(504 ",
+        "(429 ",
+        "500 internal server error",
+        "502 bad gateway",
+        "503 service unavailable",
+        "504 gateway timeout",
+        "429 too many requests",
+    ];
+    TRANSIENT.iter().any(|needle| msg.contains(needle))
+}
+
+/// Run `op`, retrying transient failures per the global [`RetryConfig`].
+///
+/// `op` is a closure that returns a fresh future on each call, so a retry
+/// genuinely re-issues the request (and picks a fresh pooled connection).
+/// `label` names the operation for log lines.
+pub async fn with_retry<T, F, Fut>(label: &str, op: F) -> anyhow::Result<T>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = anyhow::Result<T>>,
+{
+    let cfg = global();
+    let max = if cfg.enabled {
+        cfg.max_attempts.max(1)
+    } else {
+        1
+    };
+
+    let mut attempt: u32 = 1;
+    loop {
+        match op().await {
+            Ok(value) => return Ok(value),
+            Err(err) => {
+                if attempt >= max || !cfg.enabled || !is_transient(&err) {
+                    return Err(err);
+                }
+                let backoff = backoff_delay(&cfg, attempt);
+                warn!(
+                    "{label}: transient failure on attempt {attempt}/{max}, \
+                     retrying in {}ms: {err:#}",
+                    backoff.as_millis()
+                );
+                tokio::time::sleep(backoff).await;
+                attempt += 1;
+            }
+        }
+    }
+}
+
+/// Exponential backoff with full jitter, capped at `max_backoff_ms`.
+///
+/// `attempt` is 1-based: the first retry waits `initial_backoff_ms`, the
+/// next `2x`, and so on. Jitter spreads the delay over `[half, full]` to
+/// avoid a thundering herd when many calls fail at once.
+fn backoff_delay(cfg: &RetryConfig, attempt: u32) -> Duration {
+    let shift = (attempt - 1).min(16);
+    let exp = cfg
+        .initial_backoff_ms
+        .saturating_mul(1_u64 << shift)
+        .min(cfg.max_backoff_ms);
+    let half = exp / 2;
+    let jitter = if half > 0 {
+        rand::random::<u64>() % half
+    } else {
+        0
+    };
+    Duration::from_millis(half + jitter)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    #[test]
+    fn classifies_transient_vs_permanent() {
+        let eof = anyhow::anyhow!(
+            "error reading a body from connection: end of file before message length reached"
+        );
+        assert!(is_transient(&eof));
+        let server = anyhow::anyhow!("GitLab API error (503 Service Unavailable): down");
+        assert!(is_transient(&server));
+        let throttled = anyhow::anyhow!("AI API error (429 Too Many Requests): slow down");
+        assert!(is_transient(&throttled));
+
+        let not_found = anyhow::anyhow!("GitLab API error (404 Not Found): missing");
+        assert!(!is_transient(&not_found));
+        let auth = anyhow::anyhow!("Anthropic API error (401 Unauthorized): bad key");
+        assert!(!is_transient(&auth));
+    }
+
+    #[tokio::test]
+    async fn retries_then_succeeds() {
+        set_global(RetryConfig {
+            enabled: true,
+            max_attempts: 3,
+            initial_backoff_ms: 50,
+            max_backoff_ms: 100,
+        });
+        let calls = AtomicU32::new(0);
+        let result: anyhow::Result<u32> = with_retry("test", || async {
+            let n = calls.fetch_add(1, Ordering::SeqCst) + 1;
+            if n < 3 {
+                anyhow::bail!("connection reset by peer");
+            }
+            Ok(n)
+        })
+        .await;
+        assert_eq!(result.unwrap(), 3);
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_permanent_errors() {
+        set_global(RetryConfig {
+            enabled: true,
+            max_attempts: 5,
+            initial_backoff_ms: 50,
+            max_backoff_ms: 100,
+        });
+        let calls = AtomicU32::new(0);
+        let result: anyhow::Result<u32> = with_retry("test", || async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            anyhow::bail!("AI API error (404 Not Found): missing")
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -61,24 +61,25 @@ async fn fetch_latest_release(
 ) -> Result<(String, String)> {
     let url = format!("https://api.github.com/repos/{repo}/releases/latest");
 
-    let mut req = http
-        .get(&url)
-        .header("User-Agent", format!("{binary_name}-updater"))
-        .header("Accept", "application/vnd.github+json");
-
-    if let Some(t) = token {
-        req = req.header("Authorization", format!("Bearer {t}"));
-    }
-
-    let resp = req.send().await.context("Failed to fetch latest release")?;
-    let status = resp.status();
-    let body = resp.text().await?;
-
-    if !status.is_success() {
-        let end = crate::ai::prompts::truncate_utf8(&body, 200);
-        let safe_body = &body[..end];
-        anyhow::bail!("GitHub API error ({status}): {safe_body}");
-    }
+    let body = crate::retry::with_retry("update: fetch latest release", || async {
+        let mut req = http
+            .get(&url)
+            .header("User-Agent", format!("{binary_name}-updater"))
+            .header("Accept", "application/vnd.github+json");
+        if let Some(t) = token {
+            req = req.header("Authorization", format!("Bearer {t}"));
+        }
+        let resp = req.send().await.context("Failed to fetch latest release")?;
+        let status = resp.status();
+        let body = resp.text().await?;
+        if !status.is_success() {
+            let end = crate::ai::prompts::truncate_utf8(&body, 200);
+            let safe_body = &body[..end];
+            anyhow::bail!("GitHub API error ({status}): {safe_body}");
+        }
+        Ok::<_, anyhow::Error>(body)
+    })
+    .await?;
 
     let json: serde_json::Value = serde_json::from_str(&body)?;
     let tag = json["tag_name"]
@@ -99,20 +100,23 @@ async fn fetch_release_assets(
 ) -> Result<Vec<(String, String)>> {
     let url = format!("https://api.github.com/repos/{repo}/releases/tags/{tag}");
 
-    let mut req = http
-        .get(&url)
-        .header("User-Agent", format!("{binary_name}-updater"))
-        .header("Accept", "application/vnd.github+json");
-    if let Some(t) = token {
-        req = req.header("Authorization", format!("Bearer {t}"));
-    }
+    let text = crate::retry::with_retry("update: fetch release assets", || async {
+        let mut req = http
+            .get(&url)
+            .header("User-Agent", format!("{binary_name}-updater"))
+            .header("Accept", "application/vnd.github+json");
+        if let Some(t) = token {
+            req = req.header("Authorization", format!("Bearer {t}"));
+        }
+        let resp = req.send().await.context("Failed to fetch release assets")?;
+        if !resp.status().is_success() {
+            anyhow::bail!("Failed to fetch release {tag} ({})", resp.status());
+        }
+        Ok::<_, anyhow::Error>(resp.text().await?)
+    })
+    .await?;
 
-    let resp = req.send().await.context("Failed to fetch release assets")?;
-    if !resp.status().is_success() {
-        anyhow::bail!("Failed to fetch release {tag} ({})", resp.status());
-    }
-
-    let json: serde_json::Value = serde_json::from_str(&resp.text().await?)?;
+    let json: serde_json::Value = serde_json::from_str(&text)?;
     let assets = json["assets"]
         .as_array()
         .context("Missing assets in release")?;
@@ -135,20 +139,21 @@ async fn download_asset(
     api_url: &str,
     token: Option<&str>,
 ) -> Result<Vec<u8>> {
-    let mut req = http
-        .get(api_url)
-        .header("User-Agent", format!("{binary_name}-updater"))
-        .header("Accept", "application/octet-stream");
-    if let Some(t) = token {
-        req = req.header("Authorization", format!("Bearer {t}"));
-    }
-
-    let resp = req.send().await.context("Failed to download asset")?;
-    if !resp.status().is_success() {
-        anyhow::bail!("Failed to download asset ({})", resp.status());
-    }
-
-    Ok(resp.bytes().await?.to_vec())
+    crate::retry::with_retry("update: download asset", || async {
+        let mut req = http
+            .get(api_url)
+            .header("User-Agent", format!("{binary_name}-updater"))
+            .header("Accept", "application/octet-stream");
+        if let Some(t) = token {
+            req = req.header("Authorization", format!("Bearer {t}"));
+        }
+        let resp = req.send().await.context("Failed to download asset")?;
+        if !resp.status().is_success() {
+            anyhow::bail!("Failed to download asset ({})", resp.status());
+        }
+        Ok(resp.bytes().await?.to_vec())
+    })
+    .await
 }
 
 async fn fetch_checksums(

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -511,6 +511,35 @@ export async function updateRepoFeatures(
 	return res.json();
 }
 
+/// HTTP retry policy, shared by every outbound call (poller, git
+/// providers, AI, self-update). Editable from Settings -> Reliability;
+/// changes apply live without a daemon restart.
+export interface RetrySettings {
+	enabled: boolean;
+	max_attempts: number;
+	initial_backoff_ms: number;
+	max_backoff_ms: number;
+}
+
+export function fetchRetrySettings(): Promise<RetrySettings> {
+	return apiGet<RetrySettings>('/config/retry');
+}
+
+export async function updateRetrySettings(
+	patch: Partial<RetrySettings>
+): Promise<RetrySettings> {
+	const res = await fetch('/api/v1/config/retry', {
+		method: 'PATCH',
+		headers: { 'Content-Type': 'application/json', ...CSRF_HEADERS },
+		body: JSON.stringify(patch)
+	});
+	if (!res.ok) {
+		const body = await res.json().catch(() => ({}));
+		throw new Error(body.error ?? `HTTP ${res.status}`);
+	}
+	return res.json();
+}
+
 export interface Me {
 	id?: number;
 	email: string | null;

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -74,6 +74,7 @@
 	"settings.tabs.license": "License",
 	"settings.tabs.appearance": "Appearance",
 	"settings.tabs.configuration": "Configuration",
+	"settings.tabs.reliability": "Reliability",
 	"settings.tabs.secrets": "Secrets",
 	"settings.tabs.users": "Users",
 
@@ -161,6 +162,18 @@
 	"settings.config.section.prAnalysis": "PR Analysis",
 	"settings.config.section.mergeQueue": "Merge Queue",
 	"settings.config.section.sync": "Sync",
+
+	"settings.retry.title": "HTTP retry policy",
+	"settings.retry.helper": "How wshm retries transient network failures — dropped connections, timeouts, server 5xx / 429 — on every outbound call: the poller, git providers, AI, and self-update. Changes apply immediately, no restart needed.",
+	"settings.retry.enabled": "Enable retries",
+	"settings.retry.maxAttempts": "Max attempts",
+	"settings.retry.maxAttemptsHelp": "Total tries including the first one (1–10).",
+	"settings.retry.initialBackoff": "Initial backoff (ms)",
+	"settings.retry.initialBackoffHelp": "Delay before the first retry; doubles on each attempt.",
+	"settings.retry.maxBackoff": "Max backoff (ms)",
+	"settings.retry.maxBackoffHelp": "Upper bound on any single retry delay.",
+	"settings.retry.save": "Save retry policy",
+	"settings.retry.saved": "Retry policy saved.",
 
 	"settings.secrets.banner.title": "Advanced encrypted secrets store.",
 	"settings.secrets.banner.body": "For your GitHub token, use Git providers; for Anthropic / OpenAI / Gemini API keys, use AI providers. This tab is for additional secrets (per-repo overrides, custom integrations) stored encrypted alongside the token store.",

--- a/web/src/lib/i18n/fr.json
+++ b/web/src/lib/i18n/fr.json
@@ -74,6 +74,7 @@
 	"settings.tabs.license": "Licence",
 	"settings.tabs.appearance": "Apparence",
 	"settings.tabs.configuration": "Configuration",
+	"settings.tabs.reliability": "Fiabilité",
 	"settings.tabs.secrets": "Secrets",
 	"settings.tabs.users": "Utilisateurs",
 
@@ -161,6 +162,18 @@
 	"settings.config.section.prAnalysis": "Analyse PR",
 	"settings.config.section.mergeQueue": "File de merge",
 	"settings.config.section.sync": "Synchronisation",
+
+	"settings.retry.title": "Politique de réessai HTTP",
+	"settings.retry.helper": "Comment wshm réessaie les échecs réseau transitoires — connexions coupées, délais dépassés, erreurs serveur 5xx / 429 — sur chaque appel sortant : le poller, les fournisseurs Git, l'IA et la mise à jour automatique. Les changements s'appliquent immédiatement, sans redémarrage.",
+	"settings.retry.enabled": "Activer les réessais",
+	"settings.retry.maxAttempts": "Tentatives max",
+	"settings.retry.maxAttemptsHelp": "Nombre total d'essais, première tentative incluse (1–10).",
+	"settings.retry.initialBackoff": "Délai initial (ms)",
+	"settings.retry.initialBackoffHelp": "Délai avant le premier réessai ; doublé à chaque tentative.",
+	"settings.retry.maxBackoff": "Délai max (ms)",
+	"settings.retry.maxBackoffHelp": "Limite supérieure d'un délai de réessai.",
+	"settings.retry.save": "Enregistrer la politique",
+	"settings.retry.saved": "Politique de réessai enregistrée.",
 
 	"settings.secrets.banner.title": "Stockage avancé de secrets chiffrés.",
 	"settings.secrets.banner.body": "Pour ton token GitHub, utilise Fournisseurs Git ; pour les clés API Anthropic / OpenAI / Gemini, utilise Fournisseurs IA. Cet onglet sert aux secrets additionnels (overrides par dépôt, intégrations custom) stockés chiffrés à côté du token store.",

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -20,6 +20,7 @@
 		TableBodyCell,
 		Modal,
 		Tooltip,
+		Toggle,
 	} from 'flowbite-svelte';
 	import { colorConfig, type ColorConfig } from '$lib/colors';
 	import { t, tr } from '$lib/i18n';
@@ -46,7 +47,10 @@
 		deleteUser,
 		fetchRepoFeatures,
 		updateRepoFeatures,
+		fetchRetrySettings,
+		updateRetrySettings,
 		type RepoFeatures,
+		type RetrySettings,
 		type LicenseInfo,
 		type ReposListResponse,
 		type AuthStatus,
@@ -439,8 +443,30 @@
 		activating = false;
 	}
 
+	// Retry policy (Reliability tab)
+	let retrySettings: RetrySettings | null = $state(null);
+	let savingRetry: boolean = $state(false);
+	let retryMessage: string | null = $state(null);
+	let retryError: boolean = $state(false);
+
+	async function handleSaveRetry() {
+		if (!retrySettings) return;
+		savingRetry = true;
+		retryMessage = null;
+		try {
+			retrySettings = await updateRetrySettings(retrySettings);
+			retryError = false;
+			retryMessage = translate('settings.retry.saved');
+		} catch (e) {
+			retryError = true;
+			retryMessage = e instanceof Error ? e.message : String(e);
+		}
+		savingRetry = false;
+	}
+
 	onMount(async () => {
 		try { license = await fetchLicense(); } catch { /* ignore */ }
+		try { retrySettings = await fetchRetrySettings(); } catch { /* ignore */ }
 		await refreshRepos();
 		await refreshAuth();
 		await refreshSecrets();
@@ -801,6 +827,53 @@
 				{/each}
 			</div>
 		</Card>
+	</TabItem>
+
+	<!-- ========================= RELIABILITY ========================= -->
+	<TabItem title={$t('settings.tabs.reliability')}>
+		<div class="w-full">
+			<Card class="bg-gray-800 border-gray-700 max-w-none">
+				<Heading tag="h3" class="text-base mb-1">{$t('settings.retry.title')}</Heading>
+				<Helper class="mb-4">{$t('settings.retry.helper')}</Helper>
+
+				{#if retrySettings}
+					{#if retryMessage}
+						<Alert color={retryError ? 'red' : 'green'} class="text-xs py-2 mb-3">{retryMessage}</Alert>
+					{/if}
+
+					<form onsubmit={(e) => { e.preventDefault(); handleSaveRetry(); }} class="space-y-4 max-w-md">
+						<div class="flex items-center justify-between">
+							<Label class="text-xs">{$t('settings.retry.enabled')}</Label>
+							<Toggle bind:checked={retrySettings.enabled} disabled={savingRetry} />
+						</div>
+
+						<div>
+							<Label for="retry-attempts" class="text-xs mb-1">{$t('settings.retry.maxAttempts')}</Label>
+							<Input id="retry-attempts" type="number" min="1" max="10" bind:value={retrySettings.max_attempts} disabled={savingRetry || !retrySettings.enabled} size="sm" />
+							<Helper class="text-xs mt-1">{$t('settings.retry.maxAttemptsHelp')}</Helper>
+						</div>
+
+						<div>
+							<Label for="retry-initial" class="text-xs mb-1">{$t('settings.retry.initialBackoff')}</Label>
+							<Input id="retry-initial" type="number" min="50" max="60000" step="50" bind:value={retrySettings.initial_backoff_ms} disabled={savingRetry || !retrySettings.enabled} size="sm" />
+							<Helper class="text-xs mt-1">{$t('settings.retry.initialBackoffHelp')}</Helper>
+						</div>
+
+						<div>
+							<Label for="retry-max" class="text-xs mb-1">{$t('settings.retry.maxBackoff')}</Label>
+							<Input id="retry-max" type="number" min="50" max="120000" step="100" bind:value={retrySettings.max_backoff_ms} disabled={savingRetry || !retrySettings.enabled} size="sm" />
+							<Helper class="text-xs mt-1">{$t('settings.retry.maxBackoffHelp')}</Helper>
+						</div>
+
+						<Button type="submit" color="blue" disabled={savingRetry} size="sm" class="w-full">
+							{savingRetry ? $t('common.saving') : $t('settings.retry.save')}
+						</Button>
+					</form>
+				{:else}
+					<p class="text-sm text-gray-500">{$t('common.loading')}</p>
+				{/if}
+			</Card>
+		</div>
 	</TabItem>
 
 	<!-- ========================= SECRETS ============================ -->


### PR DESCRIPTION
## Problem

The GitHub event poller on the kube was logging:

> `wshm_core::daemon::poller [rtk-ai/rtk] Polling error: Hyper Error: error reading a body from connection ... end of file before message length reached`

A keep-alive HTTPS connection is closed by an intermediary (NAT/egress) between two 30s polls; the next poll reuses the dead connection and the server has already hung up. Self-recovering but noisy, and delays event processing.

## What this does

A centralized, configurable retry system applied to **every outbound HTTP call**.

- **`src/retry.rs`** — `RetryConfig`, a live-updatable process-global policy, an `is_transient` error classifier (premature EOF, resets, timeouts, server 5xx / 429 — never 4xx or parse errors), and `with_retry()` with exponential backoff + full jitter. Unit-tested.
- **Config** — `[retry]` table in `global.toml`; installed at daemon startup, editable live via `GET`/`PATCH /api/v1/config/retry` (no restart).
- **Settings → Reliability** — new tab to tune enable / max attempts / initial & max backoff.
- **Call sites wrapped** — poller, GitHub (client / issues / pulls), GitLab / Gitea / Azure DevOps providers, AI providers, self-update.

## Tests

- `cargo build`, `cargo clippy --all-targets` (no issues), `cargo fmt --check` clean.
- 3 new unit tests in `retry.rs` pass.
- `svelte-check` clean for the new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)