### PR TITLE
fix(daemon): fetch fresh issue/PR directly to avoid "not found in cache"

### DIFF
--- a/src/daemon/processor.rs
+++ b/src/daemon/processor.rs
@@ -213,6 +213,31 @@ async fn handle_issue(state: &DaemonState, event: &WebhookEvent) -> anyhow::Resu
     // Force sync issues (bypass throttle — we know there's a new event)
     gh_sync::sync_issues_now(&state.gh(), &state.db).await?;
 
+    // The list endpoint lags issue creation by a few seconds (replicated
+    // index), so a sync right after `issues.opened` can miss the brand-new
+    // issue, which then surfaces as "Issue #N not found in cache" at triage.
+    // Fetch it directly from the canonical single-issue endpoint to guarantee
+    // it is cached before we triage.
+    if let Some(n) = number {
+        if matches!(state.db.get_issue(n), Ok(None)) {
+            match state.gh().fetch_issue(n).await {
+                Ok(Some(issue)) => {
+                    if let Err(e) = state.db.upsert_issue(&issue) {
+                        warn!("Failed to cache issue #{n} after direct fetch: {e}");
+                    }
+                }
+                Ok(None) => {
+                    info!(
+                        "[{}] issue #{n} not returned by GitHub (deleted, transferred, or a PR) — skipping",
+                        state.config.repo_slug()
+                    );
+                    return Ok(());
+                }
+                Err(e) => warn!("Direct fetch of issue #{n} failed: {e:#}"),
+            }
+        }
+    }
+
     if !features.triage_issues {
         info!(
             "[{}] triage_issues disabled — issue {number:?} synced but not triaged",
@@ -330,6 +355,30 @@ async fn handle_pull_request(state: &DaemonState, event: &WebhookEvent) -> anyho
     }
     // Force sync pulls (bypass throttle — we know there's a new event)
     gh_sync::sync_pulls_now(&state.gh(), &state.db).await?;
+
+    // The list endpoint lags PR creation by a few seconds (replicated index),
+    // so a sync right after `pull_request.opened` can miss the brand-new PR,
+    // which then surfaces as "PR #N not found in cache" at analysis. Fetch it
+    // directly from the canonical single-PR endpoint to guarantee it is cached.
+    if let Some(n) = number {
+        if matches!(state.db.get_pull(n), Ok(None)) {
+            match state.gh().fetch_pull(n).await {
+                Ok(Some(pr)) => {
+                    if let Err(e) = state.db.upsert_pull(&pr) {
+                        warn!("Failed to cache PR #{n} after direct fetch: {e}");
+                    }
+                }
+                Ok(None) => {
+                    info!(
+                        "[{}] PR #{n} not returned by GitHub (deleted or transferred) — skipping",
+                        state.config.repo_slug()
+                    );
+                    return Ok(());
+                }
+                Err(e) => warn!("Direct fetch of PR #{n} failed: {e:#}"),
+            }
+        }
+    }
 
     if !features.analyze_prs {
         info!(

--- a/src/github/issues.rs
+++ b/src/github/issues.rs
@@ -8,6 +8,41 @@ use crate::github::Client;
 /// The actual marker is derived from branding.name via `BrandingConfig::comment_marker()`.
 pub const WSHM_COMMENT_MARKER: &str = "<!-- wshm -->";
 
+/// Build an [`Issue`] from a GitHub API issue JSON object.
+///
+/// Returns `None` for pull requests, which the issues endpoint also serves
+/// (they carry a `pull_request` key).
+fn parse_issue(item: &serde_json::Value) -> Option<Issue> {
+    if item.get("pull_request").is_some() {
+        return None;
+    }
+
+    let reactions = item.get("reactions");
+    let reactions_plus1 = reactions
+        .and_then(|r| r.get("+1"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    let reactions_total = reactions
+        .and_then(|r| r.get("total_count"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+
+    let state = item.get("state").and_then(|v| v.as_str()).unwrap_or("open");
+
+    Some(Issue {
+        number: item["number"].as_u64().unwrap_or(0),
+        title: item["title"].as_str().unwrap_or("").to_string(),
+        body: item.get("body").and_then(|v| v.as_str()).map(String::from),
+        state: state.to_string(),
+        labels: super::extract_labels(item),
+        author: super::extract_author(item),
+        created_at: item["created_at"].as_str().unwrap_or("").to_string(),
+        updated_at: item["updated_at"].as_str().unwrap_or("").to_string(),
+        reactions_plus1,
+        reactions_total,
+    })
+}
+
 impl Client {
     pub async fn fetch_issues(&self, since: Option<&str>) -> Result<Vec<Issue>> {
         self.fetch_issues_with_state("open", since).await
@@ -15,6 +50,54 @@ impl Client {
 
     pub async fn fetch_all_issues(&self, since: Option<&str>) -> Result<Vec<Issue>> {
         self.fetch_issues_with_state("all", since).await
+    }
+
+    /// Fetch a single issue by number from the canonical (strongly consistent)
+    /// `/issues/{number}` endpoint.
+    ///
+    /// The list endpoint is served from a replicated index that lags behind
+    /// issue creation by seconds, so a list sync triggered right after an
+    /// `issues.opened` webhook can miss the brand-new issue. The single-issue
+    /// endpoint always reflects the latest state, so we use it to guarantee a
+    /// freshly opened issue is in cache before triage.
+    ///
+    /// Returns `Ok(None)` when the number is a pull request (the issues
+    /// endpoint also serves PRs) or the issue was deleted/transferred (404).
+    pub async fn fetch_issue(&self, number: u64) -> Result<Option<Issue>> {
+        let url = format!(
+            "https://api.github.com/repos/{}/{}/issues/{number}",
+            self.owner, self.repo
+        );
+
+        let body = crate::retry::with_retry("github: fetch issue", || async {
+            let response = self
+                .octocrab
+                ._get(&url)
+                .await
+                .with_context(|| format!("Failed to fetch issue #{number}"))?;
+            self.octocrab
+                .body_to_string(response)
+                .await
+                .context("Failed to read issue response body")
+        })
+        .await?;
+
+        let item: serde_json::Value =
+            serde_json::from_str(&body).context("Failed to parse issue JSON")?;
+
+        // A 404 (deleted/transferred issue) comes back as an object with a
+        // `message` field rather than an issue payload.
+        if item.get("number").is_none() {
+            if let Some(msg) = item.get("message").and_then(|v| v.as_str()) {
+                if msg.eq_ignore_ascii_case("Not Found") {
+                    return Ok(None);
+                }
+                anyhow::bail!("GitHub error while fetching issue #{number}: {msg}");
+            }
+            return Ok(None);
+        }
+
+        Ok(parse_issue(&item))
     }
 
     async fn fetch_issues_with_state(
@@ -58,34 +141,9 @@ impl Client {
 
             for item in &items {
                 // Skip PRs (the issues endpoint includes them)
-                if item.get("pull_request").is_some() {
-                    continue;
+                if let Some(issue) = parse_issue(item) {
+                    all_issues.push(issue);
                 }
-
-                let reactions = item.get("reactions");
-                let reactions_plus1 = reactions
-                    .and_then(|r| r.get("+1"))
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0) as u32;
-                let reactions_total = reactions
-                    .and_then(|r| r.get("total_count"))
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0) as u32;
-
-                let state = item.get("state").and_then(|v| v.as_str()).unwrap_or("open");
-
-                all_issues.push(Issue {
-                    number: item["number"].as_u64().unwrap_or(0),
-                    title: item["title"].as_str().unwrap_or("").to_string(),
-                    body: item.get("body").and_then(|v| v.as_str()).map(String::from),
-                    state: state.to_string(),
-                    labels: super::extract_labels(item),
-                    author: super::extract_author(item),
-                    created_at: item["created_at"].as_str().unwrap_or("").to_string(),
-                    updated_at: item["updated_at"].as_str().unwrap_or("").to_string(),
-                    reactions_plus1,
-                    reactions_total,
-                });
             }
 
             if items.len() < 100 || page >= 100 {
@@ -380,5 +438,40 @@ mod tests {
         let body = "This is a comment";
         let result = ensure_wshm_marker(body);
         assert!(result.contains(WSHM_COMMENT_MARKER));
+    }
+
+    #[test]
+    fn test_parse_issue_builds_issue() {
+        let item = serde_json::json!({
+            "number": 338,
+            "title": "Something broke",
+            "body": "details",
+            "state": "open",
+            "labels": [{ "name": "bug" }],
+            "user": { "login": "octocat" },
+            "created_at": "2026-05-01T00:00:00Z",
+            "updated_at": "2026-05-02T00:00:00Z",
+            "reactions": { "+1": 3, "total_count": 5 },
+        });
+        let issue = parse_issue(&item).expect("issue should parse");
+        assert_eq!(issue.number, 338);
+        assert_eq!(issue.title, "Something broke");
+        assert_eq!(issue.state, "open");
+        assert_eq!(issue.labels, vec!["bug".to_string()]);
+        assert_eq!(issue.author.as_deref(), Some("octocat"));
+        assert_eq!(issue.reactions_plus1, 3);
+        assert_eq!(issue.reactions_total, 5);
+    }
+
+    #[test]
+    fn test_parse_issue_skips_pull_requests() {
+        // The issues endpoint also returns PRs; they carry a `pull_request` key.
+        let item = serde_json::json!({
+            "number": 339,
+            "title": "A pull request",
+            "state": "open",
+            "pull_request": { "url": "https://api.github.com/..." },
+        });
+        assert!(parse_issue(&item).is_none());
     }
 }

--- a/src/github/pulls.rs
+++ b/src/github/pulls.rs
@@ -16,6 +16,43 @@ pub struct MergedPullRequest {
     pub created_at: String,
 }
 
+/// Build a [`PullRequest`] from a GitHub API pull request JSON object.
+fn parse_pull(pr: &serde_json::Value) -> PullRequest {
+    let state = pr.get("state").and_then(|v| v.as_str()).unwrap_or("open");
+    PullRequest {
+        number: pr["number"].as_u64().unwrap_or(0),
+        title: pr["title"].as_str().unwrap_or("").to_string(),
+        body: pr.get("body").and_then(|v| v.as_str()).map(String::from),
+        state: state.to_string(),
+        labels: super::extract_labels(pr),
+        author: super::extract_author(pr),
+        head_sha: pr
+            .get("head")
+            .and_then(|h| h.get("sha"))
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        base_sha: pr
+            .get("base")
+            .and_then(|h| h.get("sha"))
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        head_ref: pr
+            .get("head")
+            .and_then(|h| h.get("ref"))
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        base_ref: pr
+            .get("base")
+            .and_then(|h| h.get("ref"))
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        mergeable: pr.get("mergeable").and_then(|v| v.as_bool()),
+        ci_status: None,
+        created_at: pr["created_at"].as_str().unwrap_or("").to_string(),
+        updated_at: pr["updated_at"].as_str().unwrap_or("").to_string(),
+    }
+}
+
 impl Client {
     /// Fetch merged pull requests, optionally filtering to those merged since a given ISO date.
     pub async fn fetch_merged_pulls(&self, since: Option<&str>) -> Result<Vec<MergedPullRequest>> {
@@ -136,50 +173,16 @@ impl Client {
             let mut should_stop = false;
 
             for pr in &items {
-                let state = pr.get("state").and_then(|v| v.as_str()).unwrap_or("open");
-                let mergeable = pr.get("mergeable").and_then(|v| v.as_bool());
-                let updated_at = pr["updated_at"].as_str().unwrap_or("").to_string();
-
                 // Forever-incremental: stop if this PR is older than `since`
                 if let Some(since_ts) = since {
-                    if updated_at.as_str() < since_ts {
+                    let updated_at = pr["updated_at"].as_str().unwrap_or("");
+                    if updated_at < since_ts {
                         should_stop = true;
                         break;
                     }
                 }
 
-                all_pulls.push(PullRequest {
-                    number: pr["number"].as_u64().unwrap_or(0),
-                    title: pr["title"].as_str().unwrap_or("").to_string(),
-                    body: pr.get("body").and_then(|v| v.as_str()).map(String::from),
-                    state: state.to_string(),
-                    labels: super::extract_labels(pr),
-                    author: super::extract_author(pr),
-                    head_sha: pr
-                        .get("head")
-                        .and_then(|h| h.get("sha"))
-                        .and_then(|v| v.as_str())
-                        .map(String::from),
-                    base_sha: pr
-                        .get("base")
-                        .and_then(|h| h.get("sha"))
-                        .and_then(|v| v.as_str())
-                        .map(String::from),
-                    head_ref: pr
-                        .get("head")
-                        .and_then(|h| h.get("ref"))
-                        .and_then(|v| v.as_str())
-                        .map(String::from),
-                    base_ref: pr
-                        .get("base")
-                        .and_then(|h| h.get("ref"))
-                        .and_then(|v| v.as_str())
-                        .map(String::from),
-                    mergeable,
-                    ci_status: None,
-                    created_at: pr["created_at"].as_str().unwrap_or("").to_string(),
-                    updated_at,
-                });
+                all_pulls.push(parse_pull(pr));
             }
 
             if should_stop || items.len() < 100 || page >= 100 {
@@ -214,6 +217,53 @@ impl Client {
             serde_json::from_str(&body).context("Failed to parse PR JSON")?;
 
         Ok(pr_json.get("mergeable").and_then(|v| v.as_bool()))
+    }
+
+    /// Fetch a single pull request by number from the canonical (strongly
+    /// consistent) `/pulls/{number}` endpoint.
+    ///
+    /// Mirrors [`Client::fetch_issue`]: the list endpoint is served from a
+    /// replicated index that lags PR creation by a few seconds, so a sync
+    /// triggered right after a `pull_request.opened` webhook can miss the
+    /// brand-new PR and surface "PR #N not found in cache" at analysis time.
+    /// The single-PR endpoint always reflects the latest state.
+    ///
+    /// Returns `Ok(None)` when the PR was deleted/transferred (404).
+    pub async fn fetch_pull(&self, number: u64) -> Result<Option<PullRequest>> {
+        let url = format!(
+            "https://api.github.com/repos/{}/{}/pulls/{number}",
+            self.owner, self.repo
+        );
+
+        let body = crate::retry::with_retry("github: fetch PR", || async {
+            let response = self
+                .octocrab
+                ._get(&url)
+                .await
+                .with_context(|| format!("Failed to fetch PR #{number}"))?;
+            self.octocrab
+                .body_to_string(response)
+                .await
+                .with_context(|| format!("Failed to read PR #{number} body"))
+        })
+        .await?;
+
+        let item: serde_json::Value =
+            serde_json::from_str(&body).context("Failed to parse PR JSON")?;
+
+        // A 404 (deleted/transferred PR) comes back as an object with a
+        // `message` field rather than a PR payload.
+        if item.get("number").is_none() {
+            if let Some(msg) = item.get("message").and_then(|v| v.as_str()) {
+                if msg.eq_ignore_ascii_case("Not Found") {
+                    return Ok(None);
+                }
+                anyhow::bail!("GitHub error while fetching PR #{number}: {msg}");
+            }
+            return Ok(None);
+        }
+
+        Ok(Some(parse_pull(&item)))
     }
 
     pub async fn fetch_pr_diff(&self, number: u64) -> Result<String> {
@@ -352,5 +402,55 @@ impl Client {
     /// Delegates to comment_issue since GitHub uses the same API for both.
     pub async fn comment_pr(&self, number: u64, body: &str) -> Result<()> {
         self.comment_issue(number, body).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_pull_builds_pull_request() {
+        let item = serde_json::json!({
+            "number": 42,
+            "title": "Add feature",
+            "body": "description",
+            "state": "open",
+            "labels": [{ "name": "enhancement" }],
+            "user": { "login": "octocat" },
+            "head": { "sha": "abc123", "ref": "feature" },
+            "base": { "sha": "def456", "ref": "main" },
+            "mergeable": true,
+            "created_at": "2026-05-01T00:00:00Z",
+            "updated_at": "2026-05-02T00:00:00Z",
+        });
+        let pr = parse_pull(&item);
+        assert_eq!(pr.number, 42);
+        assert_eq!(pr.title, "Add feature");
+        assert_eq!(pr.state, "open");
+        assert_eq!(pr.labels, vec!["enhancement".to_string()]);
+        assert_eq!(pr.author.as_deref(), Some("octocat"));
+        assert_eq!(pr.head_sha.as_deref(), Some("abc123"));
+        assert_eq!(pr.base_ref.as_deref(), Some("main"));
+        assert_eq!(pr.mergeable, Some(true));
+    }
+
+    #[test]
+    fn test_parse_pull_handles_missing_optionals() {
+        // A freshly opened PR may have null mergeable and no body.
+        let item = serde_json::json!({
+            "number": 43,
+            "title": "Draft",
+            "state": "open",
+            "head": { "sha": "aaa", "ref": "wip" },
+            "base": { "sha": "bbb", "ref": "develop" },
+            "created_at": "2026-05-01T00:00:00Z",
+            "updated_at": "2026-05-01T00:00:00Z",
+        });
+        let pr = parse_pull(&item);
+        assert_eq!(pr.number, 43);
+        assert_eq!(pr.body, None);
+        assert_eq!(pr.mergeable, None);
+        assert!(pr.labels.is_empty());
     }
 }


### PR DESCRIPTION
## Problem

On the live kube pod, triage was intermittently skipped with:

```
Handling issue event: number=Some(2007)
Syncing issues...
Synced 821 issues.
Issue #2007 not found in cache. Run `wshm sync` first.
```

When an `issues.opened` / `pull_request.opened` webhook fires, the daemon forces a **list** sync and then triages/analyzes the record by number. But GitHub's list endpoints are served from a replicated index that lags creation by a few seconds, so a sync run immediately after the webhook can miss the brand-new issue/PR. `get_issue` / `get_pull` then return `None`, the daemon logs "not found in cache", and silently skips the very record that triggered the event. Hence the intermittent behavior — it only misses records created just before the sync.

## Fix

After the list sync, if the triggering record is still absent, fetch it directly from the **canonical single-record endpoint** (`/issues/{n}`, `/pulls/{n}`), which is strongly consistent, and upsert it before processing. A 404 (deleted/transferred, or a PR returned by the issues endpoint) is handled by skipping cleanly instead of erroring.

- add `Client::fetch_issue` and `Client::fetch_pull`
- factor JSON parsing into `parse_issue` / `parse_pull` helpers, reused by the list fetchers and the new single-record fetchers (removes duplicated field mapping)
- guard both `handle_issue` and `handle_pull_request` in the daemon processor
- unit tests for `parse_issue` (incl. PR skip) and `parse_pull`

## Out of scope

The `/health` slash command path (`commands.rs`) also reports "PR not found in cache", but that is triggered by a human comment on an existing PR (already synced), not the eventual-consistency-after-creation case — left unchanged.

## Verification

- `cargo check --tests` ✅
- `cargo clippy --lib` ✅ (no issues)
- `cargo test --lib github::` ✅ (9 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)