### PR TITLE
fix(triage): drop labels from issue hash to break apply-mode re-triage loop

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1454,7 +1454,7 @@ impl RepoFeatures {
 /// Per-action filters (whitelist + blacklist combinable). Empty vector
 /// or `0` numeric = no filter on that dimension. All fields default to
 /// permissive — restrict explicitly when narrower behavior is wanted.
-#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct RepoFilters {
     // ── Global (apply to every action) ────────────────────────────
     #[serde(default)]
@@ -1471,6 +1471,15 @@ pub struct RepoFilters {
     pub triage_skip_labels: Vec<String>,
     #[serde(default)]
     pub triage_max_age_days: u32,
+    /// Labels that, when present on an open issue, force re-triage even
+    /// when the content hash is unchanged. After a successful applied
+    /// triage the bot removes these labels so they don't re-fire forever.
+    #[serde(default = "default_triage_relabel_labels")]
+    pub triage_relabel_labels: Vec<String>,
+    /// Re-triage an open issue that has zero labels if its last triage is
+    /// older than this many hours. `0` disables the trigger.
+    #[serde(default = "default_triage_no_labels_min_age_hours")]
+    pub triage_no_labels_min_age_hours: u32,
 
     // ── Analyze PRs ───────────────────────────────────────────────
     #[serde(default)]
@@ -1493,6 +1502,37 @@ pub struct RepoFilters {
     pub auto_merge_min_approvals: u32,
     #[serde(default)]
     pub auto_merge_max_loc: u32,
+}
+
+fn default_triage_relabel_labels() -> Vec<String> {
+    vec!["wshm:relabel".to_string()]
+}
+
+fn default_triage_no_labels_min_age_hours() -> u32 {
+    24
+}
+
+impl Default for RepoFilters {
+    fn default() -> Self {
+        Self {
+            skip_authors: Vec::new(),
+            target_branches: Vec::new(),
+            skip_drafts: false,
+            triage_only_labels: Vec::new(),
+            triage_skip_labels: Vec::new(),
+            triage_max_age_days: 0,
+            triage_relabel_labels: default_triage_relabel_labels(),
+            triage_no_labels_min_age_hours: default_triage_no_labels_min_age_hours(),
+            analyze_min_loc: 0,
+            analyze_max_loc: 0,
+            auto_pr_only_labels: Vec::new(),
+            auto_pr_target_branch: String::new(),
+            auto_merge_only_authors: Vec::new(),
+            auto_merge_only_labels: Vec::new(),
+            auto_merge_min_approvals: 0,
+            auto_merge_max_loc: 0,
+        }
+    }
 }
 
 impl RepoFilters {

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -21,7 +21,12 @@ pub trait DatabaseBackend: Send + Sync {
     fn get_issue(&self, number: u64) -> Result<Option<Issue>>;
     fn get_open_issues(&self) -> Result<Vec<Issue>>;
     fn get_untriaged_issues(&self) -> Result<Vec<Issue>>;
-    fn get_issues_needing_triage(&self, limit: usize) -> Result<Vec<Issue>>;
+    fn get_issues_needing_triage(
+        &self,
+        limit: usize,
+        relabel_labels: &[String],
+        no_labels_min_age_hours: u32,
+    ) -> Result<Vec<Issue>>;
     fn merge_issue_labels(&self, number: u64, add: &[String], remove: &[String]) -> Result<()>;
 
     // ── Pull Requests ───────────────────────────────────────────
@@ -89,8 +94,13 @@ impl DatabaseBackend for super::Database {
         self.get_untriaged_issues()
     }
 
-    fn get_issues_needing_triage(&self, limit: usize) -> Result<Vec<Issue>> {
-        self.get_issues_needing_triage(limit)
+    fn get_issues_needing_triage(
+        &self,
+        limit: usize,
+        relabel_labels: &[String],
+        no_labels_min_age_hours: u32,
+    ) -> Result<Vec<Issue>> {
+        self.get_issues_needing_triage(limit, relabel_labels, no_labels_min_age_hours)
     }
 
     fn merge_issue_labels(&self, number: u64, add: &[String], remove: &[String]) -> Result<()> {

--- a/src/db/issues.rs
+++ b/src/db/issues.rs
@@ -54,10 +54,18 @@ impl Database {
         self.with_conn(get_untriaged_issues)
     }
 
-    /// Get issues that need triage: either never triaged OR content changed since last triage.
-    /// Returns up to `limit` issues prioritized by reaction count.
-    pub fn get_issues_needing_triage(&self, limit: usize) -> Result<Vec<Issue>> {
-        self.with_conn(|conn| get_issues_needing_triage(conn, limit))
+    /// Get issues that need triage: either never triaged OR content changed since last triage,
+    /// OR carrying a `relabel_labels` marker, OR (zero-label + last triage older than
+    /// `no_labels_min_age_hours`). Returns up to `limit` issues prioritized by reaction count.
+    pub fn get_issues_needing_triage(
+        &self,
+        limit: usize,
+        relabel_labels: &[String],
+        no_labels_min_age_hours: u32,
+    ) -> Result<Vec<Issue>> {
+        self.with_conn(|conn| {
+            get_issues_needing_triage(conn, limit, relabel_labels, no_labels_min_age_hours)
+        })
     }
 
     /// Merge new labels into the issue's existing labels in the DB cache (additive, no overwrite).
@@ -182,15 +190,24 @@ pub fn get_untriaged_issues(conn: &Connection) -> Result<Vec<Issue>> {
     Ok(issues)
 }
 
-/// Get issues that need triage: either never triaged OR content changed since last triage.
+/// Get issues that need triage. An open issue qualifies if any of:
+///   * never triaged (no stored content_hash),
+///   * its content_hash differs from the freshly recomputed one,
+///   * it carries one of `relabel_labels` (case-insensitive),
+///   * it has zero labels AND its last triage is older than
+///     `no_labels_min_age_hours` (0 disables this trigger).
 /// Returns up to `limit` issues prioritized by reaction count, then issue number.
-pub fn get_issues_needing_triage(conn: &Connection, limit: usize) -> Result<Vec<Issue>> {
+pub fn get_issues_needing_triage(
+    conn: &Connection,
+    limit: usize,
+    relabel_labels: &[String],
+    no_labels_min_age_hours: u32,
+) -> Result<Vec<Issue>> {
     use crate::db::schema::compute_issue_hash;
 
-    // First, get all open issues with their triage status
     let mut stmt = conn.prepare(
         "SELECT i.number, i.title, i.body, i.state, i.labels, i.author, i.created_at, i.updated_at, i.reactions_plus1, i.reactions_total,
-                t.content_hash
+                t.content_hash, t.acted_at
          FROM issues i
          LEFT JOIN triage_results t ON i.number = t.issue_number
          WHERE i.state = 'open'
@@ -212,19 +229,41 @@ pub fn get_issues_needing_triage(conn: &Connection, limit: usize) -> Result<Vec<
             reactions_total: row.get(9)?,
         };
         let stored_hash: Option<String> = row.get(10)?;
-        Ok((issue, stored_hash))
+        let acted_at: Option<String> = row.get(11)?;
+        Ok((issue, stored_hash, acted_at))
     })?;
+
+    let now = chrono::Utc::now();
+    let age_cutoff = if no_labels_min_age_hours > 0 {
+        Some(now - chrono::Duration::hours(no_labels_min_age_hours as i64))
+    } else {
+        None
+    };
 
     for row in rows {
         if issues_needing_triage.len() >= limit {
             break;
         }
 
-        let (issue, stored_hash) = row?;
-        let current_hash = compute_issue_hash(&issue.title, issue.body.as_deref(), &issue.labels);
+        let (issue, stored_hash, acted_at) = row?;
+        let current_hash = compute_issue_hash(&issue.title, issue.body.as_deref());
 
-        // Need triage if: never triaged (NULL hash) OR content changed (hash mismatch)
-        if stored_hash.is_none() || stored_hash.as_deref() != Some(current_hash.as_str()) {
+        let needs_triage = stored_hash.is_none()
+            || stored_hash.as_deref() != Some(current_hash.as_str())
+            || (!relabel_labels.is_empty()
+                && issue
+                    .labels
+                    .iter()
+                    .any(|l| relabel_labels.iter().any(|r| r.eq_ignore_ascii_case(l))))
+            || (age_cutoff.is_some()
+                && issue.labels.is_empty()
+                && acted_at
+                    .as_deref()
+                    .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                    .map(|dt| dt.with_timezone(&chrono::Utc) < age_cutoff.unwrap())
+                    .unwrap_or(false));
+
+        if needs_triage {
             issues_needing_triage.push(issue);
         }
     }
@@ -287,9 +326,34 @@ mod tests {
         assert_eq!(untriaged.len(), 1);
     }
 
+    fn test_classification() -> crate::ai::schemas::IssueClassification {
+        crate::ai::schemas::IssueClassification {
+            category: "bug".to_string(),
+            confidence: 0.9,
+            priority: Some("high".to_string()),
+            summary: "Test summary".to_string(),
+            suggested_labels: vec![],
+            is_duplicate_of: None,
+            is_simple_fix: false,
+            relevant_files: vec![],
+        }
+    }
+
+    /// Overwrite `acted_at` for an existing triage row (the public upsert
+    /// stamps `now()`, but the relabel/age triggers need historic timestamps).
+    fn force_acted_at(db: &Database, issue_number: u64, acted_at: &str) {
+        db.with_conn(|conn| {
+            conn.execute(
+                "UPDATE triage_results SET acted_at = ?1 WHERE issue_number = ?2",
+                params![acted_at, issue_number],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+    }
+
     #[test]
     fn test_get_issues_needing_triage() {
-        use crate::ai::schemas::IssueClassification;
         use crate::db::schema::compute_issue_hash;
 
         let db = Database::open_memory().unwrap();
@@ -304,17 +368,8 @@ mod tests {
         issue2.number = 2;
         issue2.title = "Already triaged".to_string();
         db.upsert_issue(&issue2).unwrap();
-        let classification = IssueClassification {
-            category: "bug".to_string(),
-            confidence: 0.9,
-            priority: Some("high".to_string()),
-            summary: "Test summary".to_string(),
-            suggested_labels: vec![],
-            is_duplicate_of: None,
-            is_simple_fix: false,
-            relevant_files: vec![],
-        };
-        let hash2 = compute_issue_hash(&issue2.title, issue2.body.as_deref(), &issue2.labels);
+        let classification = test_classification();
+        let hash2 = compute_issue_hash(&issue2.title, issue2.body.as_deref());
         db.upsert_triage_result_with_hash(&classification, 2, Some(&hash2))
             .unwrap();
 
@@ -323,7 +378,7 @@ mod tests {
         issue3.number = 3;
         issue3.title = "Content changed".to_string();
         db.upsert_issue(&issue3).unwrap();
-        let hash3_old = compute_issue_hash(&issue3.title, issue3.body.as_deref(), &issue3.labels);
+        let hash3_old = compute_issue_hash(&issue3.title, issue3.body.as_deref());
         db.upsert_triage_result_with_hash(&classification, 3, Some(&hash3_old))
             .unwrap();
 
@@ -331,7 +386,7 @@ mod tests {
         issue3.title = "Content changed - UPDATED".to_string();
         db.upsert_issue(&issue3).unwrap();
 
-        let needing_triage = db.get_issues_needing_triage(10).unwrap();
+        let needing_triage = db.get_issues_needing_triage(10, &[], 0).unwrap();
 
         // Should return issue 1 (never triaged) and issue 3 (content changed)
         assert_eq!(needing_triage.len(), 2);
@@ -339,5 +394,83 @@ mod tests {
         assert!(numbers.contains(&1));
         assert!(numbers.contains(&3));
         assert!(!numbers.contains(&2)); // Issue 2 unchanged, should not be returned
+    }
+
+    #[test]
+    fn test_relabel_label_forces_retriage() {
+        use crate::db::schema::compute_issue_hash;
+
+        let db = Database::open_memory().unwrap();
+
+        // Issue triaged, content unchanged, but carries the relabel marker.
+        let mut issue = test_issue();
+        issue.number = 42;
+        issue.labels = vec!["bug".to_string(), "wshm:relabel".to_string()];
+        db.upsert_issue(&issue).unwrap();
+        let hash = compute_issue_hash(&issue.title, issue.body.as_deref());
+        db.upsert_triage_result_with_hash(&test_classification(), 42, Some(&hash))
+            .unwrap();
+
+        let relabel = vec!["wshm:relabel".to_string()];
+
+        // Without the relabel list, the issue would be skipped (hash matches).
+        let none = db.get_issues_needing_triage(10, &[], 0).unwrap();
+        assert!(!none.iter().any(|i| i.number == 42));
+
+        // With the relabel list, the issue is forced back into the batch.
+        let forced = db.get_issues_needing_triage(10, &relabel, 0).unwrap();
+        assert!(forced.iter().any(|i| i.number == 42));
+
+        // Case-insensitive match.
+        let forced_ci = db
+            .get_issues_needing_triage(10, &["WSHM:Relabel".to_string()], 0)
+            .unwrap();
+        assert!(forced_ci.iter().any(|i| i.number == 42));
+    }
+
+    #[test]
+    fn test_no_labels_triggers_retriage_after_age() {
+        use crate::db::schema::compute_issue_hash;
+
+        let db = Database::open_memory().unwrap();
+
+        // Issue triaged, content unchanged, zero labels — the no-labels
+        // trigger should pick it up once acted_at is older than the cap.
+        let mut issue = test_issue();
+        issue.number = 7;
+        issue.labels = vec![]; // zero labels
+        db.upsert_issue(&issue).unwrap();
+        let hash = compute_issue_hash(&issue.title, issue.body.as_deref());
+        db.upsert_triage_result_with_hash(&test_classification(), 7, Some(&hash))
+            .unwrap();
+
+        // Case A: acted_at = now - 25h → triggers when min_age = 24.
+        let old = (chrono::Utc::now() - chrono::Duration::hours(25)).to_rfc3339();
+        force_acted_at(&db, 7, &old);
+        let triggered = db.get_issues_needing_triage(10, &[], 24).unwrap();
+        assert!(
+            triggered.iter().any(|i| i.number == 7),
+            "expected zero-label issue to re-trigger after 25h, got {:?}",
+            triggered.iter().map(|i| i.number).collect::<Vec<_>>()
+        );
+
+        // Case B: acted_at = now - 1h → does NOT trigger.
+        let recent = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+        force_acted_at(&db, 7, &recent);
+        let not_triggered = db.get_issues_needing_triage(10, &[], 24).unwrap();
+        assert!(!not_triggered.iter().any(|i| i.number == 7));
+
+        // Case C: min_age = 0 disables the trigger even when old.
+        force_acted_at(&db, 7, &old);
+        let disabled = db.get_issues_needing_triage(10, &[], 0).unwrap();
+        assert!(!disabled.iter().any(|i| i.number == 7));
+
+        // Case D: same old timestamp but the issue has labels → not triggered.
+        let mut labelled = issue.clone();
+        labelled.labels = vec!["bug".to_string()];
+        db.upsert_issue(&labelled).unwrap();
+        force_acted_at(&db, 7, &old);
+        let labelled_skip = db.get_issues_needing_triage(10, &[], 24).unwrap();
+        assert!(!labelled_skip.iter().any(|i| i.number == 7));
     }
 }

--- a/src/db/issues.rs
+++ b/src/db/issues.rs
@@ -196,6 +196,7 @@ pub fn get_untriaged_issues(conn: &Connection) -> Result<Vec<Issue>> {
 ///   * it carries one of `relabel_labels` (case-insensitive),
 ///   * it has zero labels AND its last triage is older than
 ///     `no_labels_min_age_hours` (0 disables this trigger).
+///
 /// Returns up to `limit` issues prioritized by reaction count, then issue number.
 pub fn get_issues_needing_triage(
     conn: &Connection,

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -122,6 +122,44 @@ pub fn run_migrations(conn: &Connection) -> Result<()> {
         conn.execute_batch("ALTER TABLE pr_analyses ADD COLUMN content_hash TEXT;")?;
     }
 
+    // One-shot migration: recompute every existing triage_results.content_hash
+    // with the new label-free formula. Without this, an upgrading pod would
+    // see hash mismatches on every previously-triaged issue and burn AI
+    // credits re-triaging them all on first boot.
+    let triage_hash_v2_done: bool = conn
+        .query_row(
+            "SELECT 1 FROM sync_log WHERE table_name = '__triage_hash_v2_migrated'",
+            [],
+            |_| Ok(()),
+        )
+        .is_ok();
+    if !triage_hash_v2_done {
+        let tx = conn.unchecked_transaction()?;
+        {
+            let mut select = tx.prepare(
+                "SELECT t.issue_number, i.title, i.body
+                 FROM triage_results t JOIN issues i ON t.issue_number = i.number
+                 WHERE t.content_hash IS NOT NULL",
+            )?;
+            let rows: Vec<(i64, String, Option<String>)> = select
+                .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            let mut update = tx.prepare(
+                "UPDATE triage_results SET content_hash = ?1 WHERE issue_number = ?2",
+            )?;
+            for (issue_number, title, body) in rows {
+                let new_hash = compute_issue_hash(&title, body.as_deref());
+                update.execute(rusqlite::params![new_hash, issue_number])?;
+            }
+        }
+        tx.execute(
+            "INSERT INTO sync_log (table_name, last_synced_at, etag)
+             VALUES ('__triage_hash_v2_migrated', CURRENT_TIMESTAMP, NULL)",
+            [],
+        )?;
+        tx.commit()?;
+    }
+
     // License storage. Single-row table (CHECK id = 1) so the active
     // license survives pod restarts and PVC-mounted file truncation —
     // the previous on-disk `~/.wshm/license.jwt` would silently vanish
@@ -291,21 +329,17 @@ fn install_search_fts(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
-/// Compute a stable content hash for an issue (title + body + sorted labels).
-/// Used to skip LLM re-analysis when content hasn't changed.
-pub fn compute_issue_hash(title: &str, body: Option<&str>, labels: &[String]) -> String {
+/// Compute a stable content hash for an issue (title + body only).
+///
+/// Labels are intentionally excluded: when the bot applies labels itself
+/// it would otherwise see a hash mismatch on the next cycle and re-triage
+/// the same issue forever (see `__triage_hash_v2_migrated` migration).
+pub fn compute_issue_hash(title: &str, body: Option<&str>) -> String {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(title.as_bytes());
     hasher.update(b"\n");
     hasher.update(body.unwrap_or("").as_bytes());
-    hasher.update(b"\n");
-    let mut sorted_labels: Vec<&String> = labels.iter().collect();
-    sorted_labels.sort();
-    for label in sorted_labels {
-        hasher.update(label.as_bytes());
-        hasher.update(b",");
-    }
     format!("{:x}", hasher.finalize())
 }
 
@@ -343,5 +377,57 @@ mod tests {
         conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
         run_migrations(&conn).unwrap();
         run_migrations(&conn).unwrap(); // should not fail
+    }
+
+    #[test]
+    fn test_compute_issue_hash_ignores_labels() {
+        let h1 = compute_issue_hash("title", Some("body"));
+        let h2 = compute_issue_hash("title", Some("body"));
+        assert_eq!(h1, h2);
+        // The hash is now independent of any caller-side label set — the
+        // function no longer accepts labels at all, so this test simply
+        // pins the stability of the new (title, body) signature.
+        let h3 = compute_issue_hash("title", Some("different"));
+        assert_ne!(h1, h3);
+    }
+
+    #[test]
+    fn test_triage_hash_v2_migration_recomputes_existing() {
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+
+        // Seed an issue and a triage row whose content_hash was computed
+        // with the OLD (title+body+labels) formula — simulate by inserting
+        // an arbitrary placeholder.
+        conn.execute(
+            "INSERT INTO issues (number, title, body, state, labels, created_at, updated_at)
+             VALUES (1, 't', 'b', 'open', '[\"bug\"]', '2026-01-01', '2026-01-01')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO triage_results (issue_number, category, confidence, acted_at, content_hash)
+             VALUES (1, 'bug', 0.9, '2026-01-01', 'OLD_HASH_PLACEHOLDER')",
+            [],
+        )
+        .unwrap();
+
+        // Clear the sentinel so the migration runs again on next call.
+        conn.execute(
+            "DELETE FROM sync_log WHERE table_name = '__triage_hash_v2_migrated'",
+            [],
+        )
+        .unwrap();
+
+        run_migrations(&conn).unwrap();
+
+        let stored: String = conn
+            .query_row(
+                "SELECT content_hash FROM triage_results WHERE issue_number = 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, compute_issue_hash("t", Some("b")));
     }
 }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -144,9 +144,8 @@ pub fn run_migrations(conn: &Connection) -> Result<()> {
             let rows: Vec<(i64, String, Option<String>)> = select
                 .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
-            let mut update = tx.prepare(
-                "UPDATE triage_results SET content_hash = ?1 WHERE issue_number = ?2",
-            )?;
+            let mut update =
+                tx.prepare("UPDATE triage_results SET content_hash = ?1 WHERE issue_number = ?2")?;
             for (issue_number, title, body) in rows {
                 let new_hash = compute_issue_hash(&title, body.as_deref());
                 update.execute(rusqlite::params![new_hash, issue_number])?;

--- a/src/pipelines/triage.rs
+++ b/src/pipelines/triage.rs
@@ -97,9 +97,14 @@ pub async fn run_with_filters(
         }
         issues
     } else {
-        // Get issues needing triage (never triaged OR content changed)
-        // Process in batches of 20 to avoid overwhelming the LLM API
-        db.get_issues_needing_triage(20)?
+        // Get issues needing triage (never triaged OR content changed OR
+        // carrying a force-relabel marker OR zero-label + stale).
+        // Process in batches of 20 to avoid overwhelming the LLM API.
+        db.get_issues_needing_triage(
+            20,
+            &relabel_labels_from(filters),
+            no_labels_min_age_from(filters),
+        )?
     };
 
     if issues.is_empty() {
@@ -173,6 +178,45 @@ pub async fn run_with_filters(
                 if !json {
                     print_classification(issue, &classification, args.apply);
                 }
+                // After a successful applied triage, strip the force-relabel
+                // markers so the next batch doesn't re-trigger on this issue
+                // forever.
+                if args.apply {
+                    let relabel = relabel_labels_from(filters);
+                    if !relabel.is_empty() {
+                        let to_strip: Vec<String> = issue
+                            .labels
+                            .iter()
+                            .filter(|l| {
+                                relabel.iter().any(|r| r.eq_ignore_ascii_case(l))
+                            })
+                            .cloned()
+                            .collect();
+                        for label in &to_strip {
+                            if let Err(e) = gh.remove_label(issue.number, label).await {
+                                tracing::warn!(
+                                    "Failed to remove relabel marker '{label}' from #{}: {e}",
+                                    issue.number
+                                );
+                            } else {
+                                info!(
+                                    "Removed relabel marker '{label}' from issue #{}",
+                                    issue.number
+                                );
+                            }
+                        }
+                        if !to_strip.is_empty() {
+                            if let Err(e) =
+                                db.merge_issue_labels(issue.number, &[], &to_strip)
+                            {
+                                tracing::warn!(
+                                    "Failed to update local labels for #{} after relabel cleanup: {e}",
+                                    issue.number
+                                );
+                            }
+                        }
+                    }
+                }
                 results.push(TriageOutput {
                     issue_number: issue.number,
                     title: issue.title.clone(),
@@ -226,6 +270,16 @@ pub async fn run_with_filters(
     Ok(())
 }
 
+fn relabel_labels_from(filters: Option<&crate::config::RepoFilters>) -> Vec<String> {
+    filters
+        .map(|f| f.triage_relabel_labels.clone())
+        .unwrap_or_default()
+}
+
+fn no_labels_min_age_from(filters: Option<&crate::config::RepoFilters>) -> u32 {
+    filters.map(|f| f.triage_no_labels_min_age_hours).unwrap_or(0)
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn triage_issue(
     config: &Config,
@@ -240,7 +294,7 @@ async fn triage_issue(
 ) -> Result<IssueClassification> {
     // Content hash cache: skip LLM call if content hasn't changed since last triage
     let content_hash =
-        crate::db::schema::compute_issue_hash(&issue.title, issue.body.as_deref(), &issue.labels);
+        crate::db::schema::compute_issue_hash(&issue.title, issue.body.as_deref());
 
     if let Ok(Some(existing)) = db.get_triage_result(issue.number) {
         if existing.content_hash.as_deref() == Some(content_hash.as_str()) {

--- a/src/pipelines/triage.rs
+++ b/src/pipelines/triage.rs
@@ -187,9 +187,7 @@ pub async fn run_with_filters(
                         let to_strip: Vec<String> = issue
                             .labels
                             .iter()
-                            .filter(|l| {
-                                relabel.iter().any(|r| r.eq_ignore_ascii_case(l))
-                            })
+                            .filter(|l| relabel.iter().any(|r| r.eq_ignore_ascii_case(l)))
                             .cloned()
                             .collect();
                         for label in &to_strip {
@@ -206,9 +204,7 @@ pub async fn run_with_filters(
                             }
                         }
                         if !to_strip.is_empty() {
-                            if let Err(e) =
-                                db.merge_issue_labels(issue.number, &[], &to_strip)
-                            {
+                            if let Err(e) = db.merge_issue_labels(issue.number, &[], &to_strip) {
                                 tracing::warn!(
                                     "Failed to update local labels for #{} after relabel cleanup: {e}",
                                     issue.number
@@ -277,7 +273,9 @@ fn relabel_labels_from(filters: Option<&crate::config::RepoFilters>) -> Vec<Stri
 }
 
 fn no_labels_min_age_from(filters: Option<&crate::config::RepoFilters>) -> u32 {
-    filters.map(|f| f.triage_no_labels_min_age_hours).unwrap_or(0)
+    filters
+        .map(|f| f.triage_no_labels_min_age_hours)
+        .unwrap_or(0)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -293,8 +291,7 @@ async fn triage_issue(
     exporter: Option<&ExportManager>,
 ) -> Result<IssueClassification> {
     // Content hash cache: skip LLM call if content hasn't changed since last triage
-    let content_hash =
-        crate::db::schema::compute_issue_hash(&issue.title, issue.body.as_deref());
+    let content_hash = crate::db::schema::compute_issue_hash(&issue.title, issue.body.as_deref());
 
     if let Ok(Some(existing)) = db.get_triage_result(issue.number) {
         if existing.content_hash.as_deref() == Some(content_hash.as_str()) {


### PR DESCRIPTION
## The bug

Observed on the live wshm-pro pod tonight: with `apply=true` the
scheduled triage batch kept re-processing the same 20 most-popular
issues every ~3 min cycle, burning Claude API quota and never advancing
to the rest of the backlog (529 issues still untriaged after dozens
of cycles).

**Root cause** — `compute_issue_hash` (src/db/schema.rs) hashed
`title + body + labels`. After each successful triage the bot wrote
new labels back to the local `issues` table via `merge_issue_labels`.
The next cycle recomputed the hash with the just-added labels, saw a
mismatch vs the stored `triage_results.content_hash`, and re-triaged.

Commit ff01278 fixed the *dry-run* variant of this loop; the
apply=true variant remained.

## Changes

1. **`compute_issue_hash` drops the `labels` parameter** — hash is now
   `(title, body)` only. Label changes (by the bot or by humans) no
   longer trigger re-triage.

2. **One-shot DB migration** `__triage_hash_v2_migrated` recomputes
   every existing `triage_results.content_hash` with the new formula
   in a single transaction, so upgrading pods don't re-triage the
   entire backlog on first boot.

3. **Two opt-in retriage triggers** replace what labels-in-hash gave
   accidentally:
   - `triage_relabel_labels` (default `["wshm:relabel"]`) — humans can
     force a re-triage by adding the marker label; the bot strips the
     marker after a successful applied triage so it doesn't re-fire
     forever.
   - `triage_no_labels_min_age_hours` (default `24`) — re-triage an
     open issue that has zero labels if its last triage is older than
     N hours. Setting `0` disables the trigger.

## Tests

- `test_compute_issue_hash_ignores_labels` pins the new 2-arg signature
- `test_triage_hash_v2_migration_recomputes_existing` covers the
  one-shot migration
- `test_relabel_label_forces_retriage` (case-insensitive)
- `test_no_labels_triggers_retriage_after_age` — 4 sub-cases
- existing `test_get_issues_needing_triage` updated

`cargo check --all-targets` clean, `cargo test --lib` 62/62 pass.

## Manual repro

The loop is visible in `wshm-pro` namespace logs filtered for
`Triaging issue #401`: the same issue numbers (`#401`, `#1975`,
`#1516`, ...) appear at every batch interval after first apply.
Toggling `apply=false` stops the loop because the dry-run guard
(ff01278) already skips the batch in that mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)