### PR TITLE
release: triage/PR dedup + batch skip filters

### DIFF
--- a/src/daemon/scheduler.rs
+++ b/src/daemon/scheduler.rs
@@ -136,13 +136,14 @@ pub async fn run(state: Arc<DaemonState>) {
                 retriage: false,
             };
 
-            match pipelines::triage::run(
+            match pipelines::triage::run_with_filters(
                 &state.config,
                 &state.db,
                 &state.gh(),
                 &args,
                 pipelines::triage::OutputFormat::Text,
                 None,
+                Some(&features.filters),
             )
             .await
             {
@@ -187,13 +188,14 @@ pub async fn run(state: Arc<DaemonState>) {
                 retriage: true,
             };
 
-            match pipelines::triage::run(
+            match pipelines::triage::run_with_filters(
                 &state.config,
                 &state.db,
                 &state.gh(),
                 &args,
                 pipelines::triage::OutputFormat::Text,
                 None,
+                Some(&features.filters),
             )
             .await
             {

--- a/src/db/pulls.rs
+++ b/src/db/pulls.rs
@@ -28,6 +28,8 @@ pub struct PrAnalysisRow {
     pub pr_type: String,
     pub review_notes: Option<String>,
     pub analyzed_at: String,
+    #[serde(default)]
+    pub content_hash: Option<String>,
 }
 
 use crate::db::Database;
@@ -36,7 +38,7 @@ impl Database {
     pub fn get_pr_analysis(&self, pr_number: u64) -> Result<Option<PrAnalysisRow>> {
         self.with_conn(|conn| {
             let mut stmt = conn.prepare(
-                "SELECT pr_number, summary, risk_level, pr_type, review_notes, analyzed_at
+                "SELECT pr_number, summary, risk_level, pr_type, review_notes, analyzed_at, content_hash
                  FROM pr_analyses WHERE pr_number = ?1",
             )?;
 
@@ -48,6 +50,7 @@ impl Database {
                     pr_type: row.get(3)?,
                     review_notes: row.get(4)?,
                     analyzed_at: row.get(5)?,
+                    content_hash: row.get(6)?,
                 })
             });
 
@@ -90,6 +93,10 @@ impl Database {
 
     pub fn get_unanalyzed_pulls(&self) -> Result<Vec<PullRequest>> {
         self.with_conn(get_unanalyzed_pulls)
+    }
+
+    pub fn get_pulls_needing_analysis(&self) -> Result<Vec<PullRequest>> {
+        self.with_conn(get_pulls_needing_analysis)
     }
 }
 
@@ -191,4 +198,139 @@ pub fn get_unanalyzed_pulls(conn: &Connection) -> Result<Vec<PullRequest>> {
         .query_map([], row_to_pull)?
         .collect::<Result<Vec<_>, _>>()?;
     Ok(pulls)
+}
+
+/// Open PRs that need (re)analysis: never analyzed (NULL hash) OR whose
+/// content changed since the last analysis (stored hash != current hash).
+/// Mirrors `get_issues_needing_triage` so the scheduled batch only spends
+/// AI credits when a PR actually changed.
+pub fn get_pulls_needing_analysis(conn: &Connection) -> Result<Vec<PullRequest>> {
+    use crate::db::schema::compute_pr_hash;
+
+    let mut stmt = conn.prepare(
+        "SELECT p.number, p.title, p.body, p.state, p.labels, p.author, p.head_sha, p.base_sha, p.head_ref, p.base_ref, p.mergeable, p.ci_status, p.created_at, p.updated_at,
+                a.content_hash
+         FROM pull_requests p
+         LEFT JOIN pr_analyses a ON p.number = a.pr_number
+         WHERE p.state = 'open'
+         ORDER BY p.number DESC",
+    )?;
+
+    let rows = stmt.query_map([], |row| {
+        let pr = row_to_pull(row)?;
+        let stored_hash: Option<String> = row.get(14)?;
+        Ok((pr, stored_hash))
+    })?;
+
+    let mut pulls = Vec::new();
+    for row in rows {
+        let (pr, stored_hash) = row?;
+        let current_hash = compute_pr_hash(
+            &pr.title,
+            pr.body.as_deref(),
+            pr.head_sha.as_deref(),
+            &pr.labels,
+        );
+        if stored_hash.is_none() || stored_hash.as_deref() != Some(current_hash.as_str()) {
+            pulls.push(pr);
+        }
+    }
+    Ok(pulls)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::schema::compute_pr_hash;
+    use crate::db::Database;
+
+    fn test_pull(number: u64, title: &str) -> PullRequest {
+        PullRequest {
+            number,
+            title: title.to_string(),
+            body: Some("Body".to_string()),
+            state: "open".to_string(),
+            labels: vec!["enhancement".to_string()],
+            author: Some("user".to_string()),
+            head_sha: Some("abc123".to_string()),
+            base_sha: Some("def456".to_string()),
+            head_ref: Some("feature".to_string()),
+            base_ref: Some("main".to_string()),
+            mergeable: Some(true),
+            ci_status: Some("success".to_string()),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    /// Insert a pr_analyses row with the given content hash (mirrors the
+    /// production insert in pipelines::pr_analysis).
+    fn record_analysis(db: &Database, pr_number: u64, content_hash: &str) {
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO pr_analyses (pr_number, summary, risk_level, pr_type, review_notes, analyzed_at, content_hash)
+                 VALUES (?1, 'summary', 'low', 'feature', '{}', '2026-01-01T00:00:00Z', ?2)",
+                params![pr_number, content_hash],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_get_pulls_needing_analysis() {
+        let db = Database::open_memory().unwrap();
+
+        // PR 1: never analyzed
+        db.upsert_pull(&test_pull(1, "Never analyzed")).unwrap();
+
+        // PR 2: analyzed, content unchanged
+        let pr2 = test_pull(2, "Already analyzed");
+        db.upsert_pull(&pr2).unwrap();
+        let hash2 = compute_pr_hash(
+            &pr2.title,
+            pr2.body.as_deref(),
+            pr2.head_sha.as_deref(),
+            &pr2.labels,
+        );
+        record_analysis(&db, 2, &hash2);
+
+        // PR 3: analyzed, then new commits pushed (head_sha changed)
+        let mut pr3 = test_pull(3, "New commits");
+        db.upsert_pull(&pr3).unwrap();
+        let hash3_old = compute_pr_hash(
+            &pr3.title,
+            pr3.body.as_deref(),
+            pr3.head_sha.as_deref(),
+            &pr3.labels,
+        );
+        record_analysis(&db, 3, &hash3_old);
+        pr3.head_sha = Some("zzz999".to_string());
+        db.upsert_pull(&pr3).unwrap();
+
+        // PR 4: analyzed and unchanged, but closed — must be excluded
+        let pr4 = test_pull(4, "Closed PR");
+        let mut pr4_closed = pr4.clone();
+        pr4_closed.state = "closed".to_string();
+        db.upsert_pull(&pr4_closed).unwrap();
+        let hash4 = compute_pr_hash(
+            &pr4.title,
+            pr4.body.as_deref(),
+            pr4.head_sha.as_deref(),
+            &pr4.labels,
+        );
+        record_analysis(&db, 4, &hash4);
+
+        let needing = db.get_pulls_needing_analysis().unwrap();
+        let numbers: Vec<u64> = needing.iter().map(|p| p.number).collect();
+
+        assert!(numbers.contains(&1), "never-analyzed PR should be selected");
+        assert!(
+            numbers.contains(&3),
+            "content-changed PR should be selected"
+        );
+        assert!(!numbers.contains(&2), "unchanged PR must be skipped");
+        assert!(!numbers.contains(&4), "closed PR must be skipped");
+        assert_eq!(numbers.len(), 2);
+    }
 }

--- a/src/pipelines/pr_analysis.rs
+++ b/src/pipelines/pr_analysis.rs
@@ -44,7 +44,7 @@ pub async fn run(
             }
         }
     } else {
-        db.get_unanalyzed_pulls()?
+        db.get_pulls_needing_analysis()?
     };
 
     if pulls.is_empty() {
@@ -109,6 +109,42 @@ async fn analyze_pr(
     apply: bool,
     exporter: Option<&ExportManager>,
 ) -> Result<PrAnalysis> {
+    // Content hash cache: skip LLM call if content hasn't changed since last
+    // analysis. The hash covers title + body + head_sha + labels, so a new
+    // push (head_sha change) or an edit re-triggers analysis, but a no-op
+    // event (e.g. assignee change) reuses the cached result.
+    let content_hash = crate::db::schema::compute_pr_hash(
+        &pr.title,
+        pr.body.as_deref(),
+        pr.head_sha.as_deref(),
+        &pr.labels,
+    );
+
+    if let Ok(Some(existing)) = db.get_pr_analysis(pr.number) {
+        if existing.content_hash.as_deref() == Some(content_hash.as_str()) {
+            tracing::info!(
+                "Skipping LLM for PR #{} — content unchanged (hash match)",
+                pr.number
+            );
+            // Reconstruct PrAnalysis from the cached row. suggested_labels and
+            // linked_issues were applied at first analysis and are not stored,
+            // so they stay empty (we won't re-apply on a cache hit).
+            let review_checklist = existing
+                .review_notes
+                .as_deref()
+                .and_then(|n| serde_json::from_str(n).ok())
+                .unwrap_or_default();
+            return Ok(PrAnalysis {
+                summary: existing.summary,
+                risk_level: existing.risk_level,
+                pr_type: existing.pr_type,
+                linked_issues: Vec::new(),
+                review_checklist,
+                suggested_labels: Vec::new(),
+            });
+        }
+    }
+
     // Try to fetch diff (best-effort)
     let diff = match gh.fetch_pr_diff(pr.number).await {
         Ok(d) => Some(d),
@@ -150,14 +186,15 @@ async fn analyze_pr(
     let now = chrono::Utc::now().to_rfc3339();
     db.with_conn(|conn| {
         conn.execute(
-            "INSERT INTO pr_analyses (pr_number, summary, risk_level, pr_type, review_notes, analyzed_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            "INSERT INTO pr_analyses (pr_number, summary, risk_level, pr_type, review_notes, analyzed_at, content_hash)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
              ON CONFLICT(pr_number) DO UPDATE SET
                 summary = excluded.summary,
                 risk_level = excluded.risk_level,
                 pr_type = excluded.pr_type,
                 review_notes = excluded.review_notes,
-                analyzed_at = excluded.analyzed_at",
+                analyzed_at = excluded.analyzed_at,
+                content_hash = excluded.content_hash",
             rusqlite::params![
                 pr.number,
                 analysis.summary,
@@ -165,6 +202,7 @@ async fn analyze_pr(
                 analysis.pr_type,
                 serde_json::to_string(&analysis.review_checklist)?,
                 now,
+                content_hash,
             ],
         )?;
         Ok(())

--- a/src/pipelines/triage.rs
+++ b/src/pipelines/triage.rs
@@ -37,6 +37,23 @@ pub async fn run(
     format: OutputFormat,
     exporter: Option<&ExportManager>,
 ) -> Result<()> {
+    run_with_filters(config, db, gh, args, format, exporter, None).await
+}
+
+/// Same as [`run`], but applies per-action filters (skip authors / skip
+/// labels / age) to each issue before spending AI credits. The scheduled
+/// batch passes `Some(&features.filters)` so it honors the same gates the
+/// webhook path already enforces; manual/CLI callers pass `None`.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_with_filters(
+    config: &Config,
+    db: &Database,
+    gh: &GhClient,
+    args: &TriageArgs,
+    format: OutputFormat,
+    exporter: Option<&ExportManager>,
+    filters: Option<&crate::config::RepoFilters>,
+) -> Result<()> {
     let json = format == OutputFormat::Json;
     let model = config.model_for("triage");
     let backend = AiBackend::from_config(config, model)?;
@@ -111,6 +128,31 @@ pub async fn run(
         if config.issues_blacklist.contains(&issue.number) {
             info!("Skipping blacklisted issue #{}", issue.number);
             continue;
+        }
+
+        // Apply per-action filters before consuming AI credits, so the
+        // scheduled batch honors the same gates as the webhook path (e.g. a
+        // `triage_skip_labels` marker means "never (re-)triage this issue").
+        if let Some(f) = filters {
+            if f.is_author_skipped(issue.author.as_deref()) {
+                info!(
+                    "Skipping issue #{} (author '{}' in skip_authors)",
+                    issue.number,
+                    issue.author.as_deref().unwrap_or("?")
+                );
+                continue;
+            }
+            if !f.issue_labels_pass_triage(&issue.labels) {
+                info!("Skipping issue #{} (labels filter)", issue.number);
+                continue;
+            }
+            if !f.issue_age_ok(&issue.created_at) {
+                info!(
+                    "Skipping issue #{} (older than {} days)",
+                    issue.number, f.triage_max_age_days
+                );
+                continue;
+            }
         }
 
         info!("Triaging issue #{}: {}", issue.number, issue.title);
@@ -206,13 +248,17 @@ async fn triage_issue(
                 "Skipping LLM for issue #{} — content unchanged (hash match)",
                 issue.number
             );
-            // Reconstruct IssueClassification from cached row
+            // Reconstruct IssueClassification from the cached row. The labels
+            // wshm applied are persisted as suggested_labels, so restore them
+            // for faithful --json/--csv output (we still won't re-apply on a
+            // cache hit — they are already on the issue).
+            let suggested_labels = db.get_wshm_applied_labels(issue.number).unwrap_or_default();
             return Ok(IssueClassification {
                 category: existing.category,
                 confidence: existing.confidence,
                 priority: existing.priority,
                 summary: existing.summary.unwrap_or_default(),
-                suggested_labels: Vec::new(), // not stored in row, but we won't re-apply
+                suggested_labels,
                 is_duplicate_of: None,
                 is_simple_fix: existing.is_simple_fix,
                 relevant_files: Vec::new(),


### PR DESCRIPTION
Promote `develop` → `main` to ship the triage/PR-analysis efficiency work to the Pro `:latest` image (via the `dispatch-pro` → `oss-rebuild` chain).

Includes #90:
- PR content-hash dedup (skip LLM when unchanged), mirroring issue triage.
- Issue cache-hit fidelity (restore `suggested_labels` in JSON/CSV).
- Scheduled batch honors `triage_skip_labels` / `skip_authors` / age (no-triage markers), matching the webhook path.

No DB migration. CI green on the source commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)