### PR TITLE
fix(daemon): stop dry-run triage loop and surface claude CLI errors

### DIFF
--- a/src/ai/client.rs
+++ b/src/ai/client.rs
@@ -300,8 +300,30 @@ impl AiClient {
             .context("Failed to run `claude -p`. Is claude CLI installed? (npm install -g @anthropic-ai/claude-code)")?;
 
         if !output.status.success() {
+            // The claude CLI writes operational failures (usage limit, auth,
+            // low credit) to stdout, not stderr — so capture both plus the
+            // exit code, otherwise the logged error is empty and useless.
             let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("claude CLI error: {stderr}");
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let detail: String = [stderr.trim(), stdout.trim()]
+                .into_iter()
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>()
+                .join(" | ");
+            let detail = if detail.is_empty() {
+                "no output".to_string()
+            } else {
+                detail
+            };
+            // Surface usage/rate limits distinctly so operators know to wait
+            // for the reset or switch credentials, not chase a phantom error.
+            if detail.to_ascii_lowercase().contains("limit") {
+                anyhow::bail!("claude CLI usage limit reached: {detail}");
+            }
+            anyhow::bail!(
+                "claude CLI failed (exit {}): {detail}",
+                output.status.code().unwrap_or(-1)
+            );
         }
 
         let text = String::from_utf8_lossy(&output.stdout).to_string();

--- a/src/daemon/scheduler.rs
+++ b/src/daemon/scheduler.rs
@@ -55,6 +55,8 @@ pub async fn run(state: Arc<DaemonState>) {
     let mut triage_failures: u32 = 0;
     let mut sync_alert_sent = false;
     let mut triage_alert_sent = false;
+    // Log the dry-run skip notice only once instead of every cycle.
+    let mut dry_run_triage_logged = false;
 
     info!(
         "Scheduler started (sync every {}m)",
@@ -112,7 +114,22 @@ pub async fn run(state: Arc<DaemonState>) {
         // Triage untriaged issues after sync. Both the legacy
         // [triage].enabled config flag AND the per-repo features.triage_issues
         // toggle must be true.
-        if state.config.triage.enabled && features.triage_issues {
+        //
+        // The scheduled batch only runs when applying: in dry-run nothing is
+        // persisted, so get_issues_needing_triage() returns the same issues
+        // every cycle — an infinite re-triage loop that burns AI quota for no
+        // visible effect. Webhook-driven triage still works in dry-run for
+        // one-off previews.
+        if state.config.triage.enabled && features.triage_issues && !state.apply() {
+            if !dry_run_triage_logged {
+                warn!(
+                    "Scheduled triage skipped in dry-run mode (apply=false): it would \
+                     re-triage the same issues every cycle and waste AI quota. Set \
+                     apply=true to enable applied triage."
+                );
+                dry_run_triage_logged = true;
+            }
+        } else if state.config.triage.enabled && features.triage_issues {
             let args = TriageArgs {
                 issue: None,
                 apply: state.apply(),
@@ -153,9 +170,11 @@ pub async fn run(state: Arc<DaemonState>) {
         }
 
         // Periodic retriage: re-evaluate stale triage results. Same dual
-        // gate as the regular triage loop above.
+        // gate as the regular triage loop above, plus apply (retriage only
+        // makes sense once results are persisted, which requires apply).
         if state.config.triage.enabled
             && features.triage_issues
+            && state.apply()
             && retriage_interval_hours > 0
             && last_retriage.elapsed() >= retriage_interval
         {

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -48,8 +48,40 @@ pub fn extract_linked_issues_with_type(body: &str) -> Vec<(String, u64)> {
         })
         .collect()
 }
+/// Whether an AI backend error is a usage/rate limit (vs. a per-item failure).
+///
+/// When the AI provider is rate limited, every remaining item in a batch will
+/// fail the same way, so callers use this to abort the batch early instead of
+/// burning one failed request per item. Matches the distinct marker emitted by
+/// the claude CLI backend (see `ai::client`).
+pub fn is_usage_limit_error(e: &anyhow::Error) -> bool {
+    let msg = format!("{e:#}").to_ascii_lowercase();
+    msg.contains("usage limit") || msg.contains("rate limit")
+}
+
 pub mod merge_queue;
 pub mod pr_analysis;
 pub mod pr_health;
 pub mod status;
 pub mod triage;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_usage_limit_error_detects_limit() {
+        let e = anyhow::anyhow!("claude CLI usage limit reached: You've hit your limit");
+        assert!(is_usage_limit_error(&e));
+        let e = anyhow::anyhow!("HTTP 429: rate limit exceeded");
+        assert!(is_usage_limit_error(&e));
+    }
+
+    #[test]
+    fn test_is_usage_limit_error_ignores_other_failures() {
+        let e = anyhow::anyhow!("claude CLI failed (exit 1): no output");
+        assert!(!is_usage_limit_error(&e));
+        let e = anyhow::anyhow!("Failed to parse AI response as JSON");
+        assert!(!is_usage_limit_error(&e));
+    }
+}

--- a/src/pipelines/pr_analysis.rs
+++ b/src/pipelines/pr_analysis.rs
@@ -79,6 +79,16 @@ pub async fn run(
             }
             Err(e) => {
                 tracing::error!("Failed to analyze PR #{}: {e:#}", pr.number);
+                // The AI provider is rate limited — every remaining PR in this
+                // batch will fail identically, so stop instead of burning a
+                // failed request per PR every cycle.
+                if crate::pipelines::is_usage_limit_error(&e) {
+                    tracing::warn!(
+                        "Aborting PR analysis batch — AI usage limit reached ({} PRs left)",
+                        pulls.len() - results.len()
+                    );
+                    break;
+                }
             }
         }
     }

--- a/src/pipelines/triage.rs
+++ b/src/pipelines/triage.rs
@@ -140,6 +140,16 @@ pub async fn run(
             }
             Err(e) => {
                 tracing::error!("Failed to triage issue #{}: {e:#}", issue.number);
+                // The AI provider is rate limited — every remaining issue in
+                // this batch will fail identically, so stop instead of burning
+                // a failed request per issue every cycle.
+                if crate::pipelines::is_usage_limit_error(&e) {
+                    tracing::warn!(
+                        "Aborting triage batch — AI usage limit reached ({} issues left)",
+                        issues.len() - results.len()
+                    );
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
## Context

While verifying the live `wshm-pro` pod we found it making **260 triage calls in 2h with 0 applied** — an infinite re-triage loop that exhausted the Claude subscription quota and then left every triage failing with an empty `claude CLI error:` line.

## Root cause & fixes

**1. Dry-run scheduled triage loop**
The pod runs with `apply = false`. In dry-run the triage result is never persisted (`if apply { upsert_triage_result }`), so `get_issues_needing_triage()` returns the same 20 issues every cycle — looping forever and burning AI quota for no visible effect. The scheduled batch triage/retriage now only runs when applying (logged once); webhook-driven triage still works in dry-run for one-off previews.

**2. `claude CLI` error visibility** (`ai/client.rs`)
The `claude` CLI writes operational failures (usage limit, auth, low credit) to **stdout**, not stderr — so the old handler logged an empty error. Now captures stdout + exit code and flags usage limits distinctly.

**3. Batch early-abort on usage limit**
When the AI backend is rate limited, every remaining item in a batch fails identically. Both triage and PR-analysis loops now abort early instead of burning one failed request per item. Adds the shared `pipelines::is_usage_limit_error` helper.

## Verification
- `cargo clippy --lib` ✅ (no issues)
- `cargo test --lib` ✅ (52 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)