### PR TITLE
fix(license): persist JWT to state.db so it survives PVC file truncation

### DIFF
--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -1908,7 +1908,27 @@ fn activate_license(key: &str) -> Result<String, String> {
         .map_err(|e| format!("Invalid response: {e}"))?;
 
     if let Some(token) = body["token"].as_str() {
-        // Cache JWT
+        let plan = body["license"]["type"]
+            .as_str()
+            .unwrap_or("pro")
+            .to_string();
+
+        // Persist to DB first (authoritative store — survives PVC file
+        // truncation that historically wiped license.jwt). Then mirror
+        // to the legacy file path for rétrocompat with operators that
+        // still read it directly.
+        let db_path = dirs::home_dir()
+            .unwrap_or_else(|| std::path::PathBuf::from("."))
+            .join(".wshm")
+            .join("state.db");
+        if let Ok(conn) = crate::db::licenses::open_state_db(&db_path) {
+            if let Err(e) =
+                crate::db::licenses::store(&conn, token, Some(key), Some(&plan), None, None)
+            {
+                tracing::warn!("Failed to persist license to state.db: {e}");
+            }
+        }
+
         let path = dirs::home_dir()
             .unwrap_or_else(|| std::path::PathBuf::from("."))
             .join(".wshm")
@@ -1923,10 +1943,6 @@ fn activate_license(key: &str) -> Result<String, String> {
             let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
         }
 
-        let plan = body["license"]["type"]
-            .as_str()
-            .unwrap_or("pro")
-            .to_string();
         Ok(plan)
     } else {
         Err(body["error"]

--- a/src/db/licenses.rs
+++ b/src/db/licenses.rs
@@ -1,0 +1,188 @@
+//! License JWT persistence in SQLite.
+//!
+//! Single-row table (`licenses` with `CHECK (id = 1)`) so the active
+//! license survives pod restarts and the historical class of bugs where
+//! `~/.wshm/license.jwt` would vanish from the PVC after an interrupted
+//! `fs::write`. The web UI's POST `/api/v1/license/activate` and the CLI
+//! `wshm login --license` both write through this module; readers go
+//! through `crate::license::resolve_*` which checks the DB first.
+
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+use std::path::Path;
+
+/// One row of the `licenses` table (always `id = 1`).
+#[derive(Debug, Clone)]
+pub struct StoredLicense {
+    pub jwt: String,
+    pub license_key: Option<String>,
+    pub plan: Option<String>,
+    pub activated_at: String,
+    pub activated_by: Option<String>,
+    pub expires_at: Option<String>,
+    pub last_validated_at: Option<String>,
+}
+
+/// Upsert the active license. Subsequent activations overwrite the row
+/// in place (single-row table) so callers don't have to delete first.
+pub fn store(
+    conn: &Connection,
+    jwt: &str,
+    license_key: Option<&str>,
+    plan: Option<&str>,
+    activated_by: Option<&str>,
+    expires_at: Option<&str>,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO licenses (id, jwt, license_key, plan, activated_at, activated_by, expires_at, last_validated_at)
+         VALUES (1, ?1, ?2, ?3, datetime('now'), ?4, ?5, datetime('now'))
+         ON CONFLICT(id) DO UPDATE SET
+            jwt               = excluded.jwt,
+            license_key       = COALESCE(excluded.license_key, license_key),
+            plan              = COALESCE(excluded.plan, plan),
+            activated_at      = excluded.activated_at,
+            activated_by      = COALESCE(excluded.activated_by, activated_by),
+            expires_at        = COALESCE(excluded.expires_at, expires_at),
+            last_validated_at = excluded.last_validated_at",
+        params![jwt, license_key, plan, activated_by, expires_at],
+    )
+    .context("Failed to upsert license row")?;
+    Ok(())
+}
+
+pub fn load(conn: &Connection) -> Result<Option<StoredLicense>> {
+    conn.query_row(
+        "SELECT jwt, license_key, plan, activated_at, activated_by, expires_at, last_validated_at
+         FROM licenses WHERE id = 1",
+        [],
+        |row| {
+            Ok(StoredLicense {
+                jwt: row.get(0)?,
+                license_key: row.get(1)?,
+                plan: row.get(2)?,
+                activated_at: row.get(3)?,
+                activated_by: row.get(4)?,
+                expires_at: row.get(5)?,
+                last_validated_at: row.get(6)?,
+            })
+        },
+    )
+    .optional()
+    .context("Failed to load license row")
+}
+
+pub fn load_jwt(conn: &Connection) -> Result<Option<String>> {
+    Ok(load(conn)?.map(|l| l.jwt))
+}
+
+pub fn clear(conn: &Connection) -> Result<()> {
+    conn.execute("DELETE FROM licenses WHERE id = 1", [])
+        .context("Failed to clear license row")?;
+    Ok(())
+}
+
+/// Open `state.db` at the given path, ensuring the licenses table
+/// exists. Used by `crate::license::*` which doesn't have access to the
+/// long-lived `Database` handle (resolve runs at startup before the
+/// daemon's DB pool is built).
+pub fn open_state_db(path: &Path) -> Result<Connection> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let conn = Connection::open(path)
+        .with_context(|| format!("Failed to open state.db at {}", path.display()))?;
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;")?;
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS licenses (
+            id                INTEGER PRIMARY KEY CHECK (id = 1),
+            jwt               TEXT NOT NULL,
+            license_key       TEXT,
+            plan              TEXT,
+            activated_at      TEXT NOT NULL,
+            activated_by      TEXT,
+            expires_at        TEXT,
+            last_validated_at TEXT
+        );",
+    )?;
+    Ok(conn)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE licenses (
+                id                INTEGER PRIMARY KEY CHECK (id = 1),
+                jwt               TEXT NOT NULL,
+                license_key       TEXT,
+                plan              TEXT,
+                activated_at      TEXT NOT NULL,
+                activated_by      TEXT,
+                expires_at        TEXT,
+                last_validated_at TEXT
+            );",
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn store_then_load_roundtrip() {
+        let conn = fresh_conn();
+        store(
+            &conn,
+            "jwt-a",
+            Some("KEY-1"),
+            Some("pro"),
+            Some("alice"),
+            None,
+        )
+        .unwrap();
+        let got = load(&conn).unwrap().unwrap();
+        assert_eq!(got.jwt, "jwt-a");
+        assert_eq!(got.license_key.as_deref(), Some("KEY-1"));
+        assert_eq!(got.plan.as_deref(), Some("pro"));
+        assert_eq!(got.activated_by.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn store_upserts_in_place() {
+        let conn = fresh_conn();
+        store(&conn, "jwt-a", Some("KEY-1"), Some("pro"), None, None).unwrap();
+        store(&conn, "jwt-b", None, None, None, None).unwrap();
+        let got = load(&conn).unwrap().unwrap();
+        assert_eq!(got.jwt, "jwt-b");
+        // COALESCE preserves the previous license_key + plan when new
+        // call passes None — so refresh-only updates don't wipe metadata.
+        assert_eq!(got.license_key.as_deref(), Some("KEY-1"));
+        assert_eq!(got.plan.as_deref(), Some("pro"));
+    }
+
+    #[test]
+    fn clear_removes_row() {
+        let conn = fresh_conn();
+        store(&conn, "jwt-a", None, None, None, None).unwrap();
+        clear(&conn).unwrap();
+        assert!(load(&conn).unwrap().is_none());
+    }
+
+    #[test]
+    fn load_returns_none_when_empty() {
+        let conn = fresh_conn();
+        assert!(load(&conn).unwrap().is_none());
+    }
+
+    #[test]
+    fn check_constraint_blocks_second_row() {
+        let conn = fresh_conn();
+        store(&conn, "jwt-a", None, None, None, None).unwrap();
+        let err = conn.execute(
+            "INSERT INTO licenses (id, jwt, activated_at) VALUES (2, 'x', datetime('now'))",
+            [],
+        );
+        assert!(err.is_err(), "CHECK (id = 1) must reject id=2");
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,6 +1,7 @@
 pub mod backend;
 pub mod events;
 pub mod issues;
+pub mod licenses;
 pub mod pulls;
 pub mod schema;
 pub mod search;

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -122,6 +122,26 @@ pub fn run_migrations(conn: &Connection) -> Result<()> {
         conn.execute_batch("ALTER TABLE pr_analyses ADD COLUMN content_hash TEXT;")?;
     }
 
+    // License storage. Single-row table (CHECK id = 1) so the active
+    // license survives pod restarts and PVC-mounted file truncation —
+    // the previous on-disk `~/.wshm/license.jwt` would silently vanish
+    // when an `fs::write` got interrupted, leaving the daemon unable to
+    // re-activate without operator intervention.
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS licenses (
+            id                INTEGER PRIMARY KEY CHECK (id = 1),
+            jwt               TEXT NOT NULL,
+            license_key       TEXT,
+            plan              TEXT,
+            activated_at      TEXT NOT NULL,
+            activated_by      TEXT,
+            expires_at        TEXT,
+            last_validated_at TEXT
+        );
+        ",
+    )?;
+
     install_search_fts(conn)?;
 
     Ok(())

--- a/src/license.rs
+++ b/src/license.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use crate::config::LicenseConfig;
+use crate::db::licenses as license_store;
 
 const LICENSE_API: &str = "https://api.wshm.dev/api/v1/license";
 
@@ -15,6 +16,38 @@ fn default_token_path() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".wshm")
         .join("license.jwt")
+}
+
+/// Path to the SQLite state.db used by the daemon. The license module
+/// opens its own short-lived `Connection` (not the long-lived `Database`
+/// handle) because resolve runs during startup before the daemon's DB
+/// pool exists.
+fn state_db_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".wshm")
+        .join("state.db")
+}
+
+/// Best-effort read of the active license JWT from the DB. Returns
+/// `None` on any error (missing DB, missing table, missing row) so the
+/// resolve chain falls through cleanly to the next source.
+fn load_jwt_from_db() -> Option<String> {
+    let conn = license_store::open_state_db(&state_db_path()).ok()?;
+    license_store::load_jwt(&conn).ok().flatten()
+}
+
+/// Best-effort persistence to DB. Failures are logged but never
+/// propagated — the file cache is the rétrocompat fallback.
+fn store_jwt_in_db(jwt: &str, key: Option<&str>, plan: Option<&str>) {
+    match license_store::open_state_db(&state_db_path()) {
+        Ok(conn) => {
+            if let Err(e) = license_store::store(&conn, jwt, key, plan, None, None) {
+                tracing::warn!("Failed to persist license to state.db: {e}");
+            }
+        }
+        Err(e) => tracing::warn!("Failed to open state.db for license persistence: {e}"),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -33,14 +66,21 @@ pub enum ResolvedLicense {
 
 /// Resolve the license using the full resolution chain:
 ///
+/// 0. SQLite `licenses` table (active JWT persisted via web UI / CLI activation)
 /// 1. Vault placeholder in config `[license] key = "vault(...)"`
 /// 2. Environment variable `WSHM_LICENSE_KEY`
 /// 3. Config `[license] path = "..."` (JWT file)
-/// 4. Fallback `~/.wshm/license.jwt`
+/// 4. Fallback `~/.wshm/license.jwt` (auto-migrated to DB on first read)
 pub async fn resolve(
     config: &LicenseConfig,
     vault_config: Option<&crate::config::VaultConfig>,
 ) -> ResolvedLicense {
+    // Step 0: DB-backed cache (survives file truncation / PVC quirks)
+    if let Some(jwt) = load_jwt_from_db() {
+        tracing::debug!("License JWT loaded from state.db");
+        return ResolvedLicense::Jwt(jwt);
+    }
+
     // Step 1: Check config key field (may contain vault placeholder)
     if let Some(ref key_value) = config.key {
         let key_value = key_value.trim();
@@ -101,13 +141,16 @@ pub async fn resolve(
         }
     }
 
-    // Step 4: Fallback to default path ~/.wshm/license.jwt
+    // Step 4: Fallback to default path ~/.wshm/license.jwt — auto-migrate
+    // into the DB so subsequent reads hit Step 0 and the file becoming
+    // empty / truncated stops mattering.
     let default_path = default_token_path();
     if default_path.exists() {
         if let Ok(content) = fs::read_to_string(&default_path) {
             let content = content.trim().to_string();
             if !content.is_empty() {
                 tracing::debug!("License JWT loaded from {}", default_path.display());
+                store_jwt_in_db(&content, None, None);
                 return ResolvedLicense::Jwt(content);
             }
         }
@@ -118,6 +161,11 @@ pub async fn resolve(
 
 /// Synchronous version for contexts where async isn't available.
 pub fn resolve_sync(config: &LicenseConfig) -> ResolvedLicense {
+    // Step 0: DB-backed cache
+    if let Some(jwt) = load_jwt_from_db() {
+        return ResolvedLicense::Jwt(jwt);
+    }
+
     // Step 1: Config key (vault not available in sync context — skip)
     if let Some(ref key_value) = config.key {
         let key_value = key_value.trim();
@@ -153,11 +201,12 @@ pub fn resolve_sync(config: &LicenseConfig) -> ResolvedLicense {
         }
     }
 
-    // Step 4: Fallback
+    // Step 4: Fallback (auto-migrates file → DB so next call hits Step 0)
     let default_path = default_token_path();
     if let Ok(content) = fs::read_to_string(&default_path) {
         let content = content.trim().to_string();
         if !content.is_empty() {
+            store_jwt_in_db(&content, None, None);
             return ResolvedLicense::Jwt(content);
         }
     }
@@ -237,8 +286,9 @@ pub fn activate_key(key: &str) -> Result<()> {
         Ok(r) => {
             let body: serde_json::Value = r.into_json().unwrap_or_default();
             if let Some(token) = body["token"].as_str() {
-                cache_token(token)?;
                 let plan = body["license"]["type"].as_str().unwrap_or("pro");
+                cache_token(token)?;
+                store_jwt_in_db(token, Some(key), Some(plan));
                 println!("License activated — plan: {plan}");
                 Ok(())
             } else {


### PR DESCRIPTION
## Summary

- License JWT now persists in `state.db` (single-row `licenses` table with `CHECK (id = 1)`) instead of just `~/.wshm/license.jwt`
- Web UI Settings → License and CLI `wshm login --license` both write through to the DB
- `license::resolve_*` checks the DB first (new Step 0 in the resolution chain) before falling back to vault → env → config path → legacy file
- Legacy file is kept as a write-through mirror for rétrocompat; any existing on-disk license is auto-migrated into the DB on first resolve so upgrading operators don't need to re-activate

## Root cause

On wshm-pro running in K8s (PVC-mounted `~/.wshm`), the file `license.jwt` would silently vanish after an interrupted `fs::write` (e.g. pod eviction mid-cache_token, or an `_ = std::fs::write(...)` whose error is swallowed). The init container's `[ -s license.jwt ]` check then skipped re-seeding because the file existed but was 0-byte, leaving the daemon unable to re-activate. Patrick hit this on prd-rtk-cld-01 and lost access to `wshm plan`, `wshm queue --apply`, and other Pro features.

## Why DB

- Atomic UPSERT vs `fs::write` truncation
- Single source of truth shared by CLI + web UI + daemon
- Survives the same class of file-loss bugs (the file write goes through unchanged for rétrocompat, but the DB row is the authoritative read)
- Future-friendly: wshm-pro's Postgres backend can implement the same `licenses` table without any caller changes

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-targets` clean (no new warnings)
- [x] `cargo test --lib` 58/58 pass, including:
  - `db::licenses::tests::store_then_load_roundtrip`
  - `db::licenses::tests::store_upserts_in_place` (COALESCE preserves metadata)
  - `db::licenses::tests::check_constraint_blocks_second_row`
  - `db::licenses::tests::clear_removes_row`
  - `db::licenses::tests::load_returns_none_when_empty`
  - `db::schema::tests::test_migrations_idempotent` (covers our new table)
- [ ] CI green (will follow)
- [ ] Post-merge: K8s rollout + verify `wshm plan` works without operator re-activation

## Notes

- `src/daemon/web.rs` `activate_license()` inline helper kept (not refactored to call `crate::license::activate_key`) because it must NOT print to stdout in the web context — the existing duplication is intentional. Just added the DB write before the file write so it can't silently fail.
- No schema migration required for existing deployments: `CREATE TABLE IF NOT EXISTS` is idempotent and the auto-migration on first resolve populates the row from the existing file.