### PR TITLE
feat(auth): UserStoreBackend trait for Pro PG impl

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -13,12 +13,87 @@ use anyhow::{anyhow, Context, Result};
 use argon2::password_hash::rand_core::OsRng;
 use argon2::password_hash::SaltString;
 use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier};
+use async_trait::async_trait;
 use chrono::Utc;
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+
+/// Abstract store interface so wshm-pro can plug in a Postgres-backed
+/// implementation for stateless K8s deploys (where the per-pod users.db
+/// would be wiped on restart). OSS keeps using the SQLite `UserStore`
+/// below; Pro provides its own type that implements this trait.
+#[async_trait]
+pub trait UserStoreBackend: Send + Sync {
+    async fn count(&self) -> Result<i64>;
+    async fn list(&self) -> Result<Vec<User>>;
+    async fn find_by_id(&self, id: i64) -> Result<Option<User>>;
+    async fn find_by_email(&self, email: &str) -> Result<Option<User>>;
+    async fn find_by_login(&self, login: &str) -> Result<Option<(User, Option<String>)>>;
+    async fn create_local(
+        &self,
+        email: &str,
+        username: Option<&str>,
+        password: &str,
+        role: Role,
+    ) -> Result<i64>;
+    async fn upsert_sso(&self, email: &str, username: Option<&str>, provider: &str)
+        -> Result<User>;
+    async fn update_role(&self, id: i64, role: Role) -> Result<()>;
+    async fn update_password(&self, id: i64, password: &str) -> Result<()>;
+    async fn delete(&self, id: i64) -> Result<()>;
+    async fn touch_login(&self, id: i64) -> Result<()>;
+}
+
+#[async_trait]
+impl UserStoreBackend for UserStore {
+    async fn count(&self) -> Result<i64> {
+        UserStore::count(self).await
+    }
+    async fn list(&self) -> Result<Vec<User>> {
+        UserStore::list(self).await
+    }
+    async fn find_by_id(&self, id: i64) -> Result<Option<User>> {
+        UserStore::find_by_id(self, id).await
+    }
+    async fn find_by_email(&self, email: &str) -> Result<Option<User>> {
+        UserStore::find_by_email(self, email).await
+    }
+    async fn find_by_login(&self, login: &str) -> Result<Option<(User, Option<String>)>> {
+        UserStore::find_by_login(self, login).await
+    }
+    async fn create_local(
+        &self,
+        email: &str,
+        username: Option<&str>,
+        password: &str,
+        role: Role,
+    ) -> Result<i64> {
+        UserStore::create_local(self, email, username, password, role).await
+    }
+    async fn upsert_sso(
+        &self,
+        email: &str,
+        username: Option<&str>,
+        provider: &str,
+    ) -> Result<User> {
+        UserStore::upsert_sso(self, email, username, provider).await
+    }
+    async fn update_role(&self, id: i64, role: Role) -> Result<()> {
+        UserStore::update_role(self, id, role).await
+    }
+    async fn update_password(&self, id: i64, password: &str) -> Result<()> {
+        UserStore::update_password(self, id, password).await
+    }
+    async fn delete(&self, id: i64) -> Result<()> {
+        UserStore::delete(self, id).await
+    }
+    async fn touch_login(&self, id: i64) -> Result<()> {
+        UserStore::touch_login(self, id).await
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -359,7 +434,7 @@ pub fn verify_password(password: &str, hash: &str) -> bool {
 ///
 /// Password resolution: `WSHM_ADMIN_PASSWORD` if set, otherwise a random
 /// 24-char password is generated and logged once at WARN level.
-pub async fn seed_admin_if_empty(store: &UserStore) -> Result<()> {
+pub async fn seed_admin_if_empty(store: &dyn UserStoreBackend) -> Result<()> {
     if store.count().await? > 0 {
         return Ok(());
     }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -389,7 +389,7 @@ pub async fn run(mut config: Config, args: DaemonArgs) -> Result<()> {
 #[derive(Default)]
 pub struct DaemonExtensions {
     /// Enable RBAC mode by passing a populated `UserStore`.
-    pub users: Option<Arc<crate::auth::UserStore>>,
+    pub users: Option<Arc<dyn crate::auth::UserStoreBackend>>,
     /// In-memory log buffer fed by the tracing layer; exposed via
     /// `GET /api/v1/logs`. Pass the same instance that's wired into the
     /// `tracing_subscriber` registry.

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -57,20 +57,20 @@ pub async fn run(
     // daemon also has a working RBAC + login flow out of the box. Same logic
     // as run_multi_with_extensions; kept here too because daemon::run takes
     // a different code path.
-    let users = match crate::auth::UserStore::open(
+    let users: Option<Arc<dyn crate::auth::UserStoreBackend>> = match crate::auth::UserStore::open(
         &dirs::home_dir()
             .unwrap_or_else(|| std::path::PathBuf::from("."))
             .join(".wshm")
             .join("users.db"),
     ) {
-        Ok(store) => Some(Arc::new(store)),
+        Ok(store) => Some(Arc::new(store) as Arc<dyn crate::auth::UserStoreBackend>),
         Err(e) => {
             warn!("Failed to open users db: {e} — login disabled");
             None
         }
     };
     if let Some(store) = users.as_ref() {
-        if let Err(e) = crate::auth::seed_admin_if_empty(store).await {
+        if let Err(e) = crate::auth::seed_admin_if_empty(store.as_ref()).await {
             warn!("Failed to seed admin user: {e}");
         }
     }
@@ -223,7 +223,7 @@ pub async fn run_multi(
 
     // Seed admin user if a UserStore is provided and the table is empty.
     if let Some(store) = extensions.users.as_ref() {
-        if let Err(e) = crate::auth::seed_admin_if_empty(store).await {
+        if let Err(e) = crate::auth::seed_admin_if_empty(store.as_ref()).await {
             warn!("Failed to seed admin user: {e}");
         }
     }

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -49,7 +49,7 @@ pub struct WebState {
     /// Optional RBAC store. `Some` enables multi-user accounts with roles
     /// (admin/member/viewer); `None` keeps the legacy single-credential
     /// `[web].username/password` Basic Auth flow.
-    pub users: Option<Arc<crate::auth::UserStore>>,
+    pub users: Option<Arc<dyn crate::auth::UserStoreBackend>>,
     /// Optional in-memory log buffer fed by the tracing layer. When `Some`,
     /// `GET /api/v1/logs` returns the daemon's recent log lines.
     pub logs: Option<Arc<crate::daemon::log_buffer::LogBuffer>>,
@@ -3094,7 +3094,7 @@ pub fn web_routes(multi: Arc<MultiDaemonState>) -> Router {
 /// The `WebState` is built from these inputs and shared with every sub-router.
 pub fn web_routes_with_extensions(
     multi: Arc<MultiDaemonState>,
-    users: Option<Arc<crate::auth::UserStore>>,
+    users: Option<Arc<dyn crate::auth::UserStoreBackend>>,
     logs: Option<Arc<crate::daemon::log_buffer::LogBuffer>>,
     secrets: Option<Arc<dyn crate::secrets::SecretStore>>,
     extra_api: Option<Router<Arc<WebState>>>,


### PR DESCRIPTION
Routine develop→main promotion. Single trait + blanket impl, lets Pro provide a PG-backed user store for stateless deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)