### PR TITLE
chore(ci): cap release artifact retention at 7 days

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,11 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: wshm-x86_64-unknown-linux-gnu
+          # Short retention: these are only a hand-off to the `release`
+          # job below. The published binaries live permanently on the
+          # GitHub Release (free storage); keeping run artifacts for the
+          # default 90 days silently fills the 0.5 GB Actions quota.
+          retention-days: 7
           path: |
             wshm-x86_64-unknown-linux-gnu.tar.gz
             wshm_*_amd64.deb
@@ -96,6 +101,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: wshm-aarch64-unknown-linux-gnu
+          retention-days: 7
           path: |
             wshm-aarch64-unknown-linux-gnu.tar.gz
             wshm_*_arm64.deb
@@ -122,6 +128,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: wshm-x86_64-pc-windows-msvc
+          retention-days: 7
           path: wshm-x86_64-pc-windows-msvc.zip
 
   release:


### PR DESCRIPTION
## Why
The `wshm-dev` account hit **100% of its 0.5 GB Actions storage** (665 MB across 66 artifacts). Root cause: the three release build jobs upload their binaries (`tar.gz`, `.deb`, `.zip`) as run artifacts with the **default 90-day retention**, so every tagged build accumulated ~50 MB of throwaway binaries.

These run artifacts exist only as a hand-off to the `release` job (line ~140), which downloads them and attaches them to the GitHub Release. Published binaries live permanently on each Release (free storage), so the run artifacts are pure leftovers.

## Changes
- `retention-days: 7` on all three `upload-artifact` steps (x86 linux, arm linux, windows).

## Notes
- Already purged the 66 existing artifacts via the API (freed the full 665 MB) — this PR prevents re-accumulation.
- Binaries remain available: permanently on each GitHub Release, and for 7 days on the run's Actions page if you need to grab one before release.
- No effect on `ci.yml` (it doesn't upload artifacts).

## Test plan
- [ ] Next tagged release: confirm binaries still attach to the Release, and the run artifacts show a 7-day expiry.