### PR TITLE
feat(triage): skip already-labeled issues by seeding stubs from forge labels

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1480,6 +1480,19 @@ pub struct RepoFilters {
     /// older than this many hours. `0` disables the trigger.
     #[serde(default = "default_triage_no_labels_min_age_hours")]
     pub triage_no_labels_min_age_hours: u32,
+    /// Label-name prefixes that wshm treats as "already triaged" evidence
+    /// on the forge. When an open issue carries any label whose name starts
+    /// with one of these prefixes and has no local `triage_results` row,
+    /// the pipeline seeds a stub row from the labels instead of spending
+    /// an LLM call. Empty disables the safety net (legacy behaviour).
+    #[serde(default = "default_triage_managed_label_prefixes")]
+    pub triage_managed_label_prefixes: Vec<String>,
+    /// Grace window before label-based seeding kicks in. An open issue
+    /// must have been quiet (no `updated_at` change) for at least this
+    /// many hours before its labels are trusted as evidence of a prior
+    /// triage. `0` (default) means seed immediately.
+    #[serde(default)]
+    pub triage_managed_label_grace_hours: u32,
 
     // ── Analyze PRs ───────────────────────────────────────────────
     #[serde(default)]
@@ -1512,6 +1525,10 @@ fn default_triage_no_labels_min_age_hours() -> u32 {
     24
 }
 
+fn default_triage_managed_label_prefixes() -> Vec<String> {
+    vec!["priority:".to_string(), "category:".to_string()]
+}
+
 impl Default for RepoFilters {
     fn default() -> Self {
         Self {
@@ -1523,6 +1540,8 @@ impl Default for RepoFilters {
             triage_max_age_days: 0,
             triage_relabel_labels: default_triage_relabel_labels(),
             triage_no_labels_min_age_hours: default_triage_no_labels_min_age_hours(),
+            triage_managed_label_prefixes: default_triage_managed_label_prefixes(),
+            triage_managed_label_grace_hours: 0,
             analyze_min_loc: 0,
             analyze_max_loc: 0,
             auto_pr_only_labels: Vec::new(),

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -57,6 +57,21 @@ pub trait DatabaseBackend: Send + Sync {
         content_hash: Option<&str>,
     ) -> Result<()>;
     fn get_triage_result(&self, issue_number: u64) -> Result<Option<TriageResultRow>>;
+    /// Insert `triage_results` stubs for open issues that already carry
+    /// wshm-managed labels on the forge but have no local row. Lets a
+    /// fresh install / migration / wiped state.db avoid re-spending LLM
+    /// credits on issues that are clearly already triaged. See
+    /// [`Database::seed_triage_stubs_from_labels`] for details. Default
+    /// impl returns 0 so a backend without label-aware seeding still
+    /// compiles — the SQLite impl overrides it.
+    fn seed_triage_stubs_from_labels(
+        &self,
+        managed_label_prefixes: &[String],
+        grace_hours: u32,
+    ) -> Result<u64> {
+        let _ = (managed_label_prefixes, grace_hours);
+        Ok(0)
+    }
     fn get_stale_triage_results(&self, max_age_hours: u32) -> Result<Vec<TriageResultRow>>;
     fn get_wshm_applied_labels(&self, issue_number: u64) -> Result<Vec<String>>;
     fn recent_activity(&self, limit: usize) -> Result<Vec<TriageResultRow>>;
@@ -231,6 +246,14 @@ impl DatabaseBackend for super::Database {
 
     fn get_triage_result(&self, issue_number: u64) -> Result<Option<TriageResultRow>> {
         self.get_triage_result(issue_number)
+    }
+
+    fn seed_triage_stubs_from_labels(
+        &self,
+        managed_label_prefixes: &[String],
+        grace_hours: u32,
+    ) -> Result<u64> {
+        self.seed_triage_stubs_from_labels(managed_label_prefixes, grace_hours)
     }
 
     fn get_stale_triage_results(&self, max_age_hours: u32) -> Result<Vec<TriageResultRow>> {

--- a/src/db/triage.rs
+++ b/src/db/triage.rs
@@ -5,6 +5,24 @@ use serde::{Deserialize, Serialize};
 use crate::ai::schemas::IssueClassification;
 use crate::db::Database;
 
+/// Return the suffix of the first label whose name starts with `prefix`
+/// (case-insensitive). Used to reconstruct category / priority from
+/// already-applied labels like `category:bug`.
+fn first_after_prefix(labels: &[String], prefix: &str) -> Option<String> {
+    let p = prefix.to_ascii_lowercase();
+    labels.iter().find_map(|l| {
+        if !l.to_ascii_lowercase().starts_with(&p) {
+            return None;
+        }
+        let suffix = l.get(prefix.len()..)?.trim().to_string();
+        if suffix.is_empty() {
+            None
+        } else {
+            Some(suffix)
+        }
+    })
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TriageResultRow {
     pub issue_number: u64,
@@ -174,6 +192,142 @@ impl Database {
         })
     }
 
+    /// Seed `triage_results` stubs for open issues that already carry
+    /// wshm-managed labels on the forge but have no local row — typical
+    /// after a fresh install, a storage migration, or wiping the local
+    /// state.db. Returns the number of stub rows inserted.
+    ///
+    /// An issue qualifies when ALL of:
+    ///   * it is open,
+    ///   * it has no row in `triage_results`,
+    ///   * its `updated_at` is older than `now - grace_hours` (so we don't
+    ///     race ongoing label edits; `grace_hours = 0` skips this check),
+    ///   * at least one of its labels starts with one of `managed_label_prefixes`.
+    ///
+    /// Each stub row stores a content_hash so the next batch's normal
+    /// "needs triage" check sees the issue as already-triaged and avoids
+    /// the LLM call. `category` is reconstructed from the first
+    /// `category:*` label (defaults to `"uncategorized"`), `priority` from
+    /// the first `priority:*` label.
+    pub fn seed_triage_stubs_from_labels(
+        &self,
+        managed_label_prefixes: &[String],
+        grace_hours: u32,
+    ) -> Result<u64> {
+        use crate::db::schema::compute_issue_hash;
+
+        if managed_label_prefixes.is_empty() {
+            return Ok(0);
+        }
+
+        let cutoff = if grace_hours > 0 {
+            Some(chrono::Utc::now() - chrono::Duration::hours(grace_hours as i64))
+        } else {
+            None
+        };
+
+        self.with_conn(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT i.number, i.title, i.body, i.labels, i.updated_at
+                 FROM issues i
+                 LEFT JOIN triage_results t ON i.number = t.issue_number
+                 WHERE i.state = 'open' AND t.issue_number IS NULL",
+            )?;
+
+            struct Candidate {
+                number: u64,
+                title: String,
+                body: Option<String>,
+                labels: Vec<String>,
+                updated_at: String,
+            }
+
+            let rows = stmt.query_map([], |row| {
+                let labels_json: String = row.get(3)?;
+                Ok(Candidate {
+                    number: row.get(0)?,
+                    title: row.get(1)?,
+                    body: row.get(2)?,
+                    labels: serde_json::from_str(&labels_json).unwrap_or_default(),
+                    updated_at: row.get(4)?,
+                })
+            })?;
+
+            struct Stub {
+                number: u64,
+                category: String,
+                priority: Option<String>,
+                content_hash: String,
+                matched_labels: Vec<String>,
+            }
+
+            let mut stubs: Vec<Stub> = Vec::new();
+
+            for row in rows {
+                let c = row?;
+
+                if let Some(cutoff_dt) = cutoff {
+                    let stale = chrono::DateTime::parse_from_rfc3339(&c.updated_at)
+                        .map(|dt| dt.with_timezone(&chrono::Utc) < cutoff_dt)
+                        .unwrap_or(true);
+                    if !stale {
+                        continue;
+                    }
+                }
+
+                let matched: Vec<String> = c
+                    .labels
+                    .iter()
+                    .filter(|l| {
+                        managed_label_prefixes
+                            .iter()
+                            .any(|p| l.to_ascii_lowercase().starts_with(&p.to_ascii_lowercase()))
+                    })
+                    .cloned()
+                    .collect();
+                if matched.is_empty() {
+                    continue;
+                }
+
+                let category = first_after_prefix(&matched, "category:")
+                    .unwrap_or_else(|| "uncategorized".to_string());
+                let priority = first_after_prefix(&matched, "priority:");
+                let content_hash = compute_issue_hash(&c.title, c.body.as_deref());
+
+                stubs.push(Stub {
+                    number: c.number,
+                    category,
+                    priority,
+                    content_hash,
+                    matched_labels: matched,
+                });
+            }
+
+            let now = chrono::Utc::now().to_rfc3339();
+            let mut inserted: u64 = 0;
+            for stub in stubs {
+                let suggested = serde_json::to_string(&stub.matched_labels)?;
+                let n = conn.execute(
+                    "INSERT INTO triage_results (issue_number, category, confidence, priority, summary, suggested_labels, is_duplicate_of, is_simple_fix, relevant_files, acted_at, content_hash)
+                     VALUES (?1, ?2, ?3, ?4, NULL, ?5, NULL, 0, '[]', ?6, ?7)
+                     ON CONFLICT(issue_number) DO NOTHING",
+                    params![
+                        stub.number,
+                        stub.category,
+                        1.0_f64,
+                        stub.priority,
+                        suggested,
+                        now,
+                        stub.content_hash,
+                    ],
+                )?;
+                inserted += n as u64;
+            }
+
+            Ok(inserted)
+        })
+    }
+
     pub fn is_triaged(&self, issue_number: u64) -> Result<bool> {
         self.with_conn(|conn| {
             let count: i64 = conn.query_row(
@@ -183,5 +337,141 @@ impl Database {
             )?;
             Ok(count > 0)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::issues::Issue;
+    use crate::db::Database;
+
+    fn open_issue(number: u64, labels: Vec<&str>) -> Issue {
+        Issue {
+            number,
+            title: format!("Issue #{number}"),
+            body: Some("body".to_string()),
+            state: "open".to_string(),
+            labels: labels.into_iter().map(String::from).collect(),
+            author: Some("alice".to_string()),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            reactions_plus1: 0,
+            reactions_total: 0,
+        }
+    }
+
+    #[test]
+    fn first_after_prefix_extracts_value() {
+        let labels = vec!["category:bug".to_string(), "priority:high".to_string()];
+        assert_eq!(
+            first_after_prefix(&labels, "category:"),
+            Some("bug".to_string())
+        );
+        assert_eq!(
+            first_after_prefix(&labels, "priority:"),
+            Some("high".to_string())
+        );
+        assert_eq!(first_after_prefix(&labels, "nope:"), None);
+    }
+
+    #[test]
+    fn first_after_prefix_is_case_insensitive_on_prefix() {
+        let labels = vec!["Category:Bug".to_string()];
+        assert_eq!(
+            first_after_prefix(&labels, "category:"),
+            Some("Bug".to_string())
+        );
+    }
+
+    #[test]
+    fn first_after_prefix_skips_empty_suffix() {
+        let labels = vec!["category:".to_string(), "category:bug".to_string()];
+        assert_eq!(
+            first_after_prefix(&labels, "category:"),
+            Some("bug".to_string())
+        );
+    }
+
+    #[test]
+    fn seed_stubs_inserts_for_labeled_issues_only() {
+        let db = Database::open_memory().unwrap();
+        db.upsert_issue(&open_issue(1, vec!["category:bug", "priority:high"]))
+            .unwrap();
+        db.upsert_issue(&open_issue(2, vec!["needs-info"])).unwrap();
+        db.upsert_issue(&open_issue(3, vec!["category:docs"]))
+            .unwrap();
+
+        let prefixes = vec!["category:".to_string(), "priority:".to_string()];
+        let inserted = db.seed_triage_stubs_from_labels(&prefixes, 0).unwrap();
+        assert_eq!(inserted, 2);
+
+        let row1 = db.get_triage_result(1).unwrap().expect("issue 1 stub");
+        assert_eq!(row1.category, "bug");
+        assert_eq!(row1.priority.as_deref(), Some("high"));
+        assert!(row1.content_hash.is_some());
+
+        let row3 = db.get_triage_result(3).unwrap().expect("issue 3 stub");
+        assert_eq!(row3.category, "docs");
+        assert_eq!(row3.priority, None);
+
+        assert!(
+            db.get_triage_result(2).unwrap().is_none(),
+            "issue 2 not seeded"
+        );
+    }
+
+    #[test]
+    fn seed_stubs_is_idempotent() {
+        let db = Database::open_memory().unwrap();
+        db.upsert_issue(&open_issue(1, vec!["category:bug"]))
+            .unwrap();
+        let prefixes = vec!["category:".to_string()];
+
+        assert_eq!(db.seed_triage_stubs_from_labels(&prefixes, 0).unwrap(), 1);
+        assert_eq!(
+            db.seed_triage_stubs_from_labels(&prefixes, 0).unwrap(),
+            0,
+            "second run must not re-insert"
+        );
+    }
+
+    #[test]
+    fn seed_stubs_skips_when_grace_window_not_elapsed() {
+        let db = Database::open_memory().unwrap();
+        let mut recent = open_issue(1, vec!["category:bug"]);
+        recent.updated_at = chrono::Utc::now().to_rfc3339();
+        db.upsert_issue(&recent).unwrap();
+
+        let prefixes = vec!["category:".to_string()];
+        assert_eq!(db.seed_triage_stubs_from_labels(&prefixes, 24).unwrap(), 0);
+        assert!(db.get_triage_result(1).unwrap().is_none());
+    }
+
+    #[test]
+    fn seed_stubs_no_op_when_prefixes_empty() {
+        let db = Database::open_memory().unwrap();
+        db.upsert_issue(&open_issue(1, vec!["category:bug"]))
+            .unwrap();
+        assert_eq!(db.seed_triage_stubs_from_labels(&[], 0).unwrap(), 0);
+        assert!(db.get_triage_result(1).unwrap().is_none());
+    }
+
+    #[test]
+    fn seeded_stub_marks_issue_as_already_triaged() {
+        // Acceptance criteria from issue #100: after seeding, the next
+        // `get_issues_needing_triage` call must yield 0 issues — exactly
+        // what stops the LLM burn on a wiped state.db.
+        let db = Database::open_memory().unwrap();
+        for n in 1..=5 {
+            db.upsert_issue(&open_issue(n, vec!["category:bug", "priority:low"]))
+                .unwrap();
+        }
+
+        let prefixes = vec!["category:".to_string(), "priority:".to_string()];
+        assert_eq!(db.seed_triage_stubs_from_labels(&prefixes, 0).unwrap(), 5);
+
+        let needing = db.get_issues_needing_triage(10, &[], 0).unwrap();
+        assert!(needing.is_empty(), "seeded issues must not need triage");
     }
 }

--- a/src/pipelines/triage.rs
+++ b/src/pipelines/triage.rs
@@ -97,6 +97,25 @@ pub async fn run_with_filters(
         }
         issues
     } else {
+        // Safety net: before counting "needs triage", reconstruct stub
+        // rows for any open issue that already carries wshm-managed
+        // labels on the forge but has no local triage_results row. Stops
+        // a wiped state.db / fresh install / storage migration from
+        // re-burning LLM credits on issues that are visibly already triaged.
+        let prefixes = managed_label_prefixes_from(filters);
+        if !prefixes.is_empty() {
+            let grace = managed_label_grace_hours_from(filters);
+            match db.seed_triage_stubs_from_labels(&prefixes, grace) {
+                Ok(0) => {}
+                Ok(n) => info!(
+                    "Seeded {n} triage stub(s) from existing forge labels (skipping LLM for already-triaged issues)"
+                ),
+                Err(e) => tracing::warn!(
+                    "Failed to seed triage stubs from labels: {e}; continuing without safety net"
+                ),
+            }
+        }
+
         // Get issues needing triage (never triaged OR content changed OR
         // carrying a force-relabel marker OR zero-label + stale).
         // Process in batches of 20 to avoid overwhelming the LLM API.
@@ -275,6 +294,18 @@ fn relabel_labels_from(filters: Option<&crate::config::RepoFilters>) -> Vec<Stri
 fn no_labels_min_age_from(filters: Option<&crate::config::RepoFilters>) -> u32 {
     filters
         .map(|f| f.triage_no_labels_min_age_hours)
+        .unwrap_or(0)
+}
+
+fn managed_label_prefixes_from(filters: Option<&crate::config::RepoFilters>) -> Vec<String> {
+    filters
+        .map(|f| f.triage_managed_label_prefixes.clone())
+        .unwrap_or_default()
+}
+
+fn managed_label_grace_hours_from(filters: Option<&crate::config::RepoFilters>) -> u32 {
+    filters
+        .map(|f| f.triage_managed_label_grace_hours)
         .unwrap_or(0)
 }
 


### PR DESCRIPTION
## Summary
A fresh install, storage migration, or wiped `state.db` would re-burn LLM credits on every open issue that already carried wshm-applied labels (`category:*`, `priority:*`) on the forge — the recent SQLite → Postgres migration on a 555-open-issue repo triggered ~510 redundant calls before being caught.

This adds a label-aware safety net. Before each triage batch the pipeline seeds `triage_results` stub rows reconstructed from the existing forge labels, so the existing content_hash check sees those issues as already triaged and the LLM is never called for them.

### Changes
- `RepoFilters.triage_managed_label_prefixes` (default `["priority:", "category:"]`) and `triage_managed_label_grace_hours` (default 0) — both per-repo overridable from `config.toml`.
- `Database::seed_triage_stubs_from_labels(prefixes, grace_hours) -> u64`. For each open issue with no `triage_results` row whose `updated_at < now - grace_hours` and that carries at least one label matching a prefix, insert a stub:
  - `category` = suffix of the first `category:*` label (defaults to `"uncategorized"`)
  - `priority` = suffix of the first `priority:*` label (or `NULL`)
  - `content_hash` = `compute_issue_hash(title, body)` so next cycle skips by hash
  - `suggested_labels` = the matched managed labels (so a subsequent compare against current forge labels is a no-op)
  - Idempotent via `ON CONFLICT(issue_number) DO NOTHING`.
- Added to the `DatabaseBackend` trait with a default impl returning 0 — Postgres backend stays compiling and can override later.
- `pipelines::triage::run_with_filters` seeds before `get_issues_needing_triage`; a seed failure is `tracing::warn`-logged and the cycle proceeds without the safety net.

### Out of scope
- Refreshing stale labels (already covered by `triage_relabel_labels` + `no_labels_min_age_hours`).
- Cross-repo label conventions — each install configures its own prefixes.

## Test plan
- [x] Unit: `seed_stubs_inserts_for_labeled_issues_only` — only labeled issues get stubs.
- [x] Unit: `seed_stubs_is_idempotent` — second call inserts 0.
- [x] Unit: `seed_stubs_skips_when_grace_window_not_elapsed`.
- [x] Unit: `seed_stubs_no_op_when_prefixes_empty`.
- [x] Acceptance: `seeded_stub_marks_issue_as_already_triaged` — 5 pre-labeled issues + seed ⇒ `get_issues_needing_triage` returns 0.
- [ ] Manual: on a real repo, wipe `triage_results`, run a triage cycle, confirm 0 LLM calls and rows reappear.

Closes #100