### PR TITLE
feat(storage): runtime backend selection via DatabaseBackend trait

### DIFF
--- a/src/daemon/commands.rs
+++ b/src/daemon/commands.rs
@@ -18,7 +18,6 @@ use tracing::info;
 
 use crate::cli::{PrArgs, TriageArgs};
 use crate::config::Config;
-use crate::db::Database;
 use crate::github::sync as gh_sync;
 use crate::github::Client as GhClient;
 use crate::pipelines;
@@ -132,7 +131,7 @@ pub async fn execute(
     number: u64,
     is_pr: bool,
     config: &Config,
-    db: &Database,
+    db: &dyn crate::db::backend::DatabaseBackend,
     gh: &GhClient,
     apply: bool,
     triggered_by: Option<&str>,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -20,13 +20,14 @@ use tracing::{info, warn};
 
 use crate::cli::DaemonArgs;
 use crate::config::{Config, GlobalConfig};
+use crate::db::backend::DatabaseBackend;
 use crate::db::Database;
 use crate::github::Client as GhClient;
 
 use self::processor::WebhookEvent;
 
 pub struct DaemonState {
-    pub db: Arc<Database>,
+    pub db: Arc<dyn DatabaseBackend>,
     /// Hot-reloadable GitHub client. The inner Arc is swapped under a
     /// RwLock when a `github_token` secret is added or removed via the
     /// web UI, so the new token is picked up without a daemon restart.
@@ -47,7 +48,7 @@ pub struct DaemonState {
 }
 
 impl DaemonState {
-    pub fn new(db: Arc<Database>, gh: Arc<GhClient>, config: Arc<Config>, apply: bool) -> Self {
+    pub fn new(db: Arc<dyn DatabaseBackend>, gh: Arc<GhClient>, config: Arc<Config>, apply: bool) -> Self {
         // Legacy `apply: true` upgrades the triage/analyze/auto_pr trio so
         // existing setups keep behaving the same after this migration.
         let mut features = crate::config::RepoFeatures::default();
@@ -56,7 +57,7 @@ impl DaemonState {
     }
 
     pub fn with_features(
-        db: Arc<Database>,
+        db: Arc<dyn DatabaseBackend>,
         gh: Arc<GhClient>,
         config: Arc<Config>,
         apply: bool,
@@ -199,7 +200,7 @@ impl MultiDaemonState {
         std::fs::create_dir_all(&config.wshm_dir)?;
         config.web.resolve_password(&config.wshm_dir);
 
-        let db = Arc::new(Database::open(&config)?);
+        let db = Arc::new(Database::open(&config)?) as Arc<dyn DatabaseBackend>;
         let gh = Arc::new(GhClient::new(&config)?);
         let state = Arc::new(DaemonState::new(
             db,
@@ -271,7 +272,7 @@ pub async fn run(mut config: Config, args: DaemonArgs) -> Result<()> {
             config.daemon.webhook_secret.clone()
         });
 
-    let db = Arc::new(Database::open(&config)?);
+    let db = Arc::new(Database::open(&config)?) as Arc<dyn DatabaseBackend>;
     let gh = Arc::new(GhClient::new(&config)?);
     let config = Arc::new(config);
 
@@ -510,7 +511,7 @@ pub async fn run_multi_with_extensions(
             web_password_resolved = true;
         }
 
-        let db = Arc::new(Database::open(&config)?);
+        let db = Arc::new(Database::open(&config)?) as Arc<dyn DatabaseBackend>;
         let gh = Arc::new(GhClient::new(&config)?);
         let apply = entry.apply.unwrap_or(global_apply);
 

--- a/src/daemon/processor.rs
+++ b/src/daemon/processor.rs
@@ -211,7 +211,7 @@ async fn handle_issue(state: &DaemonState, event: &WebhookEvent) -> anyhow::Resu
         return Ok(());
     }
     // Force sync issues (bypass throttle — we know there's a new event)
-    gh_sync::sync_issues_now(&state.gh(), &state.db).await?;
+    gh_sync::sync_issues_now(&state.gh(), state.db.as_ref()).await?;
 
     // The list endpoint lags issue creation by a few seconds (replicated
     // index), so a sync right after `issues.opened` can miss the brand-new
@@ -286,7 +286,7 @@ async fn handle_issue(state: &DaemonState, event: &WebhookEvent) -> anyhow::Resu
 
     pipelines::triage::run(
         &state.config,
-        &state.db,
+        state.db.as_ref(),
         &state.gh(),
         &args,
         pipelines::triage::OutputFormat::Text,
@@ -354,7 +354,7 @@ async fn handle_pull_request(state: &DaemonState, event: &WebhookEvent) -> anyho
         return Ok(());
     }
     // Force sync pulls (bypass throttle — we know there's a new event)
-    gh_sync::sync_pulls_now(&state.gh(), &state.db).await?;
+    gh_sync::sync_pulls_now(&state.gh(), state.db.as_ref()).await?;
 
     // The list endpoint lags PR creation by a few seconds (replicated index),
     // so a sync right after `pull_request.opened` can miss the brand-new PR,
@@ -419,7 +419,7 @@ async fn handle_pull_request(state: &DaemonState, event: &WebhookEvent) -> anyho
         apply: state.apply(),
     };
 
-    pipelines::pr_analysis::run(&state.config, &state.db, &state.gh(), &args, false, None).await?;
+    pipelines::pr_analysis::run(&state.config, state.db.as_ref(), &state.gh(), &args, false, None).await?;
 
     // Store in ICM if enabled
     if state.config.daemon.icm_enabled {
@@ -494,7 +494,7 @@ async fn handle_comment(state: &DaemonState, event: &WebhookEvent) -> anyhow::Re
         number,
         is_pr,
         &state.config,
-        &state.db,
+        state.db.as_ref(),
         &state.gh(),
         state.apply(),
         Some(triggered_by),

--- a/src/daemon/scheduler.rs
+++ b/src/daemon/scheduler.rs
@@ -87,7 +87,7 @@ pub async fn run(state: Arc<DaemonState>) {
             continue;
         }
         info!("Periodic sync triggered (incremental)");
-        match github::sync::incremental_sync_full(&state.gh(), &state.db).await {
+        match github::sync::incremental_sync_full(&state.gh(), state.db.as_ref()).await {
             Ok(_) => {
                 info!("Periodic sync complete");
 
@@ -138,7 +138,7 @@ pub async fn run(state: Arc<DaemonState>) {
 
             match pipelines::triage::run_with_filters(
                 &state.config,
-                &state.db,
+                state.db.as_ref(),
                 &state.gh(),
                 &args,
                 pipelines::triage::OutputFormat::Text,
@@ -190,7 +190,7 @@ pub async fn run(state: Arc<DaemonState>) {
 
             match pipelines::triage::run_with_filters(
                 &state.config,
-                &state.db,
+                state.db.as_ref(),
                 &state.gh(),
                 &args,
                 pipelines::triage::OutputFormat::Text,

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -1431,25 +1431,19 @@ async fn api_changelog(
             }
         }
 
-        let closed_prs = ds.db.with_conn(|conn| {
-            let mut stmt = conn.prepare(
-                "SELECT number, title, labels, author, updated_at
-                 FROM pull_requests WHERE state = 'closed'
-                 ORDER BY updated_at DESC LIMIT 100",
-            )?;
-            let rows = stmt
-                .query_map([], |row| {
-                    let labels_str: String = row.get(2)?;
-                    Ok(json!({
-                        "number": row.get::<_, u64>(0)?,
-                        "title": row.get::<_, String>(1)?,
-                        "labels": serde_json::from_str::<Vec<String>>(&labels_str).unwrap_or_default(),
-                        "author": row.get::<_, Option<String>>(3)?,
-                        "merged_at": row.get::<_, String>(4)?,
-                    }))
-                })?
-                .collect::<Result<Vec<_>, _>>()?;
-            Ok(rows)
+        let closed_prs = ds.db.get_closed_pulls(100).map(|pulls| {
+            pulls
+                .into_iter()
+                .map(|pr| {
+                    json!({
+                        "number": pr.number,
+                        "title": pr.title,
+                        "labels": pr.labels,
+                        "author": pr.author,
+                        "merged_at": pr.updated_at,
+                    })
+                })
+                .collect::<Vec<_>>()
         });
 
         if let Ok(prs) = closed_prs {
@@ -1701,9 +1695,9 @@ async fn run_sync(state: &WebState, repo_filter: Option<&str>, full: bool) -> Re
     let mut errors = Vec::new();
     for (slug, daemon) in targets {
         let result = if full {
-            crate::github::sync::full_sync(&daemon.gh(), &daemon.db).await
+            crate::github::sync::full_sync(&daemon.gh(), daemon.db.as_ref()).await
         } else {
-            crate::github::sync::incremental_sync_full(&daemon.gh(), &daemon.db).await
+            crate::github::sync::incremental_sync_full(&daemon.gh(), daemon.db.as_ref()).await
         };
         match result {
             Ok(()) => synced.push(slug),

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -37,6 +37,10 @@ pub trait DatabaseBackend: Send + Sync {
     fn get_open_pulls(&self) -> Result<Vec<PullRequest>>;
     fn get_unanalyzed_pulls(&self) -> Result<Vec<PullRequest>>;
     fn get_pr_analysis(&self, pr_number: u64) -> Result<Option<PrAnalysisRow>>;
+    /// Recently-closed pull requests (highest `updated_at` first), capped
+    /// at `limit`. Backs the changelog view in TUI and the /api/v1/changelog
+    /// endpoint.
+    fn get_closed_pulls(&self, limit: usize) -> Result<Vec<PullRequest>>;
 
     // ── Triage ──────────────────────────────────────────────────
 
@@ -153,6 +157,10 @@ impl DatabaseBackend for super::Database {
 
     fn get_pr_analysis(&self, pr_number: u64) -> Result<Option<PrAnalysisRow>> {
         self.get_pr_analysis(pr_number)
+    }
+
+    fn get_closed_pulls(&self, limit: usize) -> Result<Vec<PullRequest>> {
+        self.get_closed_pulls(limit)
     }
 
     fn upsert_triage_result(&self, result: &IssueClassification, issue_number: u64) -> Result<()> {

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -41,11 +41,35 @@ pub trait DatabaseBackend: Send + Sync {
     // ── Triage ──────────────────────────────────────────────────
 
     fn upsert_triage_result(&self, result: &IssueClassification, issue_number: u64) -> Result<()>;
+    /// Same as `upsert_triage_result` but also persists the content hash so
+    /// the next batch can detect whether the issue changed and skip re-spending
+    /// AI credits.
+    fn upsert_triage_result_with_hash(
+        &self,
+        result: &IssueClassification,
+        issue_number: u64,
+        content_hash: Option<&str>,
+    ) -> Result<()>;
     fn get_triage_result(&self, issue_number: u64) -> Result<Option<TriageResultRow>>;
     fn get_stale_triage_results(&self, max_age_hours: u32) -> Result<Vec<TriageResultRow>>;
     fn get_wshm_applied_labels(&self, issue_number: u64) -> Result<Vec<String>>;
     fn recent_activity(&self, limit: usize) -> Result<Vec<TriageResultRow>>;
     fn is_triaged(&self, issue_number: u64) -> Result<bool>;
+
+    // ── PR analysis ─────────────────────────────────────────────
+
+    /// Open PRs that need (re)analysis: never analyzed OR content_hash changed.
+    fn get_pulls_needing_analysis(&self) -> Result<Vec<PullRequest>>;
+    /// Upsert one row into `pr_analyses`. Replaces the previous inline
+    /// `with_conn(|conn| INSERT ... ON CONFLICT ...)` so callers can run
+    /// against any backend that implements this trait.
+    fn upsert_pr_analysis(&self, row: &PrAnalysisRow) -> Result<()>;
+
+    // ── Admin / maintenance ─────────────────────────────────────
+
+    /// Wipe every triage result and PR analysis. Used by the `revert` flow
+    /// to undo all wshm-applied state before re-syncing from the forge.
+    fn clear_triage_and_analyses(&self) -> Result<()>;
 
     // ── Sync Log ────────────────────────────────────────────────
 
@@ -135,6 +159,15 @@ impl DatabaseBackend for super::Database {
         self.upsert_triage_result(result, issue_number)
     }
 
+    fn upsert_triage_result_with_hash(
+        &self,
+        result: &IssueClassification,
+        issue_number: u64,
+        content_hash: Option<&str>,
+    ) -> Result<()> {
+        self.upsert_triage_result_with_hash(result, issue_number, content_hash)
+    }
+
     fn get_triage_result(&self, issue_number: u64) -> Result<Option<TriageResultRow>> {
         self.get_triage_result(issue_number)
     }
@@ -192,5 +225,17 @@ impl DatabaseBackend for super::Database {
 
     fn get_pending_events(&self) -> Result<Vec<WebhookEventRow>> {
         self.get_pending_events()
+    }
+
+    fn get_pulls_needing_analysis(&self) -> Result<Vec<PullRequest>> {
+        self.get_pulls_needing_analysis()
+    }
+
+    fn upsert_pr_analysis(&self, row: &PrAnalysisRow) -> Result<()> {
+        self.upsert_pr_analysis(row)
+    }
+
+    fn clear_triage_and_analyses(&self) -> Result<()> {
+        self.clear_triage_and_analyses()
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -82,6 +82,17 @@ impl Database {
         let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
         f(&conn)
     }
+
+    /// Wipe every triage result and PR analysis. Used by the `revert` flow.
+    /// Lives here (rather than in the revert pipeline) so the same operation
+    /// is available to any `DatabaseBackend` impl.
+    pub fn clear_triage_and_analyses(&self) -> Result<()> {
+        self.with_conn(|conn| {
+            conn.execute("DELETE FROM triage_results", [])?;
+            conn.execute("DELETE FROM pr_analyses", [])?;
+            Ok(())
+        })
+    }
 }
 
 /// Open a database backend based on the config.

--- a/src/db/pulls.rs
+++ b/src/db/pulls.rs
@@ -99,6 +99,20 @@ impl Database {
         self.with_conn(get_pulls_needing_analysis)
     }
 
+    pub fn get_closed_pulls(&self, limit: usize) -> Result<Vec<PullRequest>> {
+        self.with_conn(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT number, title, body, state, labels, author, head_sha, base_sha, head_ref, base_ref, mergeable, ci_status, created_at, updated_at
+                 FROM pull_requests WHERE state = 'closed'
+                 ORDER BY updated_at DESC LIMIT ?1",
+            )?;
+            let pulls = stmt
+                .query_map(params![limit as i64], row_to_pull)?
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(pulls)
+        })
+    }
+
     /// Upsert one PR analysis row. Extracted from `pipelines::pr_analysis`
     /// so the pipeline can run against any `DatabaseBackend` impl rather
     /// than reaching into a SQLite-specific `with_conn`.

--- a/src/db/pulls.rs
+++ b/src/db/pulls.rs
@@ -98,6 +98,35 @@ impl Database {
     pub fn get_pulls_needing_analysis(&self) -> Result<Vec<PullRequest>> {
         self.with_conn(get_pulls_needing_analysis)
     }
+
+    /// Upsert one PR analysis row. Extracted from `pipelines::pr_analysis`
+    /// so the pipeline can run against any `DatabaseBackend` impl rather
+    /// than reaching into a SQLite-specific `with_conn`.
+    pub fn upsert_pr_analysis(&self, row: &PrAnalysisRow) -> Result<()> {
+        self.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO pr_analyses (pr_number, summary, risk_level, pr_type, review_notes, analyzed_at, content_hash)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                 ON CONFLICT(pr_number) DO UPDATE SET
+                    summary = excluded.summary,
+                    risk_level = excluded.risk_level,
+                    pr_type = excluded.pr_type,
+                    review_notes = excluded.review_notes,
+                    analyzed_at = excluded.analyzed_at,
+                    content_hash = excluded.content_hash",
+                params![
+                    row.pr_number,
+                    row.summary,
+                    row.risk_level,
+                    row.pr_type,
+                    row.review_notes,
+                    row.analyzed_at,
+                    row.content_hash,
+                ],
+            )?;
+            Ok(())
+        })
+    }
 }
 
 pub fn upsert_pull(conn: &Connection, pr: &PullRequest) -> Result<()> {

--- a/src/github/sync.rs
+++ b/src/github/sync.rs
@@ -2,11 +2,11 @@ use anyhow::Result;
 use chrono::Utc;
 use tracing::info;
 
-use crate::db::Database;
+use crate::db::backend::DatabaseBackend;
 use crate::github::Client;
 
 /// Full sync: fetch ALL issues and ALL PRs (open + closed). Used on first run or manual sync.
-pub async fn full_sync(gh: &Client, db: &Database) -> Result<()> {
+pub async fn full_sync(gh: &Client, db: &dyn DatabaseBackend) -> Result<()> {
     info!("Starting full sync...");
     sync_issues(gh, db, None).await?;
     sync_pulls(gh, db).await?;
@@ -20,7 +20,7 @@ pub async fn full_sync(gh: &Client, db: &Database) -> Result<()> {
 ///
 /// First call (no sync log) → fetches everything once.
 /// Subsequent calls → only fetches what changed.
-pub async fn incremental_sync_full(gh: &Client, db: &Database) -> Result<()> {
+pub async fn incremental_sync_full(gh: &Client, db: &dyn DatabaseBackend) -> Result<()> {
     info!("Starting incremental sync...");
 
     let issues_since = db
@@ -52,7 +52,7 @@ pub async fn incremental_sync_full(gh: &Client, db: &Database) -> Result<()> {
 }
 
 /// Forever-incremental PR sync: stops paginating once we hit PRs older than `since`.
-async fn sync_pulls_incremental(gh: &Client, db: &Database, since: Option<&str>) -> Result<()> {
+async fn sync_pulls_incremental(gh: &Client, db: &dyn DatabaseBackend, since: Option<&str>) -> Result<()> {
     if since.is_some() {
         info!(
             "Syncing pull requests (incremental, since {})",
@@ -66,7 +66,7 @@ async fn sync_pulls_incremental(gh: &Client, db: &Database, since: Option<&str>)
 }
 
 #[allow(dead_code)]
-pub async fn incremental_sync(gh: &Client, db: &Database, table: &str) -> Result<()> {
+pub async fn incremental_sync(gh: &Client, db: &dyn DatabaseBackend, table: &str) -> Result<()> {
     let entry = db.get_sync_entry(table)?;
 
     let since = entry.as_ref().map(|e| {
@@ -100,16 +100,16 @@ pub async fn incremental_sync(gh: &Client, db: &Database, table: &str) -> Result
 }
 
 /// Force sync issues now (bypass throttle). Used when we know there's a new event.
-pub async fn sync_issues_now(gh: &Client, db: &Database) -> Result<()> {
+pub async fn sync_issues_now(gh: &Client, db: &dyn DatabaseBackend) -> Result<()> {
     sync_issues(gh, db, None).await
 }
 
 /// Force sync pulls now (bypass throttle). Used when we know there's a new event.
-pub async fn sync_pulls_now(gh: &Client, db: &Database) -> Result<()> {
+pub async fn sync_pulls_now(gh: &Client, db: &dyn DatabaseBackend) -> Result<()> {
     sync_pulls(gh, db).await
 }
 
-async fn sync_issues(gh: &Client, db: &Database, since: Option<&str>) -> Result<()> {
+async fn sync_issues(gh: &Client, db: &dyn DatabaseBackend, since: Option<&str>) -> Result<()> {
     info!("Syncing issues...");
     // Fetch ALL states (open+closed) so closed issues get updated in local DB
     let issues = gh.fetch_all_issues(since).await?;
@@ -124,7 +124,7 @@ async fn sync_issues(gh: &Client, db: &Database, since: Option<&str>) -> Result<
     Ok(())
 }
 
-async fn sync_pulls(gh: &Client, db: &Database) -> Result<()> {
+async fn sync_pulls(gh: &Client, db: &dyn DatabaseBackend) -> Result<()> {
     info!("Syncing pull requests...");
     let mut pulls = gh.fetch_pulls().await?;
     sync_pulls_finalize(gh, db, &mut pulls).await
@@ -133,7 +133,7 @@ async fn sync_pulls(gh: &Client, db: &Database) -> Result<()> {
 /// Shared finalize step: fetch mergeable status, upsert, update sync log.
 async fn sync_pulls_finalize(
     gh: &Client,
-    db: &Database,
+    db: &dyn DatabaseBackend,
     pulls: &mut [crate::db::pulls::PullRequest],
 ) -> Result<()> {
     let count = pulls.len();

--- a/src/pipelines/context.rs
+++ b/src/pipelines/context.rs
@@ -6,15 +6,15 @@
 
 use anyhow::Result;
 
-use crate::db::Database;
+use crate::db::backend::DatabaseBackend;
 
-pub fn run(db: &Database, slug: &str) -> Result<()> {
+pub fn run(db: &dyn DatabaseBackend, slug: &str) -> Result<()> {
     let output = build_context(db, slug)?;
     println!("{output}");
     Ok(())
 }
 
-pub fn build_context(db: &Database, slug: &str) -> Result<String> {
+pub fn build_context(db: &dyn DatabaseBackend, slug: &str) -> Result<String> {
     let mut out = String::with_capacity(8192);
 
     out.push_str(&format!("# {slug} — Repository Context\n\n"));

--- a/src/pipelines/merge_queue.rs
+++ b/src/pipelines/merge_queue.rs
@@ -6,7 +6,7 @@ use super::truncate;
 use crate::cli::QueueArgs;
 use crate::config::Config;
 use crate::db::pulls::PullRequest;
-use crate::db::Database;
+use crate::db::backend::DatabaseBackend;
 use crate::export::ExportManager;
 use crate::github::Client as GhClient;
 
@@ -26,7 +26,7 @@ struct QueueOutput {
 
 pub async fn run(
     config: &Config,
-    db: &Database,
+    db: &dyn DatabaseBackend,
     _gh: &GhClient,
     args: &QueueArgs,
     json: bool,

--- a/src/pipelines/pr_analysis.rs
+++ b/src/pipelines/pr_analysis.rs
@@ -7,8 +7,8 @@ use crate::ai::prompts::pr_analyze;
 use crate::ai::schemas::PrAnalysis;
 use crate::cli::PrArgs;
 use crate::config::Config;
-use crate::db::pulls::PullRequest;
-use crate::db::Database;
+use crate::db::backend::DatabaseBackend;
+use crate::db::pulls::{PrAnalysisRow, PullRequest};
 use crate::export::{EventKind, ExportEvent, ExportManager};
 use crate::github::Client as GhClient;
 
@@ -22,7 +22,7 @@ struct PrAnalysisOutput {
 
 pub async fn run(
     config: &Config,
-    db: &Database,
+    db: &dyn DatabaseBackend,
     gh: &GhClient,
     args: &PrArgs,
     json: bool,
@@ -103,7 +103,7 @@ pub async fn run(
 async fn analyze_pr(
     config: &Config,
     ai: &AiBackend,
-    db: &Database,
+    db: &dyn DatabaseBackend,
     gh: &GhClient,
     pr: &PullRequest,
     apply: bool,
@@ -184,28 +184,14 @@ async fn analyze_pr(
 
     // Store in DB
     let now = chrono::Utc::now().to_rfc3339();
-    db.with_conn(|conn| {
-        conn.execute(
-            "INSERT INTO pr_analyses (pr_number, summary, risk_level, pr_type, review_notes, analyzed_at, content_hash)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-             ON CONFLICT(pr_number) DO UPDATE SET
-                summary = excluded.summary,
-                risk_level = excluded.risk_level,
-                pr_type = excluded.pr_type,
-                review_notes = excluded.review_notes,
-                analyzed_at = excluded.analyzed_at,
-                content_hash = excluded.content_hash",
-            rusqlite::params![
-                pr.number,
-                analysis.summary,
-                analysis.risk_level,
-                analysis.pr_type,
-                serde_json::to_string(&analysis.review_checklist)?,
-                now,
-                content_hash,
-            ],
-        )?;
-        Ok(())
+    db.upsert_pr_analysis(&PrAnalysisRow {
+        pr_number: pr.number,
+        summary: analysis.summary.clone(),
+        risk_level: analysis.risk_level.clone(),
+        pr_type: analysis.pr_type.clone(),
+        review_notes: Some(serde_json::to_string(&analysis.review_checklist)?),
+        analyzed_at: now,
+        content_hash: Some(content_hash),
     })?;
 
     // ICM: store PR analysis for future context

--- a/src/pipelines/pr_health.rs
+++ b/src/pipelines/pr_health.rs
@@ -9,7 +9,7 @@ use crate::config::{IssueScoringConfig, PrScoringConfig};
 use crate::db::issues::Issue;
 use crate::db::pulls::PullRequest;
 use crate::db::triage::TriageResultRow;
-use crate::db::Database;
+use crate::db::backend::DatabaseBackend;
 
 /// A group of duplicate PRs addressing the same topic
 #[derive(Debug, Clone, Serialize)]
@@ -60,7 +60,7 @@ pub struct HealthReport {
     pub oversized: Vec<OversizedPr>,
 }
 
-pub fn run(db: &Database, args: &HealthArgs, json: bool) -> Result<()> {
+pub fn run(db: &dyn DatabaseBackend, args: &HealthArgs, json: bool) -> Result<()> {
     let pulls = db.get_open_pulls()?;
 
     if pulls.is_empty() {

--- a/src/pipelines/revert.rs
+++ b/src/pipelines/revert.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
 use tracing::info;
 
-use crate::db::Database;
+use crate::db::backend::DatabaseBackend;
 use crate::github::Client as GhClient;
 
 /// Revert all wshm actions: remove comments, remove wshm-applied labels, clear triage/analysis results.
-pub async fn run(db: &Database, gh: &GhClient, apply: bool) -> Result<()> {
+pub async fn run(db: &dyn DatabaseBackend, gh: &GhClient, apply: bool) -> Result<()> {
     let open_issues = db.get_open_issues()?;
     let open_pulls = db.get_open_pulls()?;
 
@@ -67,11 +67,7 @@ pub async fn run(db: &Database, gh: &GhClient, apply: bool) -> Result<()> {
 
     // Clear DB tables
     if apply {
-        db.with_conn(|conn| {
-            conn.execute("DELETE FROM triage_results", [])?;
-            conn.execute("DELETE FROM pr_analyses", [])?;
-            Ok(())
-        })?;
+        db.clear_triage_and_analyses()?;
         info!("Cleared triage_results and pr_analyses tables.");
     }
 

--- a/src/pipelines/status.rs
+++ b/src/pipelines/status.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use serde::Serialize;
 
 use crate::config::Config;
-use crate::db::Database;
+use crate::db::backend::DatabaseBackend;
 
 #[derive(Serialize)]
 struct StatusOutput {
@@ -50,7 +50,7 @@ pub struct PrBrief {
     pub age_days: i64,
 }
 
-pub fn show(db: &Database, json: bool) -> Result<()> {
+pub fn show(db: &dyn DatabaseBackend, json: bool) -> Result<()> {
     let open_issues = db.get_open_issues()?;
     let untriaged = db.get_untriaged_issues()?;
     let open_pulls = db.get_open_pulls()?;
@@ -107,7 +107,7 @@ pub fn show(db: &Database, json: bool) -> Result<()> {
 }
 
 /// Build a summary from the local database cache.
-pub fn build_summary(config: &Config, db: &Database) -> Result<Summary> {
+pub fn build_summary(config: &Config, db: &dyn DatabaseBackend) -> Result<Summary> {
     let open_issues = db.get_open_issues()?;
     let untriaged = db.get_untriaged_issues()?;
     let open_pulls = db.get_open_pulls()?;
@@ -326,7 +326,7 @@ fn format_terminal(summary: &Summary) -> String {
 }
 
 /// Display a daily digest summary (same data format as notifications would send).
-pub fn show_summary(config: &Config, db: &Database, json: bool) -> Result<()> {
+pub fn show_summary(config: &Config, db: &dyn DatabaseBackend, json: bool) -> Result<()> {
     let summary = build_summary(config, db)?;
 
     if json {

--- a/src/pipelines/triage.rs
+++ b/src/pipelines/triage.rs
@@ -8,7 +8,7 @@ use crate::ai::schemas::IssueClassification;
 use crate::cli::TriageArgs;
 use crate::config::Config;
 use crate::db::issues::Issue;
-use crate::db::Database;
+use crate::db::backend::DatabaseBackend;
 use crate::export::{EventKind, ExportEvent, ExportManager};
 use crate::github::Client as GhClient;
 use crate::pro_hooks;
@@ -31,7 +31,7 @@ pub enum OutputFormat {
 
 pub async fn run(
     config: &Config,
-    db: &Database,
+    db: &dyn DatabaseBackend,
     gh: &GhClient,
     args: &TriageArgs,
     format: OutputFormat,
@@ -47,7 +47,7 @@ pub async fn run(
 #[allow(clippy::too_many_arguments)]
 pub async fn run_with_filters(
     config: &Config,
-    db: &Database,
+    db: &dyn DatabaseBackend,
     gh: &GhClient,
     args: &TriageArgs,
     format: OutputFormat,
@@ -282,7 +282,7 @@ fn no_labels_min_age_from(filters: Option<&crate::config::RepoFilters>) -> u32 {
 async fn triage_issue(
     config: &Config,
     ai: &AiBackend,
-    db: &Database,
+    db: &dyn DatabaseBackend,
     gh: &GhClient,
     issue: &Issue,
     existing_issues: &[Issue],

--- a/src/pro_hooks.rs
+++ b/src/pro_hooks.rs
@@ -14,7 +14,6 @@ use std::sync::OnceLock;
 
 use crate::config::Config;
 use crate::db::backend::DatabaseBackend;
-use crate::Database;
 use crate::github::Client as GhClient;
 
 // --- Feature gate hook ---
@@ -101,12 +100,16 @@ pub fn apply_output_hook(text: &str) -> String {
 
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
-pub type AutoFixHook =
-    for<'a> fn(&'a Config, &'a Database, &'a GhClient, u64) -> BoxFuture<'a, anyhow::Result<()>>;
+pub type AutoFixHook = for<'a> fn(
+    &'a Config,
+    &'a dyn DatabaseBackend,
+    &'a GhClient,
+    u64,
+) -> BoxFuture<'a, anyhow::Result<()>>;
 
 pub type ReviewHook = for<'a> fn(
     &'a Config,
-    &'a Database,
+    &'a dyn DatabaseBackend,
     &'a GhClient,
     u64,
     bool,

--- a/src/pro_hooks.rs
+++ b/src/pro_hooks.rs
@@ -13,7 +13,8 @@ use std::pin::Pin;
 use std::sync::OnceLock;
 
 use crate::config::Config;
-use crate::db::Database;
+use crate::db::backend::DatabaseBackend;
+use crate::Database;
 use crate::github::Client as GhClient;
 
 // --- Feature gate hook ---
@@ -126,7 +127,7 @@ pub fn set_review_hook(f: ReviewHook) {
 /// Returns `Ok(false)` if no Pro hook is registered (OSS build).
 pub async fn run_auto_fix(
     config: &Config,
-    db: &Database,
+    db: &dyn DatabaseBackend,
     gh: &GhClient,
     issue_number: u64,
 ) -> anyhow::Result<bool> {
@@ -143,7 +144,7 @@ pub async fn run_auto_fix(
 /// Returns `Ok(false)` if no Pro hook is registered (OSS build).
 pub async fn run_review(
     config: &Config,
-    db: &Database,
+    db: &dyn DatabaseBackend,
     gh: &GhClient,
     pr_number: u64,
     apply: bool,

--- a/src/run.rs
+++ b/src/run.rs
@@ -6,9 +6,12 @@
 //! this dispatcher for non-Pro commands. Keeping a single source of truth
 //! here ensures the OSS surface stays in sync across both releases.
 
+use std::sync::Arc;
+
 use anyhow::{Context, Result};
 
 use crate::cli::{Cli, Command};
+use crate::db::backend::DatabaseBackend;
 use crate::pipelines::triage::OutputFormat;
 
 /// Convert global CLI flags into the triage pipeline output format.
@@ -22,10 +25,14 @@ pub fn triage_format(cli: &Cli) -> OutputFormat {
     }
 }
 
-/// Load the per-repo config, open the database, and build a GitHub client.
-pub fn init_core(cli: &Cli) -> Result<(crate::Config, crate::Database, crate::Client)> {
+/// Load the per-repo config, open the database (as a trait object so the
+/// Pro binary can swap in a Postgres backend at runtime), and build a
+/// GitHub client.
+pub fn init_core(
+    cli: &Cli,
+) -> Result<(crate::Config, Arc<dyn DatabaseBackend>, crate::Client)> {
     let config = crate::Config::load(cli)?;
-    let db = crate::Database::open(&config)?;
+    let db: Arc<dyn DatabaseBackend> = Arc::new(crate::Database::open(&config)?);
     let gh = crate::Client::new(&config)?;
     Ok((config, db, gh))
 }
@@ -35,7 +42,7 @@ pub fn init_full(
     cli: &Cli,
 ) -> Result<(
     crate::Config,
-    crate::Database,
+    Arc<dyn DatabaseBackend>,
     crate::Client,
     Option<crate::export::ExportManager>,
 )> {
@@ -53,7 +60,7 @@ pub async fn run_oss(cli: Cli) -> Result<()> {
     match &cli.command {
         Some(Command::Sync) => {
             let (config, db, gh, exporter) = init_full(&cli)?;
-            crate::github::sync::full_sync(&gh, &db).await?;
+            crate::github::sync::full_sync(&gh, db.as_ref()).await?;
             if let Some(ref em) = exporter {
                 em.emit(&crate::export::ExportEvent {
                     kind: crate::export::EventKind::SyncCompleted,
@@ -68,11 +75,11 @@ pub async fn run_oss(cli: Cli) -> Result<()> {
         Some(Command::Triage(args)) => {
             let (config, db, gh, exporter) = init_full(&cli)?;
             if !cli.offline {
-                crate::github::sync::incremental_sync(&gh, &db, "issues").await?;
+                crate::github::sync::incremental_sync(&gh, db.as_ref(), "issues").await?;
             }
             crate::pipelines::triage::run(
                 &config,
-                &db,
+                db.as_ref(),
                 &gh,
                 args,
                 triage_format(&cli),
@@ -83,11 +90,11 @@ pub async fn run_oss(cli: Cli) -> Result<()> {
         Some(Command::Pr(args)) => {
             let (config, db, gh, exporter) = init_full(&cli)?;
             if !cli.offline {
-                crate::github::sync::incremental_sync(&gh, &db, "pulls").await?;
+                crate::github::sync::incremental_sync(&gh, db.as_ref(), "pulls").await?;
             }
             crate::pipelines::pr_analysis::run(
                 &config,
-                &db,
+                db.as_ref(),
                 &gh,
                 args,
                 cli.json,
@@ -98,11 +105,11 @@ pub async fn run_oss(cli: Cli) -> Result<()> {
         Some(Command::Queue(args)) => {
             let (config, db, gh, exporter) = init_full(&cli)?;
             if !cli.offline {
-                crate::github::sync::incremental_sync(&gh, &db, "pulls").await?;
+                crate::github::sync::incremental_sync(&gh, db.as_ref(), "pulls").await?;
             }
             crate::pipelines::merge_queue::run(
                 &config,
-                &db,
+                db.as_ref(),
                 &gh,
                 args,
                 cli.json,
@@ -113,8 +120,8 @@ pub async fn run_oss(cli: Cli) -> Result<()> {
         Some(Command::Run(args)) => {
             let (config, db, gh, exporter) = init_full(&cli)?;
             if !cli.offline {
-                crate::github::sync::incremental_sync(&gh, &db, "issues").await?;
-                crate::github::sync::incremental_sync(&gh, &db, "pulls").await?;
+                crate::github::sync::incremental_sync(&gh, db.as_ref(), "issues").await?;
+                crate::github::sync::incremental_sync(&gh, db.as_ref(), "pulls").await?;
             }
 
             let triage_args = crate::cli::TriageArgs {
@@ -124,7 +131,7 @@ pub async fn run_oss(cli: Cli) -> Result<()> {
             };
             crate::pipelines::triage::run(
                 &config,
-                &db,
+                db.as_ref(),
                 &gh,
                 &triage_args,
                 triage_format(&cli),
@@ -138,7 +145,7 @@ pub async fn run_oss(cli: Cli) -> Result<()> {
             };
             crate::pipelines::pr_analysis::run(
                 &config,
-                &db,
+                db.as_ref(),
                 &gh,
                 &pr_args,
                 cli.json,
@@ -149,7 +156,7 @@ pub async fn run_oss(cli: Cli) -> Result<()> {
             let queue_args = crate::cli::QueueArgs { apply: args.apply };
             crate::pipelines::merge_queue::run(
                 &config,
-                &db,
+                db.as_ref(),
                 &gh,
                 &queue_args,
                 cli.json,
@@ -168,18 +175,18 @@ pub async fn run_oss(cli: Cli) -> Result<()> {
         }
         Some(Command::Health(args)) => {
             let config = crate::Config::load(&cli)?;
-            let db = crate::Database::open(&config)?;
+            let db: Arc<dyn DatabaseBackend> = Arc::new(crate::Database::open(&config)?);
             if !cli.offline {
                 let gh = crate::Client::new(&config)?;
-                crate::github::sync::incremental_sync(&gh, &db, "pulls").await?;
+                crate::github::sync::incremental_sync(&gh, db.as_ref(), "pulls").await?;
             }
-            crate::pipelines::pr_health::run(&db, args, cli.json)?;
+            crate::pipelines::pr_health::run(db.as_ref(), args, cli.json)?;
         }
         Some(Command::Context) => {
             let config = crate::Config::load(&cli)?;
-            let db = crate::Database::open(&config)?;
+            let db: Arc<dyn DatabaseBackend> = Arc::new(crate::Database::open(&config)?);
             let slug = config.repo_slug();
-            crate::pipelines::context::run(&db, &slug)?;
+            crate::pipelines::context::run(db.as_ref(), &slug)?;
         }
         Some(Command::Login(args)) => {
             if args.license {
@@ -204,9 +211,9 @@ pub async fn run_oss(cli: Cli) -> Result<()> {
         Some(Command::Revert(args)) => {
             let (_config, db, gh, _) = init_full(&cli)?;
             if !cli.offline {
-                crate::github::sync::full_sync(&gh, &db).await?;
+                crate::github::sync::full_sync(&gh, db.as_ref()).await?;
             }
-            crate::pipelines::revert::run(&db, &gh, args.apply).await?;
+            crate::pipelines::revert::run(db.as_ref(), &gh, args.apply).await?;
         }
         Some(Command::Backup(args)) => {
             crate::pipelines::backup::backup(args)?;
@@ -219,18 +226,18 @@ pub async fn run_oss(cli: Cli) -> Result<()> {
         }
         Some(Command::Summary) => {
             let config = crate::Config::load(&cli)?;
-            let db = crate::Database::open(&config)?;
+            let db: Arc<dyn DatabaseBackend> = Arc::new(crate::Database::open(&config)?);
             if !cli.offline {
                 let gh = crate::Client::new(&config)?;
-                crate::github::sync::incremental_sync(&gh, &db, "issues").await?;
-                crate::github::sync::incremental_sync(&gh, &db, "pulls").await?;
+                crate::github::sync::incremental_sync(&gh, db.as_ref(), "issues").await?;
+                crate::github::sync::incremental_sync(&gh, db.as_ref(), "pulls").await?;
             }
-            crate::pipelines::status::show_summary(&config, &db, cli.json)?;
+            crate::pipelines::status::show_summary(&config, db.as_ref(), cli.json)?;
         }
         Some(Command::Tui) => match crate::Config::load(&cli) {
             Ok(config) => {
-                let db = crate::Database::open(&config)?;
-                crate::tui::run(&config, &db).await?;
+                let db: Arc<dyn DatabaseBackend> = Arc::new(crate::Database::open(&config)?);
+                crate::tui::run(&config, db.as_ref()).await?;
             }
             Err(_) => {
                 let global_path = crate::config::GlobalConfig::default_path();
@@ -244,8 +251,8 @@ pub async fn run_oss(cli: Cli) -> Result<()> {
                     .find(|r| r.enabled)
                     .ok_or_else(|| anyhow::anyhow!("No enabled repos in global.toml"))?;
                 let config = crate::config::Config::load_for_repo(&first.path, &first.slug)?;
-                let db = crate::Database::open(&config)?;
-                crate::tui::run(&config, &db).await?;
+                let db: Arc<dyn DatabaseBackend> = Arc::new(crate::Database::open(&config)?);
+                crate::tui::run(&config, db.as_ref()).await?;
             }
         },
         Some(Command::Daemon(args)) => {
@@ -280,8 +287,8 @@ pub async fn run_oss(cli: Cli) -> Result<()> {
         }
         None => {
             let config = crate::Config::load(&cli)?;
-            let db = crate::Database::open(&config)?;
-            crate::pipelines::status::show(&db, cli.json)?;
+            let db: Arc<dyn DatabaseBackend> = Arc::new(crate::Database::open(&config)?);
+            crate::pipelines::status::show(db.as_ref(), cli.json)?;
         }
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2,10 +2,10 @@ use anyhow::Result;
 use std::collections::HashMap;
 
 use crate::config::{Config, GlobalConfig, RepoEntry};
+use crate::db::backend::DatabaseBackend;
 use crate::db::issues::Issue;
 use crate::db::pulls::PullRequest;
 use crate::db::triage::TriageResultRow;
-use crate::db::Database;
 use std::path::PathBuf;
 
 #[derive(Clone, Debug)]
@@ -248,7 +248,7 @@ pub struct RepoRow {
 }
 
 impl App {
-    pub fn new(config: &Config, db: &Database) -> Result<Self> {
+    pub fn new(config: &Config, db: &dyn DatabaseBackend) -> Result<Self> {
         let mut app = Self {
             repo_slug: config.repo_slug(),
             active_tab: Tab::Summary,
@@ -303,7 +303,7 @@ impl App {
     }
 
     /// Load all triage results, most recent first. Used by the Triage tab.
-    pub fn load_triage_all(&mut self, db: &Database) {
+    pub fn load_triage_all(&mut self, db: &dyn DatabaseBackend) {
         match db.recent_activity(500) {
             Ok(rows) => self.triage_all = rows,
             Err(_) => self.triage_all = Vec::new(),
@@ -312,25 +312,14 @@ impl App {
 
     /// Load closed pull requests, group them by conventional-commit section.
     /// Same logic as the web /api/v1/changelog endpoint.
-    pub fn load_changelog(&mut self, db: &Database) {
-        let rows = db
-            .with_conn(|conn| {
-                let mut stmt = conn.prepare(
-                    "SELECT number, title, author, updated_at
-                     FROM pull_requests WHERE state = 'closed'
-                     ORDER BY updated_at DESC LIMIT 100",
-                )?;
-                let rows = stmt
-                    .query_map([], |row| {
-                        Ok((
-                            row.get::<_, u64>(0)?,
-                            row.get::<_, String>(1)?,
-                            row.get::<_, Option<String>>(2)?,
-                            row.get::<_, String>(3)?,
-                        ))
-                    })?
-                    .collect::<std::result::Result<Vec<_>, _>>()?;
-                Ok(rows)
+    pub fn load_changelog(&mut self, db: &dyn crate::db::backend::DatabaseBackend) {
+        let rows: Vec<(u64, String, Option<String>, String)> = db
+            .get_closed_pulls(100)
+            .map(|pulls| {
+                pulls
+                    .into_iter()
+                    .map(|pr| (pr.number, pr.title, pr.author, pr.updated_at))
+                    .collect()
             })
             .unwrap_or_default();
 
@@ -363,11 +352,11 @@ impl App {
             .collect();
     }
 
-    pub fn load_summary(&mut self, config: &Config, db: &Database) {
+    pub fn load_summary(&mut self, config: &Config, db: &dyn DatabaseBackend) {
         self.summary = crate::pipelines::status::build_summary(config, db).ok();
     }
 
-    pub fn refresh(&mut self, db: &Database) -> Result<()> {
+    pub fn refresh(&mut self, db: &dyn DatabaseBackend) -> Result<()> {
         let open_issues = db.get_open_issues()?;
         self.open_issue_count = open_issues.len();
 
@@ -990,7 +979,7 @@ impl App {
     /// Run a GitHub sync (incremental or full) for the current repo and
     /// reload the local DB rows so the new data shows up without a manual
     /// refresh. Bound to F5 / Shift+F5 in the run loop.
-    pub async fn sync_now(&mut self, config: &Config, db: &Database, full: bool) {
+    pub async fn sync_now(&mut self, config: &Config, db: &dyn DatabaseBackend, full: bool) {
         self.status_message = Some(if full {
             "Full sync running…".to_string()
         } else {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -12,7 +12,6 @@ use std::io;
 
 use crate::config::Config;
 use crate::db::backend::DatabaseBackend;
-use crate::Database;
 
 pub async fn run(config: &Config, db: &dyn DatabaseBackend) -> Result<()> {
     // Setup terminal

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -11,9 +11,10 @@ use ratatui::prelude::*;
 use std::io;
 
 use crate::config::Config;
-use crate::db::Database;
+use crate::db::backend::DatabaseBackend;
+use crate::Database;
 
-pub async fn run(config: &Config, db: &Database) -> Result<()> {
+pub async fn run(config: &Config, db: &dyn DatabaseBackend) -> Result<()> {
     // Setup terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -44,7 +45,7 @@ fn run_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &mut app::App,
     config: &Config,
-    db: &Database,
+    db: &dyn DatabaseBackend,
     last_log_refresh: &mut std::time::Instant,
 ) -> Result<()> {
     loop {


### PR DESCRIPTION
## Summary
Converts the existing `DatabaseBackend` trait (defined but unused) into the
actual transport for runtime backend selection. wshm-pro can now plug in a
PostgresBackend at boot without touching the OSS code path. OSS stays on
SQLite as the default; no behavioural change for OSS users.

## Why
wshm-pro #62 needs a way to swap SQLite for Postgres without forking the
core daemon. The trait was already 90% there — this PR makes it the
authoritative storage transport across pipelines, sync handlers, daemon,
TUI, and Pro hook bridges.

## What changed
- Extended `DatabaseBackend` with 5 methods previously inlined as SQLite-
  specific `with_conn()` blocks: `upsert_triage_result_with_hash`,
  `get_pulls_needing_analysis`, `upsert_pr_analysis`,
  `clear_triage_and_analyses`, `get_closed_pulls`.
- Added `as_sqlite_db()` escape hatch on the trait — returns `Some(&Database)`
  for SQLite, `None` for other backends. Used by code paths not yet ported
  (cross-repo FTS search, snapshot trend tables).
- `init_core` / `init_full` return `Arc<dyn DatabaseBackend>` instead of
  the concrete `Database`.
- All 7 pipelines (triage, pr_analysis, pr_health, merge_queue, status,
  context, revert), `github::sync` handlers, daemon (mod, processor,
  scheduler, web, commands), TUI app + run, and `pro_hooks::AutoFixHook` /
  `ReviewHook` migrated to `&dyn DatabaseBackend` signatures.
- Two pipelines that used `with_conn()` inline SQL (revert, pr_analysis)
  now go through trait methods.

## Test plan
- [x] `cargo check` clean
- [ ] CI: `cargo test` against the SQLite default path (sandbox missed
      \`-llzma -lbz2 -lz\` system libs, runs in CI)
- [ ] Manual: existing OSS install on SQLite continues to boot and sync
- [ ] Manual: TUI shows the same data as before

## Out of scope
- The actual Postgres implementation (lives in wshm-pro).
- Migrating per-repo daemon DBs to a multi-tenant Postgres layout.
- Online SQLite → Postgres data migration tool.