### PR TITLE
feat(db): trait method record_llm_invocation + wire pipelines

### DIFF
--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -1802,6 +1802,10 @@ async fn api_license() -> impl IntoResponse {
         // wshm-pro. Declared here only so the SPA can gate the sidebar
         // entry; `is_pro` is the enabled flag.
         ("issue-insights", "Issue insights dashboard", is_pro),
+        // Usage dashboard (Pro). Tracks LLM invocations from the Pro
+        // Postgres backend + live GitHub rate limit. Sidebar entry is
+        // gated; the page itself ships only in the Pro web bundle.
+        ("usage-dashboard", "LLM + API usage dashboard", is_pro),
     ];
 
     let features: Vec<serde_json::Value> = pro_features

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -9,6 +9,7 @@ use crate::db::pulls::{PrAnalysisRow, PullRequest};
 use crate::db::search::SearchHit;
 use crate::db::sync::SyncEntry;
 use crate::db::triage::TriageResultRow;
+use crate::db::usage::UsageCounts;
 
 /// Unified interface for both SQLite and PostgreSQL database backends.
 ///
@@ -126,6 +127,15 @@ pub trait DatabaseBackend: Send + Sync {
     fn record_llm_invocation(&self, kind: &str, model: Option<&str>) -> Result<()> {
         let _ = (kind, model);
         Ok(())
+    }
+
+    /// Roll-up of LLM invocation counts over the last 24h / 7d / 30d
+    /// (plus all-time total and a per-kind breakdown) for this repo's
+    /// backend. Default impl returns zeroes so OSS SQLite installs
+    /// render an empty Pro usage dashboard rather than failing the
+    /// route; only the Pro Postgres backend queries `llm_invocations`.
+    fn usage_counts(&self) -> Result<UsageCounts> {
+        Ok(UsageCounts::default())
     }
 
     // ── Escape hatch ────────────────────────────────────────────

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -112,6 +112,22 @@ pub trait DatabaseBackend: Send + Sync {
     /// handler paginates the merged result set across repos.
     fn search_fts(&self, query: &str, limit: usize) -> Result<Vec<SearchHit>>;
 
+    // ── LLM accounting ──────────────────────────────────────────
+
+    /// Record one successful LLM invocation so the Pro usage dashboard
+    /// can show real call counts (vs cache-hit "triages" that touch no
+    /// LLM). `kind` is a short label like `"triage"` or `"pr_analysis"`;
+    /// `model` is the model identifier if known.
+    ///
+    /// Default impl is a no-op: OSS SQLite installs don't need the
+    /// accounting and we don't want to slow the hot path with an extra
+    /// write per LLM call. The Pro Postgres backend overrides this to
+    /// insert into the `llm_invocations` table.
+    fn record_llm_invocation(&self, kind: &str, model: Option<&str>) -> Result<()> {
+        let _ = (kind, model);
+        Ok(())
+    }
+
     // ── Escape hatch ────────────────────────────────────────────
 
     /// Downcast to the concrete SQLite `Database` if this backend is SQLite.

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -7,8 +7,10 @@ pub mod schema;
 pub mod search;
 pub mod sync;
 pub mod triage;
+pub mod usage;
 
 pub use search::{sanitize_query, SearchHit};
+pub use usage::{UsageByKind, UsageCounts};
 
 pub use backend::DatabaseBackend;
 

--- a/src/db/usage.rs
+++ b/src/db/usage.rs
@@ -1,0 +1,35 @@
+//! LLM usage accounting summary for the Pro dashboard.
+//!
+//! The Pro Postgres backend persists every successful LLM call into
+//! `llm_invocations` via [`DatabaseBackend::record_llm_invocation`].
+//! The Pro usage dashboard reads these counts back through
+//! [`DatabaseBackend::usage_counts`].
+//!
+//! OSS SQLite installs are usage-tracking opt-out: the default impl in
+//! the trait returns zeroes so the dashboard renders an empty state
+//! instead of forcing a schema migration on every OSS user.
+
+use serde::Serialize;
+
+/// Roll-up of LLM call counts for one repo over the three windows the
+/// Pro dashboard surfaces. Counts are returned per-kind (`triage`,
+/// `pr_analysis`, ...) so the UI can break them down without re-querying.
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct UsageCounts {
+    pub total: u64,
+    pub last_24h: u64,
+    pub last_7d: u64,
+    pub last_30d: u64,
+    /// Per-kind breakdown for the same windows. Keys are the `kind`
+    /// strings passed to `record_llm_invocation` (lower-case, snake_case).
+    pub by_kind: Vec<UsageByKind>,
+}
+
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct UsageByKind {
+    pub kind: String,
+    pub total: u64,
+    pub last_24h: u64,
+    pub last_7d: u64,
+    pub last_30d: u64,
+}

--- a/src/pipelines/pr_analysis.rs
+++ b/src/pipelines/pr_analysis.rs
@@ -182,6 +182,9 @@ async fn analyze_pr(
 
     let analysis: PrAnalysis = ai.complete(system_prompt, &user_prompt).await?;
 
+    // Account for the LLM call — advisory, never fail the pipeline.
+    let _ = db.record_llm_invocation("pr_analysis", None);
+
     // Store in DB
     let now = chrono::Utc::now().to_rfc3339();
     db.upsert_pr_analysis(&PrAnalysisRow {

--- a/src/pipelines/triage.rs
+++ b/src/pipelines/triage.rs
@@ -349,6 +349,12 @@ async fn triage_issue(
 
     let classification: IssueClassification = ai.complete(system_prompt, &user_prompt).await?;
 
+    // Account for the LLM call so the Pro usage dashboard reflects
+    // real spend (vs cache-hit triages above that never reach here).
+    // Errors here are advisory — never fail the pipeline because
+    // accounting failed.
+    let _ = db.record_llm_invocation("triage", None);
+
     // Only persist triage result and ICM context when applying
     if apply {
         db.upsert_triage_result_with_hash(&classification, issue.number, Some(&content_hash))?;

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -86,6 +86,7 @@
 		{ href: '/activity', label: 'Activity', icon: 'activity' },
 		{ href: '/actions', label: 'Actions', icon: 'actions' },
 		{ href: '/logs', label: 'Logs', icon: 'logs' },
+		{ href: '/usage', label: 'Usage', icon: 'activity', feature: 'usage-dashboard' },
 		{ href: '/settings', label: 'Settings', icon: 'settings' }
 	];
 	function isFeatureLicensed(featureId: string | undefined): boolean {


### PR DESCRIPTION
Adds DatabaseBackend::record_llm_invocation(kind, model) with no-op default. Wires it after ai.complete() in triage + pr_analysis pipelines. Pro PG overrides to insert into llm_invocations. Refs: Pro usage dashboard Step 1.