### PR TITLE
Release fixes to main: issue/PR cache + dry-run triage loop

### DIFF
--- a/src/ai/client.rs
+++ b/src/ai/client.rs
@@ -300,8 +300,30 @@ impl AiClient {
             .context("Failed to run `claude -p`. Is claude CLI installed? (npm install -g @anthropic-ai/claude-code)")?;
 
         if !output.status.success() {
+            // The claude CLI writes operational failures (usage limit, auth,
+            // low credit) to stdout, not stderr — so capture both plus the
+            // exit code, otherwise the logged error is empty and useless.
             let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("claude CLI error: {stderr}");
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let detail: String = [stderr.trim(), stdout.trim()]
+                .into_iter()
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>()
+                .join(" | ");
+            let detail = if detail.is_empty() {
+                "no output".to_string()
+            } else {
+                detail
+            };
+            // Surface usage/rate limits distinctly so operators know to wait
+            // for the reset or switch credentials, not chase a phantom error.
+            if detail.to_ascii_lowercase().contains("limit") {
+                anyhow::bail!("claude CLI usage limit reached: {detail}");
+            }
+            anyhow::bail!(
+                "claude CLI failed (exit {}): {detail}",
+                output.status.code().unwrap_or(-1)
+            );
         }
 
         let text = String::from_utf8_lossy(&output.stdout).to_string();

--- a/src/daemon/processor.rs
+++ b/src/daemon/processor.rs
@@ -213,6 +213,31 @@ async fn handle_issue(state: &DaemonState, event: &WebhookEvent) -> anyhow::Resu
     // Force sync issues (bypass throttle — we know there's a new event)
     gh_sync::sync_issues_now(&state.gh(), &state.db).await?;
 
+    // The list endpoint lags issue creation by a few seconds (replicated
+    // index), so a sync right after `issues.opened` can miss the brand-new
+    // issue, which then surfaces as "Issue #N not found in cache" at triage.
+    // Fetch it directly from the canonical single-issue endpoint to guarantee
+    // it is cached before we triage.
+    if let Some(n) = number {
+        if matches!(state.db.get_issue(n), Ok(None)) {
+            match state.gh().fetch_issue(n).await {
+                Ok(Some(issue)) => {
+                    if let Err(e) = state.db.upsert_issue(&issue) {
+                        warn!("Failed to cache issue #{n} after direct fetch: {e}");
+                    }
+                }
+                Ok(None) => {
+                    info!(
+                        "[{}] issue #{n} not returned by GitHub (deleted, transferred, or a PR) — skipping",
+                        state.config.repo_slug()
+                    );
+                    return Ok(());
+                }
+                Err(e) => warn!("Direct fetch of issue #{n} failed: {e:#}"),
+            }
+        }
+    }
+
     if !features.triage_issues {
         info!(
             "[{}] triage_issues disabled — issue {number:?} synced but not triaged",
@@ -330,6 +355,30 @@ async fn handle_pull_request(state: &DaemonState, event: &WebhookEvent) -> anyho
     }
     // Force sync pulls (bypass throttle — we know there's a new event)
     gh_sync::sync_pulls_now(&state.gh(), &state.db).await?;
+
+    // The list endpoint lags PR creation by a few seconds (replicated index),
+    // so a sync right after `pull_request.opened` can miss the brand-new PR,
+    // which then surfaces as "PR #N not found in cache" at analysis. Fetch it
+    // directly from the canonical single-PR endpoint to guarantee it is cached.
+    if let Some(n) = number {
+        if matches!(state.db.get_pull(n), Ok(None)) {
+            match state.gh().fetch_pull(n).await {
+                Ok(Some(pr)) => {
+                    if let Err(e) = state.db.upsert_pull(&pr) {
+                        warn!("Failed to cache PR #{n} after direct fetch: {e}");
+                    }
+                }
+                Ok(None) => {
+                    info!(
+                        "[{}] PR #{n} not returned by GitHub (deleted or transferred) — skipping",
+                        state.config.repo_slug()
+                    );
+                    return Ok(());
+                }
+                Err(e) => warn!("Direct fetch of PR #{n} failed: {e:#}"),
+            }
+        }
+    }
 
     if !features.analyze_prs {
         info!(

--- a/src/daemon/scheduler.rs
+++ b/src/daemon/scheduler.rs
@@ -55,6 +55,8 @@ pub async fn run(state: Arc<DaemonState>) {
     let mut triage_failures: u32 = 0;
     let mut sync_alert_sent = false;
     let mut triage_alert_sent = false;
+    // Log the dry-run skip notice only once instead of every cycle.
+    let mut dry_run_triage_logged = false;
 
     info!(
         "Scheduler started (sync every {}m)",
@@ -112,7 +114,22 @@ pub async fn run(state: Arc<DaemonState>) {
         // Triage untriaged issues after sync. Both the legacy
         // [triage].enabled config flag AND the per-repo features.triage_issues
         // toggle must be true.
-        if state.config.triage.enabled && features.triage_issues {
+        //
+        // The scheduled batch only runs when applying: in dry-run nothing is
+        // persisted, so get_issues_needing_triage() returns the same issues
+        // every cycle — an infinite re-triage loop that burns AI quota for no
+        // visible effect. Webhook-driven triage still works in dry-run for
+        // one-off previews.
+        if state.config.triage.enabled && features.triage_issues && !state.apply() {
+            if !dry_run_triage_logged {
+                warn!(
+                    "Scheduled triage skipped in dry-run mode (apply=false): it would \
+                     re-triage the same issues every cycle and waste AI quota. Set \
+                     apply=true to enable applied triage."
+                );
+                dry_run_triage_logged = true;
+            }
+        } else if state.config.triage.enabled && features.triage_issues {
             let args = TriageArgs {
                 issue: None,
                 apply: state.apply(),
@@ -153,9 +170,11 @@ pub async fn run(state: Arc<DaemonState>) {
         }
 
         // Periodic retriage: re-evaluate stale triage results. Same dual
-        // gate as the regular triage loop above.
+        // gate as the regular triage loop above, plus apply (retriage only
+        // makes sense once results are persisted, which requires apply).
         if state.config.triage.enabled
             && features.triage_issues
+            && state.apply()
             && retriage_interval_hours > 0
             && last_retriage.elapsed() >= retriage_interval
         {

--- a/src/github/issues.rs
+++ b/src/github/issues.rs
@@ -8,6 +8,41 @@ use crate::github::Client;
 /// The actual marker is derived from branding.name via `BrandingConfig::comment_marker()`.
 pub const WSHM_COMMENT_MARKER: &str = "<!-- wshm -->";
 
+/// Build an [`Issue`] from a GitHub API issue JSON object.
+///
+/// Returns `None` for pull requests, which the issues endpoint also serves
+/// (they carry a `pull_request` key).
+fn parse_issue(item: &serde_json::Value) -> Option<Issue> {
+    if item.get("pull_request").is_some() {
+        return None;
+    }
+
+    let reactions = item.get("reactions");
+    let reactions_plus1 = reactions
+        .and_then(|r| r.get("+1"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    let reactions_total = reactions
+        .and_then(|r| r.get("total_count"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+
+    let state = item.get("state").and_then(|v| v.as_str()).unwrap_or("open");
+
+    Some(Issue {
+        number: item["number"].as_u64().unwrap_or(0),
+        title: item["title"].as_str().unwrap_or("").to_string(),
+        body: item.get("body").and_then(|v| v.as_str()).map(String::from),
+        state: state.to_string(),
+        labels: super::extract_labels(item),
+        author: super::extract_author(item),
+        created_at: item["created_at"].as_str().unwrap_or("").to_string(),
+        updated_at: item["updated_at"].as_str().unwrap_or("").to_string(),
+        reactions_plus1,
+        reactions_total,
+    })
+}
+
 impl Client {
     pub async fn fetch_issues(&self, since: Option<&str>) -> Result<Vec<Issue>> {
         self.fetch_issues_with_state("open", since).await
@@ -15,6 +50,54 @@ impl Client {
 
     pub async fn fetch_all_issues(&self, since: Option<&str>) -> Result<Vec<Issue>> {
         self.fetch_issues_with_state("all", since).await
+    }
+
+    /// Fetch a single issue by number from the canonical (strongly consistent)
+    /// `/issues/{number}` endpoint.
+    ///
+    /// The list endpoint is served from a replicated index that lags behind
+    /// issue creation by seconds, so a list sync triggered right after an
+    /// `issues.opened` webhook can miss the brand-new issue. The single-issue
+    /// endpoint always reflects the latest state, so we use it to guarantee a
+    /// freshly opened issue is in cache before triage.
+    ///
+    /// Returns `Ok(None)` when the number is a pull request (the issues
+    /// endpoint also serves PRs) or the issue was deleted/transferred (404).
+    pub async fn fetch_issue(&self, number: u64) -> Result<Option<Issue>> {
+        let url = format!(
+            "https://api.github.com/repos/{}/{}/issues/{number}",
+            self.owner, self.repo
+        );
+
+        let body = crate::retry::with_retry("github: fetch issue", || async {
+            let response = self
+                .octocrab
+                ._get(&url)
+                .await
+                .with_context(|| format!("Failed to fetch issue #{number}"))?;
+            self.octocrab
+                .body_to_string(response)
+                .await
+                .context("Failed to read issue response body")
+        })
+        .await?;
+
+        let item: serde_json::Value =
+            serde_json::from_str(&body).context("Failed to parse issue JSON")?;
+
+        // A 404 (deleted/transferred issue) comes back as an object with a
+        // `message` field rather than an issue payload.
+        if item.get("number").is_none() {
+            if let Some(msg) = item.get("message").and_then(|v| v.as_str()) {
+                if msg.eq_ignore_ascii_case("Not Found") {
+                    return Ok(None);
+                }
+                anyhow::bail!("GitHub error while fetching issue #{number}: {msg}");
+            }
+            return Ok(None);
+        }
+
+        Ok(parse_issue(&item))
     }
 
     async fn fetch_issues_with_state(
@@ -58,34 +141,9 @@ impl Client {
 
             for item in &items {
                 // Skip PRs (the issues endpoint includes them)
-                if item.get("pull_request").is_some() {
-                    continue;
+                if let Some(issue) = parse_issue(item) {
+                    all_issues.push(issue);
                 }
-
-                let reactions = item.get("reactions");
-                let reactions_plus1 = reactions
-                    .and_then(|r| r.get("+1"))
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0) as u32;
-                let reactions_total = reactions
-                    .and_then(|r| r.get("total_count"))
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0) as u32;
-
-                let state = item.get("state").and_then(|v| v.as_str()).unwrap_or("open");
-
-                all_issues.push(Issue {
-                    number: item["number"].as_u64().unwrap_or(0),
-                    title: item["title"].as_str().unwrap_or("").to_string(),
-                    body: item.get("body").and_then(|v| v.as_str()).map(String::from),
-                    state: state.to_string(),
-                    labels: super::extract_labels(item),
-                    author: super::extract_author(item),
-                    created_at: item["created_at"].as_str().unwrap_or("").to_string(),
-                    updated_at: item["updated_at"].as_str().unwrap_or("").to_string(),
-                    reactions_plus1,
-                    reactions_total,
-                });
             }
 
             if items.len() < 100 || page >= 100 {
@@ -380,5 +438,40 @@ mod tests {
         let body = "This is a comment";
         let result = ensure_wshm_marker(body);
         assert!(result.contains(WSHM_COMMENT_MARKER));
+    }
+
+    #[test]
+    fn test_parse_issue_builds_issue() {
+        let item = serde_json::json!({
+            "number": 338,
+            "title": "Something broke",
+            "body": "details",
+            "state": "open",
+            "labels": [{ "name": "bug" }],
+            "user": { "login": "octocat" },
+            "created_at": "2026-05-01T00:00:00Z",
+            "updated_at": "2026-05-02T00:00:00Z",
+            "reactions": { "+1": 3, "total_count": 5 },
+        });
+        let issue = parse_issue(&item).expect("issue should parse");
+        assert_eq!(issue.number, 338);
+        assert_eq!(issue.title, "Something broke");
+        assert_eq!(issue.state, "open");
+        assert_eq!(issue.labels, vec!["bug".to_string()]);
+        assert_eq!(issue.author.as_deref(), Some("octocat"));
+        assert_eq!(issue.reactions_plus1, 3);
+        assert_eq!(issue.reactions_total, 5);
+    }
+
+    #[test]
+    fn test_parse_issue_skips_pull_requests() {
+        // The issues endpoint also returns PRs; they carry a `pull_request` key.
+        let item = serde_json::json!({
+            "number": 339,
+            "title": "A pull request",
+            "state": "open",
+            "pull_request": { "url": "https://api.github.com/..." },
+        });
+        assert!(parse_issue(&item).is_none());
     }
 }

--- a/src/github/pulls.rs
+++ b/src/github/pulls.rs
@@ -16,6 +16,43 @@ pub struct MergedPullRequest {
     pub created_at: String,
 }
 
+/// Build a [`PullRequest`] from a GitHub API pull request JSON object.
+fn parse_pull(pr: &serde_json::Value) -> PullRequest {
+    let state = pr.get("state").and_then(|v| v.as_str()).unwrap_or("open");
+    PullRequest {
+        number: pr["number"].as_u64().unwrap_or(0),
+        title: pr["title"].as_str().unwrap_or("").to_string(),
+        body: pr.get("body").and_then(|v| v.as_str()).map(String::from),
+        state: state.to_string(),
+        labels: super::extract_labels(pr),
+        author: super::extract_author(pr),
+        head_sha: pr
+            .get("head")
+            .and_then(|h| h.get("sha"))
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        base_sha: pr
+            .get("base")
+            .and_then(|h| h.get("sha"))
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        head_ref: pr
+            .get("head")
+            .and_then(|h| h.get("ref"))
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        base_ref: pr
+            .get("base")
+            .and_then(|h| h.get("ref"))
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        mergeable: pr.get("mergeable").and_then(|v| v.as_bool()),
+        ci_status: None,
+        created_at: pr["created_at"].as_str().unwrap_or("").to_string(),
+        updated_at: pr["updated_at"].as_str().unwrap_or("").to_string(),
+    }
+}
+
 impl Client {
     /// Fetch merged pull requests, optionally filtering to those merged since a given ISO date.
     pub async fn fetch_merged_pulls(&self, since: Option<&str>) -> Result<Vec<MergedPullRequest>> {
@@ -136,50 +173,16 @@ impl Client {
             let mut should_stop = false;
 
             for pr in &items {
-                let state = pr.get("state").and_then(|v| v.as_str()).unwrap_or("open");
-                let mergeable = pr.get("mergeable").and_then(|v| v.as_bool());
-                let updated_at = pr["updated_at"].as_str().unwrap_or("").to_string();
-
                 // Forever-incremental: stop if this PR is older than `since`
                 if let Some(since_ts) = since {
-                    if updated_at.as_str() < since_ts {
+                    let updated_at = pr["updated_at"].as_str().unwrap_or("");
+                    if updated_at < since_ts {
                         should_stop = true;
                         break;
                     }
                 }
 
-                all_pulls.push(PullRequest {
-                    number: pr["number"].as_u64().unwrap_or(0),
-                    title: pr["title"].as_str().unwrap_or("").to_string(),
-                    body: pr.get("body").and_then(|v| v.as_str()).map(String::from),
-                    state: state.to_string(),
-                    labels: super::extract_labels(pr),
-                    author: super::extract_author(pr),
-                    head_sha: pr
-                        .get("head")
-                        .and_then(|h| h.get("sha"))
-                        .and_then(|v| v.as_str())
-                        .map(String::from),
-                    base_sha: pr
-                        .get("base")
-                        .and_then(|h| h.get("sha"))
-                        .and_then(|v| v.as_str())
-                        .map(String::from),
-                    head_ref: pr
-                        .get("head")
-                        .and_then(|h| h.get("ref"))
-                        .and_then(|v| v.as_str())
-                        .map(String::from),
-                    base_ref: pr
-                        .get("base")
-                        .and_then(|h| h.get("ref"))
-                        .and_then(|v| v.as_str())
-                        .map(String::from),
-                    mergeable,
-                    ci_status: None,
-                    created_at: pr["created_at"].as_str().unwrap_or("").to_string(),
-                    updated_at,
-                });
+                all_pulls.push(parse_pull(pr));
             }
 
             if should_stop || items.len() < 100 || page >= 100 {
@@ -214,6 +217,53 @@ impl Client {
             serde_json::from_str(&body).context("Failed to parse PR JSON")?;
 
         Ok(pr_json.get("mergeable").and_then(|v| v.as_bool()))
+    }
+
+    /// Fetch a single pull request by number from the canonical (strongly
+    /// consistent) `/pulls/{number}` endpoint.
+    ///
+    /// Mirrors [`Client::fetch_issue`]: the list endpoint is served from a
+    /// replicated index that lags PR creation by a few seconds, so a sync
+    /// triggered right after a `pull_request.opened` webhook can miss the
+    /// brand-new PR and surface "PR #N not found in cache" at analysis time.
+    /// The single-PR endpoint always reflects the latest state.
+    ///
+    /// Returns `Ok(None)` when the PR was deleted/transferred (404).
+    pub async fn fetch_pull(&self, number: u64) -> Result<Option<PullRequest>> {
+        let url = format!(
+            "https://api.github.com/repos/{}/{}/pulls/{number}",
+            self.owner, self.repo
+        );
+
+        let body = crate::retry::with_retry("github: fetch PR", || async {
+            let response = self
+                .octocrab
+                ._get(&url)
+                .await
+                .with_context(|| format!("Failed to fetch PR #{number}"))?;
+            self.octocrab
+                .body_to_string(response)
+                .await
+                .with_context(|| format!("Failed to read PR #{number} body"))
+        })
+        .await?;
+
+        let item: serde_json::Value =
+            serde_json::from_str(&body).context("Failed to parse PR JSON")?;
+
+        // A 404 (deleted/transferred PR) comes back as an object with a
+        // `message` field rather than a PR payload.
+        if item.get("number").is_none() {
+            if let Some(msg) = item.get("message").and_then(|v| v.as_str()) {
+                if msg.eq_ignore_ascii_case("Not Found") {
+                    return Ok(None);
+                }
+                anyhow::bail!("GitHub error while fetching PR #{number}: {msg}");
+            }
+            return Ok(None);
+        }
+
+        Ok(Some(parse_pull(&item)))
     }
 
     pub async fn fetch_pr_diff(&self, number: u64) -> Result<String> {
@@ -352,5 +402,55 @@ impl Client {
     /// Delegates to comment_issue since GitHub uses the same API for both.
     pub async fn comment_pr(&self, number: u64, body: &str) -> Result<()> {
         self.comment_issue(number, body).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_pull_builds_pull_request() {
+        let item = serde_json::json!({
+            "number": 42,
+            "title": "Add feature",
+            "body": "description",
+            "state": "open",
+            "labels": [{ "name": "enhancement" }],
+            "user": { "login": "octocat" },
+            "head": { "sha": "abc123", "ref": "feature" },
+            "base": { "sha": "def456", "ref": "main" },
+            "mergeable": true,
+            "created_at": "2026-05-01T00:00:00Z",
+            "updated_at": "2026-05-02T00:00:00Z",
+        });
+        let pr = parse_pull(&item);
+        assert_eq!(pr.number, 42);
+        assert_eq!(pr.title, "Add feature");
+        assert_eq!(pr.state, "open");
+        assert_eq!(pr.labels, vec!["enhancement".to_string()]);
+        assert_eq!(pr.author.as_deref(), Some("octocat"));
+        assert_eq!(pr.head_sha.as_deref(), Some("abc123"));
+        assert_eq!(pr.base_ref.as_deref(), Some("main"));
+        assert_eq!(pr.mergeable, Some(true));
+    }
+
+    #[test]
+    fn test_parse_pull_handles_missing_optionals() {
+        // A freshly opened PR may have null mergeable and no body.
+        let item = serde_json::json!({
+            "number": 43,
+            "title": "Draft",
+            "state": "open",
+            "head": { "sha": "aaa", "ref": "wip" },
+            "base": { "sha": "bbb", "ref": "develop" },
+            "created_at": "2026-05-01T00:00:00Z",
+            "updated_at": "2026-05-01T00:00:00Z",
+        });
+        let pr = parse_pull(&item);
+        assert_eq!(pr.number, 43);
+        assert_eq!(pr.body, None);
+        assert_eq!(pr.mergeable, None);
+        assert!(pr.labels.is_empty());
     }
 }

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -48,8 +48,40 @@ pub fn extract_linked_issues_with_type(body: &str) -> Vec<(String, u64)> {
         })
         .collect()
 }
+/// Whether an AI backend error is a usage/rate limit (vs. a per-item failure).
+///
+/// When the AI provider is rate limited, every remaining item in a batch will
+/// fail the same way, so callers use this to abort the batch early instead of
+/// burning one failed request per item. Matches the distinct marker emitted by
+/// the claude CLI backend (see `ai::client`).
+pub fn is_usage_limit_error(e: &anyhow::Error) -> bool {
+    let msg = format!("{e:#}").to_ascii_lowercase();
+    msg.contains("usage limit") || msg.contains("rate limit")
+}
+
 pub mod merge_queue;
 pub mod pr_analysis;
 pub mod pr_health;
 pub mod status;
 pub mod triage;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_usage_limit_error_detects_limit() {
+        let e = anyhow::anyhow!("claude CLI usage limit reached: You've hit your limit");
+        assert!(is_usage_limit_error(&e));
+        let e = anyhow::anyhow!("HTTP 429: rate limit exceeded");
+        assert!(is_usage_limit_error(&e));
+    }
+
+    #[test]
+    fn test_is_usage_limit_error_ignores_other_failures() {
+        let e = anyhow::anyhow!("claude CLI failed (exit 1): no output");
+        assert!(!is_usage_limit_error(&e));
+        let e = anyhow::anyhow!("Failed to parse AI response as JSON");
+        assert!(!is_usage_limit_error(&e));
+    }
+}

--- a/src/pipelines/pr_analysis.rs
+++ b/src/pipelines/pr_analysis.rs
@@ -79,6 +79,16 @@ pub async fn run(
             }
             Err(e) => {
                 tracing::error!("Failed to analyze PR #{}: {e:#}", pr.number);
+                // The AI provider is rate limited — every remaining PR in this
+                // batch will fail identically, so stop instead of burning a
+                // failed request per PR every cycle.
+                if crate::pipelines::is_usage_limit_error(&e) {
+                    tracing::warn!(
+                        "Aborting PR analysis batch — AI usage limit reached ({} PRs left)",
+                        pulls.len() - results.len()
+                    );
+                    break;
+                }
             }
         }
     }

--- a/src/pipelines/triage.rs
+++ b/src/pipelines/triage.rs
@@ -140,6 +140,16 @@ pub async fn run(
             }
             Err(e) => {
                 tracing::error!("Failed to triage issue #{}: {e:#}", issue.number);
+                // The AI provider is rate limited — every remaining issue in
+                // this batch will fail identically, so stop instead of burning
+                // a failed request per issue every cycle.
+                if crate::pipelines::is_usage_limit_error(&e) {
+                    tracing::warn!(
+                        "Aborting triage batch — AI usage limit reached ({} issues left)",
+                        issues.len() - results.len()
+                    );
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
Promotes the two daemon fixes from `develop` to `main` so they ship in the next wshm-pro image (`:latest-ai` builds from wshm-core `main`).

- **#87** — fetch fresh issue/PR directly to avoid intermittent "not found in cache" right after `issues.opened` / `pull_request.opened` (GitHub list-endpoint eventual consistency).
- **#88** — stop the dry-run scheduled triage loop (which burned AI quota by re-triaging the same issues every cycle) and surface `claude CLI` errors written to stdout (usage limit, auth, credit); early-abort batches on usage limit.

Both already CI-green and reviewed on their feature PRs. No version bump in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)