### PR TITLE
chore(hardening): security, performance & quality fixes (5-round audit sweep)

### DIFF
--- a/src/ai/client.rs
+++ b/src/ai/client.rs
@@ -345,7 +345,9 @@ impl AiClient {
             ]
         });
 
-        let text = crate::retry::with_retry("AI: Anthropic", || async {
+        // Connect-only retry: a completion is non-idempotent (each accepted
+        // request is billed), so don't re-issue on a post-send body EOF.
+        let text = crate::retry::with_retry_connect_only("AI: Anthropic", || async {
             let response = self
                 .http
                 .post(&self.provider.api_url)
@@ -387,7 +389,8 @@ impl AiClient {
             "temperature": 0.1
         });
 
-        let text = crate::retry::with_retry("AI: OpenAI-compatible", || async {
+        // Connect-only retry: see Anthropic path above.
+        let text = crate::retry::with_retry_connect_only("AI: OpenAI-compatible", || async {
             let mut req = self
                 .http
                 .post(&self.provider.api_url)
@@ -442,7 +445,8 @@ impl AiClient {
             }
         });
 
-        let text = crate::retry::with_retry("AI: Google Gemini", || async {
+        // Connect-only retry: see Anthropic path above.
+        let text = crate::retry::with_retry_connect_only("AI: Google Gemini", || async {
             let response = self
                 .http
                 .post(&self.provider.api_url)

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -424,6 +424,20 @@ pub fn verify_password(password: &str, hash: &str) -> bool {
         .is_ok()
 }
 
+/// A valid argon2 PHC hash of a fixed throwaway password, computed once per
+/// process. Login paths verify a supplied password against this when the
+/// looked-up user (or its password hash) is missing, so a non-existent
+/// account pays the same argon2 cost as a real wrong password — closing the
+/// username-enumeration timing oracle.
+pub fn dummy_password_hash() -> &'static str {
+    use std::sync::OnceLock;
+    static DUMMY: OnceLock<String> = OnceLock::new();
+    DUMMY.get_or_init(|| {
+        hash_password("wshm-dummy-password-for-constant-time-verification")
+            .expect("hashing a fixed dummy password cannot fail")
+    })
+}
+
 /// First-boot admin seed. If the `users` table is empty, create a local
 /// admin account so the operator can log in.
 ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -931,8 +931,14 @@ impl WebConfig {
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
-                let _ =
-                    std::fs::set_permissions(&creds_path, std::fs::Permissions::from_mode(0o600));
+                if let Err(e) =
+                    std::fs::set_permissions(&creds_path, std::fs::Permissions::from_mode(0o600))
+                {
+                    tracing::warn!(
+                        "Failed to set 0o600 on {}: {e}; web credentials may be world-readable",
+                        creds_path.display()
+                    );
+                }
             }
         }
 

--- a/src/daemon/commands.rs
+++ b/src/daemon/commands.rs
@@ -260,7 +260,12 @@ pub async fn execute(
                 Ok(false) => Ok(format!(
                     "Auto-fix for issue #{number} requires wshm Pro. Visit https://wshm.dev/pro"
                 )),
-                Err(e) => Ok(format!("Auto-fix failed for issue #{number}: {e:#}")),
+                Err(e) => {
+                    tracing::warn!("auto-fix #{number} failed: {e:#}");
+                    Ok(format!(
+                        "Auto-fix failed for issue #{number}. See server logs for details."
+                    ))
+                }
             }
         }
         SlashCommand::Queue => {

--- a/src/daemon/log_buffer.rs
+++ b/src/daemon/log_buffer.rs
@@ -137,6 +137,14 @@ where
 {
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
         let metadata = event.metadata();
+        // Never capture the secrets trace target into the in-memory buffer:
+        // /api/v1/logs serves this buffer to viewers, and the secrets trace
+        // logs secret key identifiers / scopes / user ids. Keeping it out of
+        // the buffer prevents that detail from being exposed via the logs API
+        // (and guards against future drift if a value ever gets added there).
+        if metadata.target() == "wshm_core::secrets_trace" {
+            return;
+        }
         let level = match *metadata.level() {
             Level::ERROR => "ERROR",
             Level::WARN => "WARN",

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -180,19 +180,39 @@ impl MultiDaemonState {
             .as_ref()
             .context("Dynamic add_repo not available (daemon not running in multi-repo mode)")?;
 
-        if !slug.contains('/') || slug.split('/').count() != 2 {
+        // Validate the slug: exactly two non-empty owner/repo segments, and
+        // no segment may be a path-traversal token (`.` / `..`) or contain a
+        // separator, so a value like "owner/.." can never become a directory
+        // component of ".." when we derive the on-disk path from it.
+        let segments: Vec<&str> = slug.split('/').collect();
+        if segments.len() != 2
+            || segments
+                .iter()
+                .any(|s| s.is_empty() || *s == "." || *s == ".." || s.contains('\\'))
+        {
             anyhow::bail!("invalid slug format, expected owner/repo");
         }
 
-        let path = path.unwrap_or_else(|| {
-            let name = slug.split('/').next_back().unwrap_or(slug);
-            runtime
-                .global_config_path
-                .parent()
-                .unwrap_or(std::path::Path::new("."))
-                .join("repos")
-                .join(name)
-        });
+        let repos_base = runtime
+            .global_config_path
+            .parent()
+            .unwrap_or(std::path::Path::new("."))
+            .join("repos");
+        let path = match path {
+            // A caller-supplied path is anchored under the repos/ base and must
+            // not escape it (the web layer already rejects absolute paths and
+            // ".." segments; re-check defensively here).
+            Some(p) => {
+                if p.is_absolute() || p.components().any(|c| c.as_os_str() == "..") {
+                    anyhow::bail!("repo path must be relative and must not contain '..'");
+                }
+                repos_base.join(p)
+            }
+            None => {
+                let name = segments[1];
+                repos_base.join(name)
+            }
+        };
 
         {
             let repos = self.repos.read().await;
@@ -492,6 +512,22 @@ pub async fn run_multi_with_extensions(
                  Make sure ONLY your reverse proxy can reach this port — anyone \
                  else can forge X-Forwarded-Email and bypass auth. On K8s, see \
                  deploy/k8s/networkpolicy.yaml."
+            );
+        }
+        let has_token = std::env::var("WSHM_PROXY_AUTH_TOKEN")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false);
+        let isolation_ack = std::env::var("WSHM_TRUST_PROXY_AUTH_NO_TOKEN")
+            .ok()
+            .filter(|v| v == "1" || v == "true")
+            .is_some();
+        if !has_token && !isolation_ack {
+            warn!(
+                "WSHM_TRUST_PROXY_AUTH=1 but WSHM_PROXY_AUTH_TOKEN is unset. \
+                 Forwarded-identity headers will be REJECTED (fail closed). \
+                 Set WSHM_PROXY_AUTH_TOKEN to a shared secret your proxy adds as \
+                 X-Auth-Request-Token, or set WSHM_TRUST_PROXY_AUTH_NO_TOKEN=1 to \
+                 explicitly rely on network isolation alone."
             );
         }
     }

--- a/src/daemon/processor.rs
+++ b/src/daemon/processor.rs
@@ -196,9 +196,19 @@ async fn handle_issue(state: &DaemonState, event: &WebhookEvent) -> anyhow::Resu
             info!("Skipping blacklisted issue #{n}");
             return Ok(());
         }
-        if let Ok(true) = state.db.is_triaged(n) {
-            info!("Issue #{n} already triaged, skipping");
-            return Ok(());
+        match state.db.is_triaged(n) {
+            Ok(true) => {
+                info!("Issue #{n} already triaged, skipping");
+                return Ok(());
+            }
+            Ok(false) => {}
+            Err(e) => {
+                // A transient DB/IO error must NOT fall through to a
+                // re-triage: that would burn AI credits on every error.
+                // Treat an unknown triage state as already-triaged (skip).
+                warn!("is_triaged check failed for #{n}, skipping to avoid re-triage: {e:#}");
+                return Ok(());
+            }
         }
     }
 

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -31,7 +31,7 @@ pub async fn run(
     tls: Option<(String, String)>,
 ) -> Result<()> {
     if secret.is_none() {
-        warn!("No webhook secret configured — webhook endpoint is unauthenticated! Set WSHM_WEBHOOK_SECRET or [daemon].webhook_secret");
+        warn!("No webhook secret configured — /webhook will reject deliveries with 503. Set WSHM_WEBHOOK_SECRET or [daemon].webhook_secret (or WSHM_ALLOW_UNSIGNED_WEBHOOKS=1 to opt in to an unauthenticated endpoint).");
     }
 
     let slug = daemon.config.repo_slug();
@@ -45,6 +45,11 @@ pub async fn run(
     let webhook_routes = Router::new()
         .route("/webhook", post(handle_webhook))
         .route("/health", get(handle_health))
+        // Raise the body limit from axum's implicit 2MB default to the
+        // 25MB GitHub maximum so legitimate large deliveries reach the
+        // explicit size check in validate_webhook instead of being
+        // silently rejected with a 413.
+        .layer(axum::extract::DefaultBodyLimit::max(MAX_WEBHOOK_SIZE))
         .with_state(state);
 
     // Build a single-repo MultiDaemonState for the web UI (no dynamic
@@ -123,6 +128,39 @@ async fn handle_webhook(
             Ok(v) => v,
             Err(resp) => return resp,
         };
+
+    // Replay protection: dedupe on the forge delivery UUID within REPLAY_TTL.
+    // GitHub sends it in x-github-delivery; Gitea/Forgejo (used by wshm-pro)
+    // send it in x-gitea-delivery / x-forgejo-delivery. Consult all three so
+    // dedup is not silently bypassed on a non-GitHub forge. Without this, a
+    // captured signed payload verifies forever and can be replayed to
+    // re-trigger issue/PR processing (auto-fix runs, comment posting, LLM spend).
+    let delivery_id = headers
+        .get("x-github-delivery")
+        .or_else(|| headers.get("x-gitea-delivery"))
+        .or_else(|| headers.get("x-forgejo-delivery"))
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    // When a webhook secret is configured the HMAC already proved authenticity,
+    // so a delivery with no id is almost certainly a forged/malformed replay:
+    // reject it rather than letting it bypass dedup. Without a secret we keep
+    // the lenient behaviour for older senders that omit the header.
+    if delivery_id.is_empty() && state.secret.is_some() {
+        warn!("Rejecting webhook with no delivery id while a secret is configured");
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "missing delivery id"})),
+        )
+            .into_response();
+    }
+    if check_replay(delivery_id).is_err() {
+        info!("Duplicate webhook delivery ignored: {delivery_id}");
+        return (
+            StatusCode::OK,
+            Json(json!({"status": "duplicate", "delivery_id": delivery_id})),
+        )
+            .into_response();
+    }
 
     // Filter: only process relevant events
     if !should_process_event(&event_type, &action) {
@@ -219,6 +257,9 @@ pub async fn run_multi(
     let webhook_routes = Router::new()
         .route("/webhook", post(handle_webhook_multi))
         .route("/health", get(handle_health_multi))
+        // See run(): raise the body limit to the 25MB GitHub maximum so the
+        // explicit size check in validate_webhook is the enforced bound.
+        .layer(axum::extract::DefaultBodyLimit::max(MAX_WEBHOOK_SIZE))
         .with_state(state);
 
     // Seed admin user if a UserStore is provided and the table is empty.
@@ -259,8 +300,18 @@ pub async fn run_multi(
 }
 
 async fn handle_health_multi(State(state): State<Arc<MultiServerState>>) -> impl IntoResponse {
-    let repos_guard = state.multi.repos.read().await;
-    let repos: Vec<Value> = repos_guard
+    // Snapshot the repo map (cloning the Arc<DaemonState> handles) and drop the
+    // read guard BEFORE running the per-repo blocking DB queries. Holding the
+    // guard across a slow/contended pending_event_count() would block
+    // repos.write() (dynamic repo add/remove, config reload) for the whole scan.
+    let snapshot: Vec<(String, Arc<DaemonState>)> = {
+        let repos_guard = state.multi.repos.read().await;
+        repos_guard
+            .iter()
+            .map(|(slug, ds)| (slug.clone(), Arc::clone(ds)))
+            .collect()
+    };
+    let repos: Vec<Value> = snapshot
         .iter()
         .map(|(slug, ds)| {
             let pending = ds.db.pending_event_count().unwrap_or_else(|e| {
@@ -281,8 +332,9 @@ async fn handle_health_multi(State(state): State<Arc<MultiServerState>>) -> impl
     }))
 }
 
-/// In-memory replay cache for inbound webhooks. Keyed on the GitHub
-/// `x-github-delivery` UUID; values are the timestamp the delivery was
+/// In-memory replay cache for inbound webhooks. Keyed on the forge delivery
+/// UUID (`x-github-delivery` / `x-gitea-delivery` / `x-forgejo-delivery`);
+/// values are the timestamp the delivery was
 /// first seen. Entries older than `REPLAY_TTL` are pruned lazily and the
 /// map is capped at `REPLAY_MAX` to bound memory.
 ///
@@ -297,17 +349,20 @@ const REPLAY_TTL: std::time::Duration = std::time::Duration::from_secs(24 * 60 *
 const REPLAY_MAX: usize = 10_000;
 
 /// Returns Ok(()) when the delivery is fresh, Err(()) when it's a
-/// duplicate. Empty / missing delivery_id is always allowed (older
-/// senders may not provide it; the HMAC still gates auth).
+/// duplicate. An empty delivery_id is treated as fresh here (the caller
+/// already rejects empty ids when a secret is configured; older
+/// secret-less senders may legitimately omit the header).
 fn check_replay(delivery_id: &str) -> Result<(), ()> {
     if delivery_id.is_empty() {
         return Ok(());
     }
     let cache =
         REPLAY_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
-    let Ok(mut map) = cache.lock() else {
-        return Ok(()); // poisoned mutex — fail open
-    };
+    // Recover from a poisoned guard rather than failing open: a panic in a
+    // prior holder must not permanently disable replay dedup. The cache is a
+    // plain map of delivery-id -> timestamp, so a partially-updated map is
+    // still safe to keep using.
+    let mut map = cache.lock().unwrap_or_else(|e| e.into_inner());
     let now = std::time::Instant::now();
     if let Some(seen_at) = map.get(delivery_id) {
         if now.duration_since(*seen_at) < REPLAY_TTL {
@@ -340,11 +395,28 @@ async fn handle_webhook_multi(
             Err(resp) => return resp,
         };
 
-    // Replay protection: dedupe on x-github-delivery within REPLAY_TTL.
+    // Replay protection: dedupe on the forge delivery UUID within REPLAY_TTL.
+    // GitHub sends it in x-github-delivery; Gitea/Forgejo (used by wshm-pro)
+    // send it in x-gitea-delivery / x-forgejo-delivery. Consult all three so
+    // dedup is not silently bypassed on a non-GitHub forge.
     let delivery_id = headers
         .get("x-github-delivery")
+        .or_else(|| headers.get("x-gitea-delivery"))
+        .or_else(|| headers.get("x-forgejo-delivery"))
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
+    // When a webhook secret is configured the HMAC already proved authenticity,
+    // so a delivery with no id is almost certainly a forged/malformed replay:
+    // reject it rather than letting it bypass dedup. Without a secret we keep
+    // the lenient behaviour for older senders that omit the header.
+    if delivery_id.is_empty() && state.secret.is_some() {
+        warn!("Rejecting webhook with no delivery id while a secret is configured");
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "missing delivery id"})),
+        )
+            .into_response();
+    }
     if check_replay(delivery_id).is_err() {
         info!("Duplicate webhook delivery ignored: {delivery_id}");
         return (
@@ -468,19 +540,44 @@ fn validate_webhook(
             .into_response());
     }
 
-    // Validate HMAC signature if secret is configured
-    if let Some(secret) = secret {
-        let sig_header = headers
-            .get("x-hub-signature-256")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("");
-        if !verify_signature(secret, body, sig_header) {
-            warn!("Invalid webhook signature");
-            return Err((
-                StatusCode::UNAUTHORIZED,
-                Json(json!({"error": "invalid signature"})),
-            )
-                .into_response());
+    // Validate HMAC signature. Without a configured secret the endpoint
+    // cannot authenticate the sender, so we refuse to process the delivery
+    // rather than silently accepting forged issues/PRs/comments into the
+    // pipeline. Operators who genuinely want an unauthenticated endpoint
+    // must opt in explicitly with WSHM_ALLOW_UNSIGNED_WEBHOOKS=1.
+    match secret {
+        Some(secret) => {
+            let sig_header = headers
+                .get("x-hub-signature-256")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            if !verify_signature(secret, body, sig_header) {
+                warn!("Invalid webhook signature");
+                return Err((
+                    StatusCode::UNAUTHORIZED,
+                    Json(json!({"error": "invalid signature"})),
+                )
+                    .into_response());
+            }
+        }
+        None => {
+            let allow_unsigned = std::env::var("WSHM_ALLOW_UNSIGNED_WEBHOOKS")
+                .ok()
+                .filter(|v| v == "1" || v == "true")
+                .is_some();
+            if !allow_unsigned {
+                warn!(
+                    "Rejecting webhook: no secret configured. Set WSHM_WEBHOOK_SECRET / \
+                     [daemon].webhook_secret, or WSHM_ALLOW_UNSIGNED_WEBHOOKS=1 to opt in \
+                     to an unauthenticated endpoint."
+                );
+                return Err((
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(json!({"error": "webhook secret not configured"})),
+                )
+                    .into_response());
+            }
+            warn!("Processing UNSIGNED webhook (WSHM_ALLOW_UNSIGNED_WEBHOOKS opt-in active)");
         }
     }
 

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -262,6 +262,44 @@ pub fn verify_user_cookie(value: &str) -> Option<i64> {
 /// cookie first, falls back to `X-Auth-Request-Email` / `X-Forwarded-Email`
 /// (oauth2-proxy SSO), upserting the SSO row on first sight. Returns `None`
 /// when no users store is configured or the request has no usable identity.
+/// Optional defense-in-depth for the `WSHM_TRUST_PROXY_AUTH` trust model.
+///
+/// `WSHM_TRUST_PROXY_AUTH=1` makes the daemon trust forwarded-identity headers
+/// (`X-Forwarded-User` / `X-Forwarded-Email` / `X-Auth-Request-Email`) set by
+/// an upstream oauth2-proxy. That trust is only safe if the daemon listener is
+/// network-isolated so ONLY the proxy can reach it — otherwise any client that
+/// can connect directly (a sidecar, SSRF, direct pod/port access) can forge
+/// those headers and authenticate as any email.
+///
+/// When `WSHM_PROXY_AUTH_TOKEN` is set, the proxy must additionally forward a
+/// matching `X-Auth-Request-Token` header (compared in constant time), so mere
+/// header presence is no longer sufficient.
+///
+/// Fail-closed by default: if `WSHM_TRUST_PROXY_AUTH` is enabled but no shared
+/// secret is configured, forwarded-identity headers are REJECTED. Trusting
+/// those headers with no shared secret is only safe behind a network-isolated
+/// listener, so relying on isolation alone must be acknowledged explicitly via
+/// `WSHM_TRUST_PROXY_AUTH_NO_TOKEN=1` — otherwise any client that can reach the
+/// listener directly could forge an identity (and self-promote to admin when
+/// the forged email matches `WSHM_ADMIN_EMAIL`).
+fn proxy_shared_secret_ok(headers: &HeaderMap) -> bool {
+    let expected = std::env::var("WSHM_PROXY_AUTH_TOKEN").unwrap_or_default();
+    if expected.is_empty() {
+        // No shared secret configured. Fail closed unless the operator has
+        // explicitly acknowledged that the trusted listener is network
+        // isolated (only the upstream proxy can reach it).
+        return std::env::var("WSHM_TRUST_PROXY_AUTH_NO_TOKEN")
+            .ok()
+            .filter(|v| v == "1" || v == "true")
+            .is_some();
+    }
+    let presented = headers
+        .get("x-auth-request-token")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    ct_eq(presented.as_bytes(), expected.as_bytes())
+}
+
 async fn current_user(state: &Arc<WebState>, headers: &HeaderMap) -> Option<crate::auth::User> {
     let store = state.users.as_ref()?;
 
@@ -277,7 +315,7 @@ async fn current_user(state: &Arc<WebState>, headers: &HeaderMap) -> Option<crat
         .ok()
         .filter(|v| v == "1" || v == "true")
         .is_some();
-    if trusts_proxy {
+    if trusts_proxy && proxy_shared_secret_ok(headers) {
         let email = headers
             .get("x-auth-request-email")
             .or_else(|| headers.get("x-forwarded-email"))
@@ -315,8 +353,10 @@ async fn current_user(state: &Arc<WebState>, headers: &HeaderMap) -> Option<crat
 /// third-party site, including sibling subdomains under the shared
 /// `.cloud.rtk-ai.app` cookie domain).
 ///
-/// Public bootstrap endpoints (login, logout, license activate) are
-/// exempt — they have no authenticated state to abuse.
+/// Only the unauthenticated bootstrap endpoints (login, logout) are exempt —
+/// they have no authenticated state to abuse. `license/activate` is an
+/// authenticated, state-changing endpoint, so it must carry the CSRF header
+/// like every other mutating route.
 #[allow(clippy::result_large_err)] // axum Response is the natural error shape here
 fn csrf_check(req: &Request<Body>) -> Result<(), Response> {
     let method = req.method();
@@ -327,10 +367,7 @@ fn csrf_check(req: &Request<Body>) -> Result<(), Response> {
     if !path.starts_with("/api/v1/") {
         return Ok(());
     }
-    if matches!(
-        path,
-        "/api/v1/auth/login" | "/api/v1/auth/logout" | "/api/v1/license/activate"
-    ) {
+    if matches!(path, "/api/v1/auth/login" | "/api/v1/auth/logout") {
         return Ok(());
     }
     let has_token = req
@@ -348,6 +385,93 @@ fn csrf_check(req: &Request<Body>) -> Result<(), Response> {
         })),
     )
         .into_response())
+}
+
+/// Build the "not authenticated" response for a rejected request.
+///
+/// Browsers (and SPA fetches) get a 302 to `/login`; API/curl callers get a
+/// 401 (with a `WWW-Authenticate: Basic` challenge for non-browser clients
+/// so CLI tooling can retry with Basic Auth).
+fn unauthorized_response(path: &str, headers: &HeaderMap) -> Response {
+    let accept = headers
+        .get(header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let wants_json = path.starts_with("/api/") || accept.contains("application/json");
+    let is_browser_fetch = headers.contains_key("sec-fetch-mode")
+        || headers.contains_key("sec-fetch-site")
+        || headers.contains_key("origin");
+
+    if wants_json {
+        if is_browser_fetch {
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({"error": "unauthorized"})),
+            )
+                .into_response()
+        } else {
+            (
+                StatusCode::UNAUTHORIZED,
+                [(header::WWW_AUTHENTICATE, "Basic realm=\"wshm\"")],
+                Json(json!({"error": "unauthorized"})),
+            )
+                .into_response()
+        }
+    } else {
+        (
+            StatusCode::FOUND,
+            [(header::LOCATION, HeaderValue::from_static("/login"))],
+        )
+            .into_response()
+    }
+}
+
+/// Whether running completely without configured credentials is explicitly
+/// permitted. Without this opt-in, a daemon that has neither RBAC users nor
+/// a `[web].password` denies all non-public requests (deny-by-default)
+/// rather than serving every repo's data anonymously.
+fn auth_explicitly_disabled() -> bool {
+    std::env::var("WSHM_AUTH_DISABLED")
+        .ok()
+        .filter(|v| v == "1" || v == "true")
+        .is_some()
+}
+
+/// Gather every repo's configured `[web]` (username, password) credential.
+async fn gather_web_cfgs(state: &Arc<WebState>) -> Vec<(String, String)> {
+    let repos = state.multi.repos.read().await;
+    repos
+        .values()
+        .filter_map(|ds| {
+            ds.config
+                .web
+                .password
+                .as_ref()
+                .map(|p| (ds.config.web.username.clone(), p.clone()))
+        })
+        .collect()
+}
+
+/// Constant-time Basic Auth check against any configured `[web]` credential.
+/// A match is a real authenticated request (a valid shared password), not an
+/// anonymous one, so honoring it does not reopen the fail-open hole.
+fn basic_auth_matches(headers: &HeaderMap, web_cfgs: &[(String, String)]) -> bool {
+    headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Basic "))
+        .and_then(|b64| base64::engine::general_purpose::STANDARD.decode(b64).ok())
+        .and_then(|bytes| String::from_utf8(bytes).ok())
+        .map(|decoded| {
+            if let Some((user, pass)) = decoded.split_once(':') {
+                web_cfgs.iter().any(|(u, p)| {
+                    ct_eq(user.as_bytes(), u.as_bytes()) & ct_eq(pass.as_bytes(), p.as_bytes())
+                })
+            } else {
+                false
+            }
+        })
+        .unwrap_or(false)
 }
 
 async fn auth_middleware(
@@ -372,8 +496,21 @@ async fn auth_middleware(
                 .insert(Some(user) as Option<crate::auth::User>);
             return next.run(req).await;
         }
-        // Fall through to the legacy paths below: a CLI client may still be
-        // hitting the API with Basic Auth even though local accounts exist.
+        // RBAC is active but the request carries no valid identity. Do NOT
+        // fall through to the legacy "no password configured" branch (that
+        // used to serve all data unauthenticated even with RBAC on). But
+        // still honor the documented Basic Auth escape hatch
+        // (`WSHM_WEB_PASSWORD` / `[web].password`) used by CLI/curl and the
+        // dev proxy: a valid shared password is authenticated, not anonymous.
+        // Such a request carries no `User`, so role-gated handlers
+        // (require_min_role) still demand a real RBAC login.
+        let web_cfgs = gather_web_cfgs(&state).await;
+        if !web_cfgs.is_empty() && basic_auth_matches(req.headers(), &web_cfgs) {
+            req.extensions_mut()
+                .insert(None as Option<crate::auth::User>);
+            return next.run(req).await;
+        }
+        return unauthorized_response(&path, req.headers());
     }
     req.extensions_mut()
         .insert(None as Option<crate::auth::User>);
@@ -387,22 +524,16 @@ async fn auth_middleware(
     // New behavior: a Basic Auth pair / signed cookie is accepted when
     // it matches ANY configured repo's [web] block. Empty credential
     // lists (no [web] anywhere) keep "auth disabled" semantics.
-    let repos = state.multi.repos.read().await;
-    let web_cfgs: Vec<(String, String)> = repos
-        .values()
-        .filter_map(|ds| {
-            ds.config
-                .web
-                .password
-                .as_ref()
-                .map(|p| (ds.config.web.username.clone(), p.clone()))
-        })
-        .collect();
-    drop(repos);
+    let web_cfgs = gather_web_cfgs(&state).await;
 
-    // No password configured anywhere → auth disabled (single-user dev mode).
+    // No credentials configured anywhere. Deny by default — serving every
+    // repo's data to anonymous callers must be an explicit opt-in
+    // (WSHM_AUTH_DISABLED=1), not the silent fallback it used to be.
     if web_cfgs.is_empty() {
-        return next.run(req).await;
+        if auth_explicitly_disabled() {
+            return next.run(req).await;
+        }
+        return unauthorized_response(&path, req.headers());
     }
     let valid_passwords: Vec<String> = web_cfgs.iter().map(|(_, p)| p.clone()).collect();
 
@@ -413,6 +544,7 @@ async fn auth_middleware(
         .ok()
         .filter(|v| v == "1" || v == "true")
         .is_some()
+        && proxy_shared_secret_ok(req.headers())
     {
         let has_proxy_header = req.headers().keys().any(|k| {
             let n = k.as_str().to_ascii_lowercase();
@@ -443,65 +575,28 @@ async fn auth_middleware(
     // 3) Basic Auth fallback (CLI / curl). Match against ANY configured
     //    repo's (username, password) pair so a single CI script can hit
     //    a multi-repo daemon without picking the "right" repo's creds.
-    let basic_ok = req
-        .headers()
-        .get(header::AUTHORIZATION)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.strip_prefix("Basic "))
-        .and_then(|b64| base64::engine::general_purpose::STANDARD.decode(b64).ok())
-        .and_then(|bytes| String::from_utf8(bytes).ok())
-        .map(|decoded| {
-            if let Some((user, pass)) = decoded.split_once(':') {
-                web_cfgs.iter().any(|(u, p)| user == u && pass == p)
-            } else {
-                false
-            }
-        })
-        .unwrap_or(false);
-    if basic_ok {
+    if basic_auth_matches(req.headers(), &web_cfgs) {
         return next.run(req).await;
     }
 
-    // Decide between 302 (browser → /login) and 401 (API/curl).
-    // Heuristic: API paths and Accept: application/json get JSON; everything
-    // else gets a redirect so the SPA can render the login page.
-    let accept = req
-        .headers()
-        .get(header::ACCEPT)
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-    let wants_json = path.starts_with("/api/") || accept.contains("application/json");
+    unauthorized_response(&path, req.headers())
+}
 
-    // Detect SPA/browser fetches so we don't trigger the native Basic Auth
-    // dialog. CLI clients (curl) don't send Sec-Fetch-* or Origin and still
-    // get the WWW-Authenticate challenge.
-    let headers = req.headers();
-    let is_browser_fetch = headers.contains_key("sec-fetch-mode")
-        || headers.contains_key("sec-fetch-site")
-        || headers.contains_key("origin");
-
-    if wants_json {
-        if is_browser_fetch {
-            (
-                StatusCode::UNAUTHORIZED,
-                Json(json!({"error": "unauthorized"})),
-            )
-                .into_response()
-        } else {
-            (
-                StatusCode::UNAUTHORIZED,
-                [(header::WWW_AUTHENTICATE, "Basic realm=\"wshm\"")],
-                Json(json!({"error": "unauthorized"})),
-            )
-                .into_response()
-        }
-    } else {
-        (
-            StatusCode::FOUND,
-            [(header::LOCATION, HeaderValue::from_static("/login"))],
-        )
-            .into_response()
+/// Constant-time byte-slice equality. Returns `true` only when both slices
+/// have the same length and identical contents, without short-circuiting on
+/// the first differing byte (no timing oracle on the shared secret).
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        // Length is not itself secret here (it leaks nothing about the
+        // matching prefix), and comparing different-length inputs as equal
+        // would be wrong. Diverge only on length.
+        return false;
     }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
 }
 
 /// POST /api/v1/auth/login -- validate credentials and set a session cookie.
@@ -546,6 +641,11 @@ async fn api_auth_login(
         let (user, hash) = match lookup {
             Some((u, Some(h))) => (u, h),
             _ => {
+                // No such user, or a user with no local password hash (SSO-
+                // only). Verify the supplied password against a fixed dummy
+                // hash so this path pays the same argon2 cost as a real wrong
+                // password — closing the username-enumeration timing oracle.
+                crate::auth::verify_password(&password, crate::auth::dummy_password_hash());
                 return (
                     StatusCode::UNAUTHORIZED,
                     Json(json!({"error": "invalid credentials"})),
@@ -603,7 +703,12 @@ async fn api_auth_login(
         }
     };
 
-    if username != web_cfg.username || password != required_password {
+    // Constant-time comparison so the static shared secret can't be
+    // recovered character-by-character via response timing. Both checks
+    // always run (no short-circuit) via the non-short-circuiting `&`.
+    let creds_ok = ct_eq(username.as_bytes(), web_cfg.username.as_bytes())
+        & ct_eq(password.as_bytes(), required_password.as_bytes());
+    if !creds_ok {
         return (
             StatusCode::UNAUTHORIZED,
             Json(json!({"error": "invalid credentials"})),
@@ -654,24 +759,34 @@ async fn api_auth_me(
             .into_response();
     }
 
-    let email = headers
-        .get("x-auth-request-email")
-        .or_else(|| headers.get("x-forwarded-email"))
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_string());
-    let user = headers
-        .get("x-forwarded-user")
-        .or_else(|| headers.get("x-forwarded-preferred-username"))
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_string());
+    // Only reflect forwarded-identity headers when the daemon is configured to
+    // trust the upstream proxy AND the shared-secret gate passes — matching the
+    // guard used in current_user(). Otherwise an attacker who can reach the
+    // listener could make the UI display a forged identity string.
+    let trusts_proxy = std::env::var("WSHM_TRUST_PROXY_AUTH")
+        .ok()
+        .filter(|v| v == "1" || v == "true")
+        .is_some();
+    if trusts_proxy && proxy_shared_secret_ok(&headers) {
+        let email = headers
+            .get("x-auth-request-email")
+            .or_else(|| headers.get("x-forwarded-email"))
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        let user = headers
+            .get("x-forwarded-user")
+            .or_else(|| headers.get("x-forwarded-preferred-username"))
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
 
-    if email.is_some() || user.is_some() {
-        return Json(json!({
-            "email": email,
-            "username": user,
-            "auth_method": "sso",
-        }))
-        .into_response();
+        if email.is_some() || user.is_some() {
+            return Json(json!({
+                "email": email,
+                "username": user,
+                "auth_method": "sso",
+            }))
+            .into_response();
+        }
     }
 
     let repos = state.multi.repos.read().await;
@@ -966,8 +1081,14 @@ async fn api_status(
         repos: Vec::new(),
     };
 
-    let __repos_guard = state.multi.repos.read().await;
-    for (slug, ds) in __repos_guard.iter() {
+    // Snapshot the repo map and drop the read guard before the per-repo
+    // blocking DB work, so the RwLock is not held across the whole scan
+    // (which would block repos.write(): repo add/remove/config reload).
+    let __repos_snapshot: Vec<(String, Arc<super::DaemonState>)> = {
+        let g = state.multi.repos.read().await;
+        g.iter().map(|(s, d)| (s.clone(), Arc::clone(d))).collect()
+    };
+    for (slug, ds) in __repos_snapshot.iter() {
         if let Some(ref f) = filter.repo {
             if f != slug {
                 continue;
@@ -1030,14 +1151,23 @@ async fn api_issues(
 ) -> impl IntoResponse {
     let mut all_issues = Vec::new();
 
-    let __repos_guard = state.multi.repos.read().await;
-    for (slug, ds) in __repos_guard.iter() {
+    // Snapshot the repo map and drop the read guard before the per-repo
+    // blocking DB work, so the RwLock is not held across the whole scan
+    // (which would block repos.write(): repo add/remove/config reload).
+    let __repos_snapshot: Vec<(String, Arc<super::DaemonState>)> = {
+        let g = state.multi.repos.read().await;
+        g.iter().map(|(s, d)| (s.clone(), Arc::clone(d))).collect()
+    };
+    for (slug, ds) in __repos_snapshot.iter() {
         if let Some(ref f) = q.repo {
             if f != slug {
                 continue;
             }
         }
         if let Ok(issues) = ds.db.get_open_issues() {
+            // Batch-load all triage results once (avoids an N+1 per-issue
+            // get_triage_result query).
+            let triage_results = ds.db.get_all_triage_results().unwrap_or_default();
             // Build a map: issue_number -> list of linked PRs (from open PRs bodies)
             let open_prs = ds.db.get_open_pulls().unwrap_or_default();
             let mut issue_prs: std::collections::HashMap<u64, Vec<serde_json::Value>> =
@@ -1058,7 +1188,7 @@ async fn api_issues(
             }
 
             for issue in issues {
-                let triage = ds.db.get_triage_result(issue.number).ok().flatten();
+                let triage = triage_results.get(&issue.number).cloned();
                 let (score, score_breakdown) = crate::pipelines::pr_health::score_issue_with(
                     &issue,
                     triage.as_ref(),
@@ -1144,16 +1274,23 @@ async fn api_pulls(
 ) -> impl IntoResponse {
     let mut all_prs = Vec::new();
 
-    let __repos_guard = state.multi.repos.read().await;
-    for (slug, ds) in __repos_guard.iter() {
+    // Snapshot the repo map and drop the read guard before the per-repo
+    // blocking DB work, so the RwLock is not held across the whole scan
+    // (which would block repos.write(): repo add/remove/config reload).
+    let __repos_snapshot: Vec<(String, Arc<super::DaemonState>)> = {
+        let g = state.multi.repos.read().await;
+        g.iter().map(|(s, d)| (s.clone(), Arc::clone(d))).collect()
+    };
+    for (slug, ds) in __repos_snapshot.iter() {
         if let Some(ref f) = q.repo {
             if f != slug {
                 continue;
             }
         }
         if let Ok(prs) = ds.db.get_open_pulls() {
+            let analyses = ds.db.get_all_pr_analyses().unwrap_or_default();
             for pr in prs {
-                let analysis = ds.db.get_pr_analysis(pr.number).ok().flatten();
+                let analysis = analyses.get(&pr.number);
                 all_prs.push(json!({
                     "repo": slug,
                     "number": pr.number,
@@ -1168,9 +1305,9 @@ async fn api_pulls(
                     "ci_status": pr.ci_status,
                     "created_at": pr.created_at,
                     "updated_at": pr.updated_at,
-                    "risk_level": analysis.as_ref().map(|a| a.risk_level.as_str()),
-                    "pr_type": analysis.as_ref().map(|a| a.pr_type.as_str()),
-                    "summary": analysis.as_ref().map(|a| a.summary.as_str()),
+                    "risk_level": analysis.map(|a| a.risk_level.as_str()),
+                    "pr_type": analysis.map(|a| a.pr_type.as_str()),
+                    "summary": analysis.map(|a| a.summary.as_str()),
                     "url": crate::git_provider::web_url_for_pr(&ds.config, pr.number),
                 }));
             }
@@ -1198,8 +1335,14 @@ async fn api_triage(
 ) -> impl IntoResponse {
     let mut all_results = Vec::new();
 
-    let __repos_guard = state.multi.repos.read().await;
-    for (slug, ds) in __repos_guard.iter() {
+    // Snapshot the repo map and drop the read guard before the per-repo
+    // blocking DB work, so the RwLock is not held across the whole scan
+    // (which would block repos.write(): repo add/remove/config reload).
+    let __repos_snapshot: Vec<(String, Arc<super::DaemonState>)> = {
+        let g = state.multi.repos.read().await;
+        g.iter().map(|(s, d)| (s.clone(), Arc::clone(d))).collect()
+    };
+    for (slug, ds) in __repos_snapshot.iter() {
         if let Some(ref f) = q.repo {
             if f != slug {
                 continue;
@@ -1240,14 +1383,21 @@ async fn api_queue(
 ) -> impl IntoResponse {
     let mut queue = Vec::new();
 
-    let __repos_guard = state.multi.repos.read().await;
-    for (slug, ds) in __repos_guard.iter() {
+    // Snapshot the repo map and drop the read guard before the per-repo
+    // blocking DB work, so the RwLock is not held across the whole scan
+    // (which would block repos.write(): repo add/remove/config reload).
+    let __repos_snapshot: Vec<(String, Arc<super::DaemonState>)> = {
+        let g = state.multi.repos.read().await;
+        g.iter().map(|(s, d)| (s.clone(), Arc::clone(d))).collect()
+    };
+    for (slug, ds) in __repos_snapshot.iter() {
         if let Some(ref f) = q.repo {
             if f != slug {
                 continue;
             }
         }
         if let Ok(prs) = ds.db.get_open_pulls() {
+            let analyses = ds.db.get_all_pr_analyses().unwrap_or_default();
             for pr in prs {
                 // Basic scoring (mirrors pipelines::merge_queue logic)
                 let mut score: i64 = 0;
@@ -1271,8 +1421,8 @@ async fn api_queue(
                 }
 
                 // Analysis data (if available)
-                let analysis = ds.db.get_pr_analysis(pr.number).ok().flatten();
-                if let Some(ref a) = analysis {
+                let analysis = analyses.get(&pr.number);
+                if let Some(a) = analysis {
                     match a.risk_level.as_str() {
                         "low" => score += 5,
                         "high" => score -= 5,
@@ -1288,8 +1438,8 @@ async fn api_queue(
                     "mergeable": pr.mergeable,
                     "ci_status": pr.ci_status,
                     "score": score,
-                    "risk_level": analysis.as_ref().map(|a| &a.risk_level),
-                    "pr_type": analysis.as_ref().map(|a| &a.pr_type),
+                    "risk_level": analysis.map(|a| &a.risk_level),
+                    "pr_type": analysis.map(|a| &a.pr_type),
                     "created_at": pr.created_at,
                 }));
             }
@@ -1318,8 +1468,14 @@ async fn api_activity(
 ) -> impl IntoResponse {
     let mut entries: Vec<ActivityEntry> = Vec::new();
 
-    let __repos_guard = state.multi.repos.read().await;
-    for (slug, ds) in __repos_guard.iter() {
+    // Snapshot the repo map and drop the read guard before the per-repo
+    // blocking DB work, so the RwLock is not held across the whole scan
+    // (which would block repos.write(): repo add/remove/config reload).
+    let __repos_snapshot: Vec<(String, Arc<super::DaemonState>)> = {
+        let g = state.multi.repos.read().await;
+        g.iter().map(|(s, d)| (s.clone(), Arc::clone(d))).collect()
+    };
+    for (slug, ds) in __repos_snapshot.iter() {
         if let Some(ref f) = q.repo {
             if f != slug {
                 continue;
@@ -1342,20 +1498,19 @@ async fn api_activity(
             }
         }
 
-        // PR analysis activity -- iterate open PRs and check for analyses
-        if let Ok(prs) = ds.db.get_open_pulls() {
-            for pr in prs {
-                if let Ok(Some(a)) = ds.db.get_pr_analysis(pr.number) {
-                    entries.push(ActivityEntry {
-                        entry_type: "pr_analysis".to_string(),
-                        repo: slug.clone(),
-                        number: pr.number,
-                        summary: Some(a.summary),
-                        category: Some(a.pr_type),
-                        risk_level: Some(a.risk_level),
-                        at: a.analyzed_at,
-                    });
-                }
+        // PR analysis activity -- one batched query returns every analysis
+        // row directly (only analyzed PRs produce an ActivityEntry).
+        if let Ok(analyses) = ds.db.get_all_pr_analyses() {
+            for (pr_number, a) in analyses {
+                entries.push(ActivityEntry {
+                    entry_type: "pr_analysis".to_string(),
+                    repo: slug.clone(),
+                    number: pr_number,
+                    summary: Some(a.summary),
+                    category: Some(a.pr_type),
+                    risk_level: Some(a.risk_level),
+                    at: a.analyzed_at,
+                });
             }
         }
     }
@@ -1423,8 +1578,14 @@ async fn api_changelog(
     let mut sections: std::collections::HashMap<String, Vec<serde_json::Value>> =
         std::collections::HashMap::new();
 
-    let __repos_guard = state.multi.repos.read().await;
-    for (slug, ds) in __repos_guard.iter() {
+    // Snapshot the repo map and drop the read guard before the per-repo
+    // blocking DB work, so the RwLock is not held across the whole scan
+    // (which would block repos.write(): repo add/remove/config reload).
+    let __repos_snapshot: Vec<(String, Arc<super::DaemonState>)> = {
+        let g = state.multi.repos.read().await;
+        g.iter().map(|(s, d)| (s.clone(), Arc::clone(d))).collect()
+    };
+    for (slug, ds) in __repos_snapshot.iter() {
         if let Some(ref f) = filter.repo {
             if f != slug {
                 continue;
@@ -1524,8 +1685,14 @@ async fn api_revert_preview(
 ) -> impl IntoResponse {
     let mut preview = Vec::new();
 
-    let __repos_guard = state.multi.repos.read().await;
-    for (slug, ds) in __repos_guard.iter() {
+    // Snapshot the repo map and drop the read guard before the per-repo
+    // blocking DB work, so the RwLock is not held across the whole scan
+    // (which would block repos.write(): repo add/remove/config reload).
+    let __repos_snapshot: Vec<(String, Arc<super::DaemonState>)> = {
+        let g = state.multi.repos.read().await;
+        g.iter().map(|(s, d)| (s.clone(), Arc::clone(d))).collect()
+    };
+    for (slug, ds) in __repos_snapshot.iter() {
         if let Some(ref f) = filter.repo {
             if f != slug {
                 continue;
@@ -1535,13 +1702,12 @@ async fn api_revert_preview(
         let mut comments_count = 0usize;
         let mut labels_count = 0usize;
 
+        // Batch-load per-issue applied-label counts once (avoids one
+        // get_wshm_applied_labels query per open issue).
         if let Ok(issues) = ds.db.get_open_issues() {
+            let label_counts = ds.db.get_applied_label_counts().unwrap_or_default();
             for issue in &issues {
-                if let Ok(labels) = ds.db.get_wshm_applied_labels(issue.number) {
-                    if !labels.is_empty() {
-                        labels_count += labels.len();
-                    }
-                }
+                labels_count += label_counts.get(&issue.number).copied().unwrap_or(0);
             }
         }
 
@@ -1549,12 +1715,15 @@ async fn api_revert_preview(
             comments_count = results.len();
         }
 
+        // Count open PRs that have an analysis row using the batched map
+        // instead of a per-PR get_pr_analysis query.
+        let analyses = ds.db.get_all_pr_analyses().unwrap_or_default();
         let pr_analyses_count = ds
             .db
             .get_open_pulls()
             .unwrap_or_default()
             .iter()
-            .filter(|pr| ds.db.get_pr_analysis(pr.number).ok().flatten().is_some())
+            .filter(|pr| analyses.contains_key(&pr.number))
             .count();
 
         preview.push(json!({
@@ -1691,17 +1860,35 @@ async fn run_sync(state: &WebState, repo_filter: Option<&str>, full: bool) -> Re
             .into_response();
     }
 
+    // Sync repos concurrently with bounded fan-out so an all-repos sync
+    // does not run strictly serially. Keep the concurrency modest to respect
+    // GitHub rate limits (mirrors github/sync.rs).
+    const SYNC_CONCURRENCY: usize = 4;
+    use futures::stream::StreamExt;
+    let results: Vec<(String, Result<(), anyhow::Error>)> = futures::stream::iter(targets)
+        .map(|(slug, daemon)| async move {
+            let result = if full {
+                crate::github::sync::full_sync(&daemon.gh(), daemon.db.as_ref()).await
+            } else {
+                crate::github::sync::incremental_sync_full(&daemon.gh(), daemon.db.as_ref()).await
+            };
+            (slug, result)
+        })
+        .buffer_unordered(SYNC_CONCURRENCY)
+        .collect()
+        .await;
+
     let mut synced = Vec::new();
     let mut errors = Vec::new();
-    for (slug, daemon) in targets {
-        let result = if full {
-            crate::github::sync::full_sync(&daemon.gh(), daemon.db.as_ref()).await
-        } else {
-            crate::github::sync::incremental_sync_full(&daemon.gh(), daemon.db.as_ref()).await
-        };
+    for (slug, result) in results {
         match result {
             Ok(()) => synced.push(slug),
-            Err(e) => errors.push(json!({"repo": slug, "error": format!("{e:#}")})),
+            Err(e) => {
+                // Log the full chain server-side; return a sanitized
+                // message in the HTTP body to avoid leaking internal paths.
+                tracing::warn!("[{slug}] sync failed: {e:#}");
+                errors.push(json!({"repo": slug, "error": "sync failed; see server logs"}));
+            }
         }
     }
 
@@ -1724,7 +1911,7 @@ async fn api_restore_backup(
             return e;
         }
     }
-    let path = match body.get("path").and_then(|v| v.as_str()) {
+    let requested = match body.get("path").and_then(|v| v.as_str()) {
         Some(p) if !p.is_empty() => p.to_string(),
         _ => {
             return (
@@ -1738,8 +1925,34 @@ async fn api_restore_backup(
         }
     };
 
+    // Restore is a privileged operation regardless of RBAC mode: it can
+    // overwrite the database, config, and credentials. Constrain the source
+    // to the .wshm/ backups directory so a single-password session cannot
+    // restore from an arbitrary filesystem path (which, combined with the
+    // tarball it points at, would otherwise grant arbitrary file write).
+    let backups_dir = std::path::PathBuf::from(".wshm");
+    let candidate = std::path::Path::new(&requested);
+    // Only accept a bare backup file name (no separators, no parent refs).
+    let file_name = candidate.file_name().and_then(|n| n.to_str());
+    let is_bare_name = file_name == Some(requested.as_str());
+    if !is_bare_name
+        || requested.contains("..")
+        || candidate.is_absolute()
+        || file_name.is_none_or(|n| !n.starts_with("backup-") || !n.ends_with(".tar.gz"))
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "status": "error",
+                "message": "path must be a backup file name inside the .wshm/ directory",
+            })),
+        )
+            .into_response();
+    }
+    let resolved = backups_dir.join(file_name.unwrap());
+
     let args = crate::cli::RestoreArgs {
-        file: path,
+        file: resolved.to_string_lossy().to_string(),
         force: true,
     };
     match crate::pipelines::backup::restore(&args) {
@@ -1934,11 +2147,22 @@ fn activate_license(key: &str) -> Result<String, String> {
         if let Some(parent) = path.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
-        let _ = std::fs::write(&path, token);
+        if let Err(e) = std::fs::write(&path, token) {
+            tracing::warn!("Failed to mirror license to {}: {e}", path.display());
+        }
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+            if let Err(e) = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            {
+                // A failure here can leave the license JWT world-readable
+                // (default umask). The DB copy is authoritative, but warn so
+                // an operator can tighten the on-disk file's permissions.
+                tracing::warn!(
+                    "Failed to set 0o600 on license file {}: {e}",
+                    path.display()
+                );
+            }
         }
 
         Ok(plan)
@@ -2160,12 +2384,29 @@ async fn api_add_repo(
 
     // Path: explicit if provided, else add_repo derives it from the runtime
     // config dir so per-repo state lives on the same volume as global.toml.
-    let path = body
+    // A caller-supplied path is a directory-creation + SQLite-write primitive
+    // (add_repo does create_dir_all + opens a DB there and loads any existing
+    // config.toml), so reject absolute paths and any parent-dir traversal —
+    // mirroring the hardening in api_restore_backup. add_repo then anchors the
+    // value under the global config dir's repos/ subtree.
+    let path_str = body
         .get("path")
         .and_then(|v| v.as_str())
         .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(std::path::PathBuf::from);
+        .filter(|s| !s.is_empty());
+    if let Some(p) = path_str {
+        let candidate = std::path::Path::new(p);
+        if candidate.is_absolute() || candidate.components().any(|c| c.as_os_str() == "..") {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "error": "path must be a relative name without '..' (it is anchored under the config repos/ directory)"
+                })),
+            )
+                .into_response();
+        }
+    }
+    let path = path_str.map(std::path::PathBuf::from);
 
     match state.multi.add_repo(&slug, path).await {
         Ok(state) => (
@@ -2220,14 +2461,28 @@ async fn api_summary(
 
     let slug = format!("{}/{}", ds.config.repo_owner, ds.config.repo_name);
     let issues = ds.db.get_open_issues().unwrap_or_default();
-    let untriaged = ds.db.get_untriaged_issues().unwrap_or_default();
     let prs = ds.db.get_open_pulls().unwrap_or_default();
     let conflicts = prs.iter().filter(|p| p.mergeable == Some(false)).count();
+
+    // Untriaged count: derive it from the already-loaded open issues and the
+    // triage-results key set instead of issuing a second full LEFT JOIN scan of
+    // the issues table (the former get_untriaged_issues query). A single
+    // get_all_triage_results() index read replaces that join.
+    let triage = ds.db.get_all_triage_results().unwrap_or_default();
+    let untriaged_count = issues
+        .iter()
+        .filter(|i| !triage.contains_key(&i.number))
+        .count();
+
+    // Batch-load all PR analyses once; the three passes below (unanalyzed
+    // count, high-risk, top PRs) all index into this map instead of issuing
+    // a per-PR get_pr_analysis query.
+    let analyses = ds.db.get_all_pr_analyses().unwrap_or_default();
 
     // unanalyzed_prs: count PRs without an analysis row.
     let unanalyzed_count = prs
         .iter()
-        .filter(|p| ds.db.get_pr_analysis(p.number).ok().flatten().is_none())
+        .filter(|p| !analyses.contains_key(&p.number))
         .count();
 
     let now = chrono::Utc::now();
@@ -2270,47 +2525,44 @@ async fn api_summary(
         .map(to_issue_brief)
         .collect();
 
-    // Top issues: by reactions+1, then by recency.
-    let mut sorted_issues = issues.clone();
+    // Top issues: by reactions+1, then by recency. Sort a Vec of
+    // references to avoid a full deep clone of every issue just to take 5.
+    let mut sorted_issues: Vec<&crate::db::issues::Issue> = issues.iter().collect();
     sorted_issues.sort_by(|a, b| {
         b.reactions_plus1
             .cmp(&a.reactions_plus1)
             .then_with(|| b.updated_at.cmp(&a.updated_at))
     });
-    let top_issues: Vec<_> = sorted_issues.iter().take(5).map(to_issue_brief).collect();
+    let top_issues: Vec<_> = sorted_issues
+        .iter()
+        .take(5)
+        .map(|i| to_issue_brief(i))
+        .collect();
 
     // High-risk PRs: where analysis.risk_level is high or critical.
     let high_risk_prs: Vec<_> = prs
         .iter()
         .filter_map(|p| {
-            ds.db
-                .get_pr_analysis(p.number)
-                .ok()
-                .flatten()
-                .and_then(|a| {
-                    if a.risk_level == "high" || a.risk_level == "critical" {
-                        Some(to_pr_brief(p, Some(a.risk_level)))
-                    } else {
-                        None
-                    }
-                })
+            analyses.get(&p.number).and_then(|a| {
+                if a.risk_level == "high" || a.risk_level == "critical" {
+                    Some(to_pr_brief(p, Some(a.risk_level.clone())))
+                } else {
+                    None
+                }
+            })
         })
         .take(5)
         .collect();
 
-    // Top PRs: oldest open first (these are the ones at risk of being forgotten).
-    let mut sorted_prs = prs.clone();
+    // Top PRs: oldest open first (these are the ones at risk of being
+    // forgotten). Sort references to avoid deep-cloning every PR.
+    let mut sorted_prs: Vec<&crate::db::pulls::PullRequest> = prs.iter().collect();
     sorted_prs.sort_by(|a, b| a.created_at.cmp(&b.created_at));
     let top_prs: Vec<_> = sorted_prs
         .iter()
         .take(5)
         .map(|p| {
-            let risk = ds
-                .db
-                .get_pr_analysis(p.number)
-                .ok()
-                .flatten()
-                .map(|a| a.risk_level);
+            let risk = analyses.get(&p.number).map(|a| a.risk_level.clone());
             to_pr_brief(p, risk)
         })
         .collect();
@@ -2319,7 +2571,7 @@ async fn api_summary(
         "repo": slug,
         "timestamp": now.to_rfc3339(),
         "open_issues": issues.len(),
-        "untriaged_issues": untriaged.len(),
+        "untriaged_issues": untriaged_count,
         "high_priority_issues": high_priority_issues,
         "top_issues": top_issues,
         "open_prs": prs.len(),
@@ -2339,27 +2591,31 @@ async fn api_summary(
 async fn api_auth_status(State(state): State<Arc<WebState>>) -> impl IntoResponse {
     let creds = crate::login::load_credentials();
 
-    let secrets_has = |key: &str| -> bool {
-        if let Some(store) = state.secrets.as_ref() {
-            if let Ok(Some(v)) = store.get_blocking(crate::secrets::Scope::Global, None, key) {
+    // Use the async get() (yields at the await point) rather than the
+    // blocking variant, so this handler never holds a std Mutex across a
+    // synchronous sqlite query on the tokio worker.
+    let store = state.secrets.as_ref();
+    let secrets_has = |key: &'static str| async move {
+        if let Some(store) = store {
+            if let Ok(Some(v)) = store.get(crate::secrets::Scope::Global, None, key).await {
                 return !v.is_empty();
             }
         }
         false
     };
 
-    let github = secrets_has("github_token")
+    let github = secrets_has("github_token").await
         || creds.contains_key("GITHUB_TOKEN")
         || std::env::var("GITHUB_TOKEN").is_ok()
         || std::env::var("WSHM_TOKEN").is_ok();
 
-    let anthropic_kind = if secrets_has("anthropic_oauth_token")
+    let anthropic_kind = if secrets_has("anthropic_oauth_token").await
         || creds.contains_key("ANTHROPIC_OAUTH_TOKEN")
         || std::env::var("ANTHROPIC_OAUTH_TOKEN").is_ok()
         || std::env::var("CLAUDE_CODE_OAUTH_TOKEN").is_ok()
     {
         Some("oauth")
-    } else if secrets_has("anthropic_api_key")
+    } else if secrets_has("anthropic_api_key").await
         || creds.contains_key("ANTHROPIC_API_KEY")
         || std::env::var("ANTHROPIC_API_KEY").is_ok()
     {
@@ -2415,9 +2671,13 @@ async fn api_auth_github(
             )
             .await
         {
+            tracing::warn!("Failed to persist GitHub token to secret store: {e:#}");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"status": "error", "message": format!("{e}")})),
+                Json(json!({
+                    "status": "error",
+                    "message": "failed to persist GitHub token; see server logs",
+                })),
             )
                 .into_response();
         }
@@ -2425,7 +2685,14 @@ async fn api_auth_github(
         // plaintext copy so we don't keep two sources of truth.
         let mut creds = crate::login::load_credentials();
         if creds.remove("GITHUB_TOKEN").is_some() {
-            let _ = crate::login::save_credentials(&creds);
+            if let Err(e) = crate::login::save_credentials(&creds) {
+                // The token now lives in the encrypted store but the
+                // legacy plaintext copy could NOT be scrubbed — surface it
+                // so the operator knows the secret still exists on disk.
+                tracing::warn!(
+                    "Failed to scrub legacy plaintext GITHUB_TOKEN after encrypting: {e:#}"
+                );
+            }
         }
         "encrypted store"
     } else {
@@ -2433,9 +2700,13 @@ async fn api_auth_github(
         let mut creds = crate::login::load_credentials();
         creds.insert("GITHUB_TOKEN".to_string(), token.clone());
         if let Err(e) = crate::login::save_credentials(&creds) {
+            tracing::warn!("Failed to persist GitHub token to credentials file: {e:#}");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"status": "error", "message": format!("{e}")})),
+                Json(json!({
+                    "status": "error",
+                    "message": "failed to persist GitHub token; see server logs",
+                })),
             )
                 .into_response();
         }
@@ -2476,8 +2747,13 @@ async fn api_auth_github_delete(
         if let Ok(list) = store.list().await {
             for s in list {
                 if s.scope == "global" && s.slug.is_none() && s.key == "github_token" {
-                    let _ = store.delete(s.id, None).await;
-                    removed_any = true;
+                    match store.delete(s.id, None).await {
+                        Ok(true) => removed_any = true,
+                        Ok(false) => {}
+                        Err(e) => tracing::warn!(
+                            "Failed to delete github_token from encrypted store: {e:#}"
+                        ),
+                    }
                 }
             }
         }
@@ -2486,8 +2762,12 @@ async fn api_auth_github_delete(
     // Remove from plaintext file.
     let mut creds = crate::login::load_credentials();
     if creds.remove("GITHUB_TOKEN").is_some() {
-        let _ = crate::login::save_credentials(&creds);
-        removed_any = true;
+        match crate::login::save_credentials(&creds) {
+            Ok(()) => removed_any = true,
+            Err(e) => tracing::warn!(
+                "Failed to scrub GITHUB_TOKEN from plaintext credentials file: {e:#}"
+            ),
+        }
     }
 
     // Clear from process env.
@@ -2561,7 +2841,11 @@ async fn api_auth_anthropic(
         if let Ok(list) = store.list().await {
             for s in list {
                 if s.scope == "global" && s.slug.is_none() && s.key == other_secret {
-                    let _ = store.delete(s.id, None).await;
+                    if let Err(e) = store.delete(s.id, None).await {
+                        tracing::warn!(
+                            "Failed to delete stale {other_secret} from encrypted store: {e:#}"
+                        );
+                    }
                 }
             }
         }
@@ -2575,9 +2859,13 @@ async fn api_auth_anthropic(
             )
             .await
         {
+            tracing::warn!("Failed to persist Anthropic token to secret store: {e:#}");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"status": "error", "message": format!("{e}")})),
+                Json(json!({
+                    "status": "error",
+                    "message": "failed to persist token; see server logs",
+                })),
             )
                 .into_response();
         }
@@ -2587,7 +2875,13 @@ async fn api_auth_anthropic(
         scrubbed |= creds.remove(env_key).is_some();
         scrubbed |= creds.remove(other_env).is_some();
         if scrubbed {
-            let _ = crate::login::save_credentials(&creds);
+            if let Err(e) = crate::login::save_credentials(&creds) {
+                // Token is in the encrypted store but the legacy plaintext
+                // copy could not be scrubbed — warn so the operator knows.
+                tracing::warn!(
+                    "Failed to scrub legacy plaintext Anthropic token after encrypting: {e:#}"
+                );
+            }
         }
         "encrypted store"
     } else {
@@ -2595,9 +2889,13 @@ async fn api_auth_anthropic(
         creds.remove(other_env);
         creds.insert(env_key.to_string(), token.clone());
         if let Err(e) = crate::login::save_credentials(&creds) {
+            tracing::warn!("Failed to persist Anthropic token to credentials file: {e:#}");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"status": "error", "message": format!("{e}")})),
+                Json(json!({
+                    "status": "error",
+                    "message": "failed to persist token; see server logs",
+                })),
             )
                 .into_response();
         }
@@ -2636,8 +2934,13 @@ async fn api_auth_anthropic_delete(
                     && s.slug.is_none()
                     && (s.key == "anthropic_oauth_token" || s.key == "anthropic_api_key")
                 {
-                    let _ = store.delete(s.id, None).await;
-                    removed_any = true;
+                    match store.delete(s.id, None).await {
+                        Ok(true) => removed_any = true,
+                        Ok(false) => {}
+                        Err(e) => {
+                            tracing::warn!("Failed to delete {} from encrypted store: {e:#}", s.key)
+                        }
+                    }
                 }
             }
         }
@@ -2648,8 +2951,12 @@ async fn api_auth_anthropic_delete(
     creds.remove("ANTHROPIC_OAUTH_TOKEN");
     creds.remove("ANTHROPIC_API_KEY");
     if creds.len() != before {
-        let _ = crate::login::save_credentials(&creds);
-        removed_any = true;
+        match crate::login::save_credentials(&creds) {
+            Ok(()) => removed_any = true,
+            Err(e) => tracing::warn!(
+                "Failed to scrub Anthropic tokens from plaintext credentials file: {e:#}"
+            ),
+        }
     }
 
     std::env::remove_var("ANTHROPIC_OAUTH_TOKEN");
@@ -3088,6 +3395,15 @@ pub fn web_routes(multi: Arc<MultiDaemonState>) -> Router {
 ///
 /// - `users`: enable RBAC mode by passing a populated UserStore. `None`
 ///   keeps the legacy single-credential `[web].username/password` flow.
+///
+///   SECURITY: in legacy mode (`users = None`) there is no role model, so the
+///   privileged, secret-writing token-management endpoints
+///   (`POST`/`DELETE /api/v1/auth/github` and `/api/v1/auth/anthropic`) cannot
+///   enforce an admin gate — any authenticated caller (the single shared web
+///   password / trusted proxy identity) can write or delete the GitHub and
+///   Anthropic tokens. The OSS `run()` path always opens a UserStore so RBAC is
+///   active there; embedders MUST NOT use `users = None` with a
+///   network-exposed listener.
 /// - `extra_api`: additional `Router<Arc<WebState>>` whose routes get merged
 ///   into the main router under the same auth layer. Use this to register
 ///   Pro API endpoints from extension crates.

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -39,6 +39,12 @@ pub trait DatabaseBackend: Send + Sync {
     fn get_open_pulls(&self) -> Result<Vec<PullRequest>>;
     fn get_unanalyzed_pulls(&self) -> Result<Vec<PullRequest>>;
     fn get_pr_analysis(&self, pr_number: u64) -> Result<Option<PrAnalysisRow>>;
+    /// Batch loader: every PR analysis keyed by PR number, in one query.
+    /// Used by the web handlers to avoid an N+1 `get_pr_analysis` per open
+    /// PR. Default impl returns an empty map; SQLite overrides it.
+    fn get_all_pr_analyses(&self) -> Result<std::collections::HashMap<u64, PrAnalysisRow>> {
+        Ok(std::collections::HashMap::new())
+    }
     /// Recently-closed pull requests (highest `updated_at` first), capped
     /// at `limit`. Backs the changelog view in TUI and the /api/v1/changelog
     /// endpoint.
@@ -57,6 +63,18 @@ pub trait DatabaseBackend: Send + Sync {
         content_hash: Option<&str>,
     ) -> Result<()>;
     fn get_triage_result(&self, issue_number: u64) -> Result<Option<TriageResultRow>>;
+    /// Batch loader: every triage result keyed by issue number. Used by the
+    /// web handlers to avoid an N+1 `get_triage_result` per open issue.
+    /// Default impl falls back to an empty map; the SQLite backend overrides
+    /// it with a single query.
+    fn get_all_triage_results(&self) -> Result<std::collections::HashMap<u64, TriageResultRow>> {
+        Ok(std::collections::HashMap::new())
+    }
+    /// Batch loader: count of wshm-applied labels per issue, in one query.
+    /// Default impl returns an empty map; SQLite overrides it.
+    fn get_applied_label_counts(&self) -> Result<std::collections::HashMap<u64, usize>> {
+        Ok(std::collections::HashMap::new())
+    }
     /// Insert `triage_results` stubs for open issues that already carry
     /// wshm-managed labels on the forge but have no local row. Lets a
     /// fresh install / migration / wiped state.db avoid re-spending LLM
@@ -227,6 +245,10 @@ impl DatabaseBackend for super::Database {
         self.get_pr_analysis(pr_number)
     }
 
+    fn get_all_pr_analyses(&self) -> Result<std::collections::HashMap<u64, PrAnalysisRow>> {
+        self.get_all_pr_analyses()
+    }
+
     fn get_closed_pulls(&self, limit: usize) -> Result<Vec<PullRequest>> {
         self.get_closed_pulls(limit)
     }
@@ -246,6 +268,14 @@ impl DatabaseBackend for super::Database {
 
     fn get_triage_result(&self, issue_number: u64) -> Result<Option<TriageResultRow>> {
         self.get_triage_result(issue_number)
+    }
+
+    fn get_all_triage_results(&self) -> Result<std::collections::HashMap<u64, TriageResultRow>> {
+        self.get_all_triage_results()
+    }
+
+    fn get_applied_label_counts(&self) -> Result<std::collections::HashMap<u64, usize>> {
+        self.get_applied_label_counts()
     }
 
     fn seed_triage_stubs_from_labels(

--- a/src/db/issues.rs
+++ b/src/db/issues.rs
@@ -247,22 +247,27 @@ pub fn get_issues_needing_triage(
         }
 
         let (issue, stored_hash, acted_at) = row?;
-        let current_hash = compute_issue_hash(&issue.title, issue.body.as_deref());
 
+        // Short-circuit: a never-triaged issue (no stored hash) always
+        // needs triage, so we can skip the comparatively expensive content
+        // hash computation entirely.
         let needs_triage = stored_hash.is_none()
-            || stored_hash.as_deref() != Some(current_hash.as_str())
+            || stored_hash.as_deref()
+                != Some(compute_issue_hash(&issue.title, issue.body.as_deref()).as_str())
             || (!relabel_labels.is_empty()
                 && issue
                     .labels
                     .iter()
                     .any(|l| relabel_labels.iter().any(|r| r.eq_ignore_ascii_case(l))))
-            || (age_cutoff.is_some()
-                && issue.labels.is_empty()
-                && acted_at
-                    .as_deref()
-                    .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-                    .map(|dt| dt.with_timezone(&chrono::Utc) < age_cutoff.unwrap())
-                    .unwrap_or(false));
+            || (issue.labels.is_empty()
+                && match age_cutoff {
+                    Some(cutoff) => acted_at
+                        .as_deref()
+                        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                        .map(|dt| dt.with_timezone(&chrono::Utc) < cutoff)
+                        .unwrap_or(false),
+                    None => false,
+                });
 
         if needs_triage {
             issues_needing_triage.push(issue);

--- a/src/db/pulls.rs
+++ b/src/db/pulls.rs
@@ -62,6 +62,34 @@ impl Database {
         })
     }
 
+    /// Load every PR analysis in a single query, keyed by PR number.
+    ///
+    /// Batch loader used by the web handlers to avoid an N+1 pattern where
+    /// `get_pr_analysis` was called once per open PR (each call took the
+    /// connection mutex and prepared a fresh statement).
+    pub fn get_all_pr_analyses(&self) -> Result<std::collections::HashMap<u64, PrAnalysisRow>> {
+        self.with_conn(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT pr_number, summary, risk_level, pr_type, review_notes, analyzed_at, content_hash
+                 FROM pr_analyses",
+            )?;
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok(PrAnalysisRow {
+                        pr_number: row.get(0)?,
+                        summary: row.get(1)?,
+                        risk_level: row.get(2)?,
+                        pr_type: row.get(3)?,
+                        review_notes: row.get(4)?,
+                        analyzed_at: row.get(5)?,
+                        content_hash: row.get(6)?,
+                    })
+                })?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            Ok(rows.into_iter().map(|r| (r.pr_number, r)).collect())
+        })
+    }
+
     pub fn upsert_pull(&self, pr: &PullRequest) -> Result<()> {
         self.with_conn(|conn| {
             upsert_pull(conn, pr)?;

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -107,6 +107,16 @@ pub fn run_migrations(conn: &Connection) -> Result<()> {
         )?;
     }
 
+    // Composite index covering the WHERE state='open' filter + the
+    // ORDER BY reactions_total DESC used by get_issues_needing_triage and
+    // get_untriaged_issues, so the scan no longer forces a full-table sort.
+    // Created here (after the reactions columns exist) rather than in the
+    // initial batch above, where reactions_total may not yet be present.
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_issues_state_reactions
+         ON issues(state, reactions_total DESC);",
+    )?;
+
     // Migration: add content_hash to triage_results and pr_analyses (for LLM call deduplication)
     let has_triage_hash: bool = conn
         .prepare("SELECT content_hash FROM triage_results LIMIT 0")

--- a/src/db/triage.rs
+++ b/src/db/triage.rs
@@ -23,6 +23,23 @@ fn first_after_prefix(labels: &[String], prefix: &str) -> Option<String> {
     })
 }
 
+/// Map a row from a `SELECT issue_number, category, confidence, priority,
+/// summary, is_simple_fix, acted_at, content_hash` query into a
+/// [`TriageResultRow`]. Shared by the three queries below so a column-order
+/// change only needs editing in one place.
+fn row_to_triage_result(row: &rusqlite::Row) -> rusqlite::Result<TriageResultRow> {
+    Ok(TriageResultRow {
+        issue_number: row.get(0)?,
+        category: row.get(1)?,
+        confidence: row.get(2)?,
+        priority: row.get(3)?,
+        summary: row.get(4)?,
+        is_simple_fix: row.get(5)?,
+        acted_at: row.get(6)?,
+        content_hash: row.get(7)?,
+    })
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TriageResultRow {
     pub issue_number: u64,
@@ -95,18 +112,7 @@ impl Database {
                  FROM triage_results WHERE issue_number = ?1",
             )?;
 
-            let result = stmt.query_row(params![issue_number], |row| {
-                Ok(TriageResultRow {
-                    issue_number: row.get(0)?,
-                    category: row.get(1)?,
-                    confidence: row.get(2)?,
-                    priority: row.get(3)?,
-                    summary: row.get(4)?,
-                    is_simple_fix: row.get(5)?,
-                    acted_at: row.get(6)?,
-                    content_hash: row.get(7)?,
-                })
-            });
+            let result = stmt.query_row(params![issue_number], row_to_triage_result);
 
             match result {
                 Ok(r) => Ok(Some(r)),
@@ -131,21 +137,30 @@ impl Database {
             )?;
 
             let rows = stmt
-                .query_map(rusqlite::params![cutoff_str], |row| {
-                    Ok(TriageResultRow {
-                        issue_number: row.get(0)?,
-                        category: row.get(1)?,
-                        confidence: row.get(2)?,
-                        priority: row.get(3)?,
-                        summary: row.get(4)?,
-                        is_simple_fix: row.get(5)?,
-                        acted_at: row.get(6)?,
-                        content_hash: row.get(7)?,
-                    })
-                })?
+                .query_map(rusqlite::params![cutoff_str], row_to_triage_result)?
                 .collect::<std::result::Result<Vec<_>, _>>()?;
 
             Ok(rows)
+        })
+    }
+
+    /// Load every triage result in a single query, keyed by issue number.
+    ///
+    /// Batch loader used by the web handlers to avoid an N+1 pattern where
+    /// `get_triage_result` was called once per open issue (each call took
+    /// the connection mutex and prepared a fresh statement).
+    pub fn get_all_triage_results(
+        &self,
+    ) -> Result<std::collections::HashMap<u64, TriageResultRow>> {
+        self.with_conn(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT issue_number, category, confidence, priority, summary, is_simple_fix, acted_at, content_hash
+                 FROM triage_results",
+            )?;
+            let rows = stmt
+                .query_map([], row_to_triage_result)?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            Ok(rows.into_iter().map(|r| (r.issue_number, r)).collect())
         })
     }
 
@@ -165,6 +180,33 @@ impl Database {
         })
     }
 
+    /// Sum the count of wshm-applied labels per issue in a single query.
+    /// Returns a map of issue_number -> number of suggested_labels.
+    ///
+    /// Batch replacement for calling `get_wshm_applied_labels` once per open
+    /// issue (used by the revert-preview handler).
+    pub fn get_applied_label_counts(&self) -> Result<std::collections::HashMap<u64, usize>> {
+        self.with_conn(|conn| {
+            let mut stmt =
+                conn.prepare("SELECT issue_number, suggested_labels FROM triage_results")?;
+            let rows = stmt
+                .query_map([], |row| {
+                    let issue_number: u64 = row.get(0)?;
+                    let labels_json: String = row.get(1)?;
+                    Ok((issue_number, labels_json))
+                })?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            let mut map = std::collections::HashMap::new();
+            for (issue_number, labels_json) in rows {
+                let count = serde_json::from_str::<Vec<String>>(&labels_json)
+                    .map(|v| v.len())
+                    .unwrap_or(0);
+                map.insert(issue_number, count);
+            }
+            Ok(map)
+        })
+    }
+
     /// Get recent triage activity (last N entries, most recent first).
     pub fn recent_activity(&self, limit: usize) -> Result<Vec<TriageResultRow>> {
         self.with_conn(|conn| {
@@ -175,18 +217,7 @@ impl Database {
                  LIMIT ?1",
             )?;
             let rows = stmt
-                .query_map(rusqlite::params![limit], |row| {
-                    Ok(TriageResultRow {
-                        issue_number: row.get(0)?,
-                        category: row.get(1)?,
-                        confidence: row.get(2)?,
-                        priority: row.get(3)?,
-                        summary: row.get(4)?,
-                        is_simple_fix: row.get(5)?,
-                        acted_at: row.get(6)?,
-                        content_hash: row.get(7)?,
-                    })
-                })?
+                .query_map(rusqlite::params![limit], row_to_triage_result)?
                 .collect::<std::result::Result<Vec<_>, _>>()?;
             Ok(rows)
         })
@@ -305,9 +336,14 @@ impl Database {
 
             let now = chrono::Utc::now().to_rfc3339();
             let mut inserted: u64 = 0;
-            for stub in stubs {
+            // Wrap the inserts in a single transaction so seeding K stubs
+            // costs one fsync instead of K (each bare conn.execute would
+            // auto-commit). On a fresh/wiped state.db this can be hundreds
+            // of issues.
+            let tx = conn.unchecked_transaction()?;
+            for stub in &stubs {
                 let suggested = serde_json::to_string(&stub.matched_labels)?;
-                let n = conn.execute(
+                let n = tx.execute(
                     "INSERT INTO triage_results (issue_number, category, confidence, priority, summary, suggested_labels, is_duplicate_of, is_simple_fix, relevant_files, acted_at, content_hash)
                      VALUES (?1, ?2, ?3, ?4, NULL, ?5, NULL, 0, '[]', ?6, ?7)
                      ON CONFLICT(issue_number) DO NOTHING",
@@ -323,6 +359,7 @@ impl Database {
                 )?;
                 inserted += n as u64;
             }
+            tx.commit()?;
 
             Ok(inserted)
         })

--- a/src/git_provider/azure_devops.rs
+++ b/src/git_provider/azure_devops.rs
@@ -94,7 +94,11 @@ impl AzureDevOpsProvider {
     }
 
     async fn post(&self, url: &str, body: &serde_json::Value) -> Result<serde_json::Value> {
-        crate::retry::with_retry("Azure DevOps POST", || async {
+        // Connect-only retry: POST creates non-idempotent resources (comments,
+        // threads). A response-body EOF after the server already created the
+        // resource must NOT be retried, or the comment is duplicated. The one
+        // read-only POST caller (WIQL query) is also safe under connect-only.
+        crate::retry::with_retry_connect_only("Azure DevOps POST", || async {
             let resp = self
                 .http
                 .post(url)

--- a/src/git_provider/gitea.rs
+++ b/src/git_provider/gitea.rs
@@ -77,7 +77,10 @@ impl GiteaProvider {
 
     async fn post_json(&self, path: &str, body: &serde_json::Value) -> Result<serde_json::Value> {
         let url = self.api_url(path);
-        crate::retry::with_retry("Gitea POST", || async {
+        // Connect-only retry: POST creates non-idempotent resources (issue
+        // comments, reviews). A response-body EOF after the server already
+        // created the comment must NOT be retried, or it is duplicated.
+        crate::retry::with_retry_connect_only("Gitea POST", || async {
             let resp = self
                 .http
                 .post(&url)

--- a/src/git_provider/gitlab.rs
+++ b/src/git_provider/gitlab.rs
@@ -73,7 +73,10 @@ impl GitLabProvider {
 
     async fn post(&self, path: &str, body: &serde_json::Value) -> Result<serde_json::Value> {
         let url = self.api_url(path);
-        crate::retry::with_retry("GitLab POST", || async {
+        // Connect-only retry: POST creates non-idempotent resources (notes,
+        // discussions). A response-body EOF after the server already created
+        // the note must NOT be retried, or the comment/review is duplicated.
+        crate::retry::with_retry_connect_only("GitLab POST", || async {
             let resp = self
                 .http
                 .post(&url)

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -135,18 +135,21 @@ impl Client {
             self.owner, self.repo
         );
 
-        let response_body = crate::retry::with_retry("github: create draft PR", || async {
-            let response = self
-                .octocrab
-                ._post(&url, Some(&pr_body))
-                .await
-                .context("Failed to create draft pull request")?;
-            self.octocrab
-                .body_to_string(response)
-                .await
-                .context("Failed to read create PR response")
-        })
-        .await?;
+        // Connect-only retry: re-issuing after a post-send EOF would create
+        // a duplicate draft PR.
+        let response_body =
+            crate::retry::with_retry_connect_only("github: create draft PR", || async {
+                let response = self
+                    .octocrab
+                    ._post(&url, Some(&pr_body))
+                    .await
+                    .context("Failed to create draft pull request")?;
+                self.octocrab
+                    .body_to_string(response)
+                    .await
+                    .context("Failed to read create PR response")
+            })
+            .await?;
 
         let pr_json: serde_json::Value =
             serde_json::from_str(&response_body).context("Failed to parse create PR response")?;

--- a/src/github/issues.rs
+++ b/src/github/issues.rs
@@ -175,7 +175,9 @@ impl Client {
         );
         let body = serde_json::json!({ "assignees": assignees });
 
-        crate::retry::with_retry("github: add assignees", || async {
+        // POST endpoint — use connect-only retry so a post-send EOF doesn't
+        // re-issue the write.
+        crate::retry::with_retry_connect_only("github: add assignees", || async {
             let response = self
                 .octocrab
                 ._post(&url, Some(&body))
@@ -202,7 +204,9 @@ impl Client {
             self.update_comment(comment_id, &body_with_marker).await?;
         } else {
             debug!("Creating new wshm comment on issue #{number}");
-            crate::retry::with_retry("github: create comment", || async {
+            // Connect-only retry: re-issuing a create after a post-send body
+            // EOF would duplicate the comment.
+            crate::retry::with_retry_connect_only("github: create comment", || async {
                 self.octocrab
                     .issues(&self.owner, &self.repo)
                     .create_comment(number, &body_with_marker)
@@ -345,7 +349,9 @@ impl Client {
 
     pub async fn create_issue(&self, title: &str, body: &str, labels: &[String]) -> Result<u64> {
         let body = ensure_comment_marker(body, &self.comment_marker);
-        let issue = crate::retry::with_retry("github: create issue", || async {
+        // Connect-only retry: re-issuing after a post-send EOF would create
+        // a duplicate issue.
+        let issue = crate::retry::with_retry_connect_only("github: create issue", || async {
             self.octocrab
                 .issues(&self.owner, &self.repo)
                 .create(title)

--- a/src/github/pulls.rs
+++ b/src/github/pulls.rs
@@ -332,7 +332,9 @@ impl Client {
             self.owner, self.repo
         );
 
-        crate::retry::with_retry("github: submit review", || async {
+        // Connect-only retry: re-issuing after a post-send EOF would submit
+        // a duplicate review.
+        crate::retry::with_retry_connect_only("github: submit review", || async {
             let response = self
                 .octocrab
                 ._post(&url, Some(&review_body))
@@ -363,7 +365,9 @@ impl Client {
             self.owner, self.repo
         );
 
-        let response_body = crate::retry::with_retry("github: create PR", || async {
+        // Connect-only retry: re-issuing after a post-send EOF would create
+        // a duplicate pull request.
+        let response_body = crate::retry::with_retry_connect_only("github: create PR", || async {
             let response = self
                 .octocrab
                 ._post(&url, Some(&pr_body))

--- a/src/github/sync.rs
+++ b/src/github/sync.rs
@@ -155,11 +155,19 @@ async fn sync_pulls_finalize(
             "Fetching mergeable status for {} PRs (concurrent)...",
             needs_mergeable.len()
         );
-        let results: Vec<(usize, Result<Option<bool>>)> = futures::future::join_all(
+        // Bound concurrency so a large open-PR backlog doesn't fire hundreds
+        // of simultaneous GitHub GETs (each also retrying with backoff),
+        // which risks secondary/abuse rate limits and connection-pool
+        // exhaustion. Keep N small to stay well under the abuse threshold.
+        use futures::stream::StreamExt;
+        const MERGEABLE_CONCURRENCY: usize = 6;
+        let results: Vec<(usize, Result<Option<bool>>)> = futures::stream::iter(
             needs_mergeable
-                .iter()
-                .map(|&(idx, number)| async move { (idx, gh.fetch_pr_mergeable(number).await) }),
+                .into_iter()
+                .map(|(idx, number)| async move { (idx, gh.fetch_pr_mergeable(number).await) }),
         )
+        .buffer_unordered(MERGEABLE_CONCURRENCY)
+        .collect()
         .await;
 
         for (idx, result) in results {

--- a/src/license.rs
+++ b/src/license.rs
@@ -341,7 +341,12 @@ fn cache_token(token: &str) -> Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
+        if let Err(e) = fs::set_permissions(&path, fs::Permissions::from_mode(0o600)) {
+            tracing::warn!(
+                "Failed to set 0o600 on cached license token {}: {e}; it may be world-readable",
+                path.display()
+            );
+        }
     }
     Ok(())
 }
@@ -392,7 +397,12 @@ fn save_credential(key: &str, value: &str) -> Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
+        if let Err(e) = fs::set_permissions(&path, fs::Permissions::from_mode(0o600)) {
+            tracing::warn!(
+                "Failed to set 0o600 on credentials file {}: {e}; secrets may be world-readable",
+                path.display()
+            );
+        }
     }
     Ok(())
 }

--- a/src/login.rs
+++ b/src/login.rs
@@ -119,6 +119,13 @@ pub fn save_credentials(creds: &std::collections::HashMap<String, String>) -> Re
             .mode(0o600)
             .open(&path)?;
         f.write_all(content.as_bytes())?;
+        // The 0o600 mode above is honoured only when the file is newly
+        // created. If .wshm/credentials already existed with broader
+        // permissions (older version, copied-in file), the rewrite keeps the
+        // looser mode. Re-tighten it explicitly so the plaintext secret file
+        // is always owner-only readable/writable.
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
     }
 
     #[cfg(not(unix))]

--- a/src/pipelines/backup.rs
+++ b/src/pipelines/backup.rs
@@ -91,10 +91,31 @@ pub fn restore(args: &RestoreArgs) -> Result<()> {
     let dec = flate2::read::GzDecoder::new(file);
     let mut archive = tar::Archive::new(dec);
 
+    // Resolve the canonical destination root once. Every extracted file
+    // must end up strictly inside this directory.
+    fs::create_dir_all(&wshm_dir)?;
+    let canonical_root = wshm_dir
+        .canonicalize()
+        .with_context(|| format!("Cannot resolve {}", wshm_dir.display()))?;
+
     let mut restored = 0u32;
     for entry in archive.entries()? {
         let mut entry = entry?;
         let path = entry.path()?.to_path_buf();
+
+        // Security: reject Zip-Slip style entries. An absolute path or any
+        // `..` component lets the entry escape .wshm/ even when its declared
+        // prefix looks safe (e.g. ".wshm/../../etc/cron.d/evil").
+        use std::path::Component;
+        if path.components().any(|c| {
+            matches!(
+                c,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        }) {
+            tracing::warn!("Skipping unsafe archive entry: {}", path.display());
+            continue;
+        }
 
         // Security: only extract into .wshm/
         if !path.starts_with("wshm/") && !path.starts_with(".wshm/") {
@@ -106,6 +127,22 @@ pub fn restore(args: &RestoreArgs) -> Result<()> {
         let target = PathBuf::from(".").join(&path);
         if let Some(parent) = target.parent() {
             fs::create_dir_all(parent)?;
+        }
+
+        // Defense in depth: after creating the parent dirs, verify the
+        // resolved parent is still inside the canonical .wshm/ root before
+        // writing anything. This catches symlink-based escapes too.
+        if let Some(parent) = target.parent() {
+            let canonical_parent = parent
+                .canonicalize()
+                .with_context(|| format!("Cannot resolve {}", parent.display()))?;
+            if !canonical_parent.starts_with(&canonical_root) {
+                tracing::warn!(
+                    "Skipping entry resolving outside .wshm/: {}",
+                    path.display()
+                );
+                continue;
+            }
         }
 
         entry
@@ -122,7 +159,12 @@ pub fn restore(args: &RestoreArgs) -> Result<()> {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let _ = fs::set_permissions(&creds, fs::Permissions::from_mode(0o600));
+            if let Err(e) = fs::set_permissions(&creds, fs::Permissions::from_mode(0o600)) {
+                tracing::warn!(
+                    "Failed to secure restored credentials file {}: {e}; the secret may be world-readable",
+                    creds.display()
+                );
+            }
         }
     }
 

--- a/src/pipelines/context.rs
+++ b/src/pipelines/context.rs
@@ -28,6 +28,10 @@ pub fn build_context(db: &dyn DatabaseBackend, slug: &str) -> Result<String> {
     let open_pulls = db.get_open_pulls()?;
     let untriaged = db.get_untriaged_issues()?;
 
+    // Batch-load triage results and PR analyses once to avoid N+1 queries.
+    let triage_map = db.get_all_triage_results().unwrap_or_default();
+    let analyses_map = db.get_all_pr_analyses().unwrap_or_default();
+
     out.push_str("## Overview\n\n");
     out.push_str(&format!(
         "- **Open issues:** {} ({} untriaged)\n",
@@ -61,7 +65,7 @@ pub fn build_context(db: &dyn DatabaseBackend, slug: &str) -> Result<String> {
             ));
 
             // Add triage info if available
-            if let Ok(Some(triage)) = db.get_triage_result(issue.number) {
+            if let Some(triage) = triage_map.get(&issue.number) {
                 out.push_str(&format!(
                     "**Triage:** {} | priority: {} | confidence: {:.0}%\n",
                     triage.category,
@@ -112,7 +116,7 @@ pub fn build_context(db: &dyn DatabaseBackend, slug: &str) -> Result<String> {
             ));
 
             // Add analysis if available
-            if let Ok(Some(analysis)) = db.get_pr_analysis(pr.number) {
+            if let Some(analysis) = analyses_map.get(&pr.number) {
                 out.push_str(&format!(
                     "**Analysis:** {} | risk: {} | type: {}\n",
                     analysis.summary, analysis.risk_level, analysis.pr_type
@@ -164,12 +168,7 @@ pub fn build_context(db: &dyn DatabaseBackend, slug: &str) -> Result<String> {
     // ── Recent triage decisions ──
     let triaged_issues: Vec<_> = open_issues
         .iter()
-        .filter_map(|i| {
-            db.get_triage_result(i.number)
-                .ok()
-                .flatten()
-                .map(|t| (i.number, &i.title, t))
-        })
+        .filter_map(|i| triage_map.get(&i.number).map(|t| (i.number, &i.title, t)))
         .collect();
 
     if !triaged_issues.is_empty() {

--- a/src/pipelines/status.rs
+++ b/src/pipelines/status.rs
@@ -118,11 +118,16 @@ pub fn build_summary(config: &Config, db: &dyn DatabaseBackend) -> Result<Summar
         .filter(|p| p.mergeable == Some(false))
         .count();
 
+    // Batch-load triage results and PR analyses once to avoid N+1 queries
+    // (each open issue/PR was previously queried individually, twice).
+    let triage_map = db.get_all_triage_results().unwrap_or_default();
+    let analyses_map = db.get_all_pr_analyses().unwrap_or_default();
+
     // Collect high/critical priority issues only — sorted oldest first (most urgent)
     let now = chrono::Utc::now();
     let mut high_priority_issues = Vec::new();
     for issue in &open_issues {
-        if let Ok(Some(triage)) = db.get_triage_result(issue.number) {
+        if let Some(triage) = triage_map.get(&issue.number) {
             let is_high = matches!(triage.priority.as_deref(), Some("high") | Some("critical"));
             if !is_high {
                 continue;
@@ -153,15 +158,15 @@ pub fn build_summary(config: &Config, db: &dyn DatabaseBackend) -> Result<Summar
     };
     let mut top_issues = Vec::new();
     for issue in &open_issues {
-        let triage = db.get_triage_result(issue.number).ok().flatten();
+        let triage = triage_map.get(&issue.number);
         let age_days = chrono::DateTime::parse_from_rfc3339(&issue.created_at)
             .map(|dt| (now - dt.with_timezone(&chrono::Utc)).num_days())
             .unwrap_or(0);
         top_issues.push(IssueBrief {
             number: issue.number,
             title: crate::pipelines::truncate(&issue.title, 80),
-            priority: triage.as_ref().and_then(|t| t.priority.clone()),
-            category: triage.as_ref().map(|t| t.category.clone()),
+            priority: triage.and_then(|t| t.priority.clone()),
+            category: triage.map(|t| t.category.clone()),
             labels: issue.labels.clone(),
             age_days,
         });
@@ -177,7 +182,7 @@ pub fn build_summary(config: &Config, db: &dyn DatabaseBackend) -> Result<Summar
     let mut high_risk_prs = Vec::new();
     let mut top_prs = Vec::new();
     for pr in &open_pulls {
-        let analysis = db.get_pr_analysis(pr.number).ok().flatten();
+        let analysis = analyses_map.get(&pr.number);
         let has_conflicts = pr.mergeable == Some(false);
         let age_days = chrono::DateTime::parse_from_rfc3339(&pr.created_at)
             .map(|dt| (now - dt.with_timezone(&chrono::Utc)).num_days())
@@ -186,21 +191,18 @@ pub fn build_summary(config: &Config, db: &dyn DatabaseBackend) -> Result<Summar
         let brief = PrBrief {
             number: pr.number,
             title: crate::pipelines::truncate(&pr.title, 80),
-            risk_level: analysis.as_ref().map(|a| a.risk_level.clone()),
+            risk_level: analysis.map(|a| a.risk_level.clone()),
             ci_status: pr.ci_status.clone(),
             has_conflicts,
             age_days,
         };
 
-        let is_high_risk = analysis
-            .as_ref()
-            .map(|a| a.risk_level == "high")
-            .unwrap_or(false);
+        let is_high_risk = analysis.map(|a| a.risk_level == "high").unwrap_or(false);
         if is_high_risk || has_conflicts {
             high_risk_prs.push(PrBrief {
                 number: pr.number,
                 title: crate::pipelines::truncate(&pr.title, 80),
-                risk_level: analysis.map(|a| a.risk_level),
+                risk_level: analysis.map(|a| a.risk_level.clone()),
                 ci_status: pr.ci_status.clone(),
                 has_conflicts,
                 age_days,

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -137,12 +137,62 @@ pub fn is_transient(err: &anyhow::Error) -> bool {
     TRANSIENT.iter().any(|needle| msg.contains(needle))
 }
 
+/// Connect-level subset of [`is_transient`]: errors that prove the request
+/// never reached (or was never accepted by) the server, so re-issuing it
+/// cannot duplicate a server-side effect.
+///
+/// This deliberately EXCLUDES post-send failures like
+/// `"error reading a body"` / `"end of file before message length reached"`:
+/// those frequently happen AFTER the server has fully processed a POST but
+/// the response read failed. Retrying a non-idempotent create on those would
+/// duplicate the issue/PR/review/comment, so write call sites must use
+/// [`with_retry_connect_only`] instead of [`with_retry`].
+pub fn is_transient_connect(err: &anyhow::Error) -> bool {
+    let msg = format!("{err:#}").to_lowercase();
+    const CONNECT_TRANSIENT: &[&str] = &[
+        "connection refused",
+        "error sending request",
+        "tls handshake",
+        "dns error",
+        "failed to lookup address",
+        "timed out",
+        "operation timed out",
+    ];
+    CONNECT_TRANSIENT.iter().any(|needle| msg.contains(needle))
+}
+
 /// Run `op`, retrying transient failures per the global [`RetryConfig`].
 ///
 /// `op` is a closure that returns a fresh future on each call, so a retry
 /// genuinely re-issues the request (and picks a fresh pooled connection).
 /// `label` names the operation for log lines.
 pub async fn with_retry<T, F, Fut>(label: &str, op: F) -> anyhow::Result<T>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = anyhow::Result<T>>,
+{
+    with_retry_classified(label, is_transient, op).await
+}
+
+/// Like [`with_retry`] but only retries connect-level failures (see
+/// [`is_transient_connect`]). Use this for NON-idempotent writes (POST
+/// creates: issues, PRs, reviews, comments, AI completions) so a response
+/// body-read EOF on an already-processed request does not duplicate the
+/// server-side effect.
+pub async fn with_retry_connect_only<T, F, Fut>(label: &str, op: F) -> anyhow::Result<T>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = anyhow::Result<T>>,
+{
+    with_retry_classified(label, is_transient_connect, op).await
+}
+
+/// Shared retry loop parameterized by the transient-error classifier.
+async fn with_retry_classified<T, F, Fut>(
+    label: &str,
+    is_retryable: fn(&anyhow::Error) -> bool,
+    op: F,
+) -> anyhow::Result<T>
 where
     F: Fn() -> Fut,
     Fut: Future<Output = anyhow::Result<T>>,
@@ -159,7 +209,7 @@ where
         match op().await {
             Ok(value) => return Ok(value),
             Err(err) => {
-                if attempt >= max || !cfg.enabled || !is_transient(&err) {
+                if attempt >= max || !cfg.enabled || !is_retryable(&err) {
                     return Err(err);
                 }
                 let backoff = backoff_delay(&cfg, attempt);
@@ -236,6 +286,47 @@ mod tests {
         .await;
         assert_eq!(result.unwrap(), 3);
         assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn connect_only_excludes_post_send_eof() {
+        // A response body-read EOF must NOT be retried for writes: the
+        // server may have already processed the POST.
+        let eof = anyhow::anyhow!(
+            "error reading a body from connection: end of file before message length reached"
+        );
+        assert!(is_transient(&eof), "EOF is transient for idempotent reads");
+        assert!(
+            !is_transient_connect(&eof),
+            "EOF must NOT be connect-transient (would duplicate a write)"
+        );
+
+        // Connect-level failures are safe to re-issue: the request never
+        // reached the server.
+        let refused = anyhow::anyhow!("error sending request: connection refused");
+        assert!(is_transient_connect(&refused));
+    }
+
+    #[tokio::test]
+    async fn connect_only_does_not_retry_body_eof() {
+        set_global(RetryConfig {
+            enabled: true,
+            max_attempts: 5,
+            initial_backoff_ms: 50,
+            max_backoff_ms: 100,
+        });
+        let calls = AtomicU32::new(0);
+        let result: anyhow::Result<u32> = with_retry_connect_only("test", || async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            anyhow::bail!("error reading a body: end of file before message length reached")
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "a post-send EOF must not be retried for writes"
+        );
     }
 
     #[tokio::test]

--- a/src/secrets/store.rs
+++ b/src/secrets/store.rs
@@ -158,9 +158,34 @@ impl SecretStore for SqliteSecretStore {
     }
 
     /// Read & decrypt a secret. Returns `None` if not present.
+    ///
+    /// The async connection Mutex is held only for the row read and released
+    /// before the AES-GCM decrypt, so concurrent lookups do not serialize
+    /// behind one another's crypto work.
     async fn get(&self, scope: Scope, slug: Option<&str>, key: &str) -> Result<Option<String>> {
-        let conn = self.conn.lock().await;
-        Self::get_inner(&conn, &self.cipher, scope, slug, key)
+        let row: Option<(Vec<u8>, Vec<u8>)> = {
+            let conn = self.conn.lock().await;
+            conn.query_row(
+                "SELECT nonce, ciphertext FROM secrets
+                 WHERE scope = ?1 AND COALESCE(slug, '') = COALESCE(?2, '') AND key = ?3",
+                params![scope.as_str(), slug, key],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .optional()?
+        };
+        match row {
+            Some((nonce, ciphertext)) => {
+                let aad_new = aad_for(scope.as_str(), slug, key);
+                let aad_legacy = aad_for_legacy(scope.as_str(), slug, key);
+                let plaintext =
+                    self.cipher
+                        .open_with_aads(&nonce, &ciphertext, &[&aad_new, &aad_legacy])?;
+                let s =
+                    String::from_utf8(plaintext).context("decrypted secret is not valid UTF-8")?;
+                Ok(Some(s))
+            }
+            None => Ok(None),
+        }
     }
 
     /// Synchronous variant of `get` — usable from non-async code
@@ -176,14 +201,17 @@ impl SecretStore for SqliteSecretStore {
 
     /// Decrypt a secret BY ID and write an audit row.
     async fn reveal(&self, id: i64, user_id: Option<i64>) -> Result<Option<String>> {
-        let conn = self.conn.lock().await;
-        let row: Option<(String, Option<String>, String, Vec<u8>, Vec<u8>)> = conn
-            .query_row(
+        // Read the row under the lock, then release it before the AES-GCM
+        // decrypt so the connection Mutex does not serialize crypto work.
+        let row: Option<(String, Option<String>, String, Vec<u8>, Vec<u8>)> = {
+            let conn = self.conn.lock().await;
+            conn.query_row(
                 "SELECT scope, slug, key, nonce, ciphertext FROM secrets WHERE id = ?1",
                 params![id],
                 |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
             )
-            .optional()?;
+            .optional()?
+        };
         match row {
             Some((scope, slug, key, nonce, ct)) => {
                 let aad_new = aad_for(&scope, slug.as_deref(), &key);
@@ -192,11 +220,15 @@ impl SecretStore for SqliteSecretStore {
                     .cipher
                     .open_with_aads(&nonce, &ct, &[&aad_new, &aad_legacy])?;
                 let s = String::from_utf8(pt).context("not utf-8")?;
-                let _ = conn.execute(
-                    "INSERT INTO secrets_audit (scope, slug, key, action, user_id)
-                     VALUES (?1, ?2, ?3, 'reveal', ?4)",
-                    params![scope, slug, key, user_id],
-                );
+                // Re-acquire the lock only for the best-effort audit insert.
+                {
+                    let conn = self.conn.lock().await;
+                    let _ = conn.execute(
+                        "INSERT INTO secrets_audit (scope, slug, key, action, user_id)
+                         VALUES (?1, ?2, ?3, 'reveal', ?4)",
+                        params![scope, slug, key, user_id],
+                    );
+                }
                 Ok(Some(s))
             }
             None => Ok(None),

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -362,11 +362,14 @@ impl App {
 
         let pulls = db.get_open_pulls()?;
 
+        // Batch-load triage results once to avoid an N+1 query per tick.
+        let triage_map = db.get_all_triage_results().unwrap_or_default();
+
         // Build issue rows with triage results + linked PRs
         self.issues = open_issues
             .into_iter()
             .map(|issue| {
-                let triage = db.get_triage_result(issue.number).ok().flatten();
+                let triage = triage_map.get(&issue.number).cloned();
                 let issue_ref = format!("#{}", issue.number);
                 let linked_prs: Vec<u64> = pulls
                     .iter()


### PR DESCRIPTION
Output of a 5-iteration audit+fix sweep (5 agents per round: security ×2, performance ×2, quality). Each round re-analyzed the code already fixed by the previous round. Only surgical, runtime-verifiable fixes were applied; large architectural items were skipped on purpose (listed below).

**Verified locally:** `cargo build/test (72 passed)/clippy -D warnings/fmt` all green, and the auth + webhook behavior changes were **smoke-tested against a running daemon** (not just compiled).

## ⚠️ Behavior changes — verify before merge/release
These alter runtime auth and are the reason this should not be fast-tracked to a release without a functional check on the real deployment:

1. **Auth is now deny-by-default.** Previously, a daemon with a `users.db` but no `[web].password` served every GET endpoint **unauthenticated** (fail-open). Now it denies. Running with *no* credentials at all requires an explicit `WSHM_AUTH_DISABLED=1`. → A deployment that relied on the implicit open behavior will start returning 401.
2. **Proxy-auth is now fail-closed.** `WSHM_TRUST_PROXY_AUTH=1` **without** `WSHM_PROXY_AUTH_TOKEN` now **rejects** forwarded-identity headers unless `WSHM_TRUST_PROXY_AUTH_NO_TOKEN=1` is set. → **The kube Pro deploy does RBAC on `X-Forwarded-Email` behind oauth2-proxy.** If the pod sets `WSHM_TRUST_PROXY_AUTH` without a token, this locks everyone out. **Must be verified against the real oauth2-proxy path before the next Pro release** (set the token, or opt into `_NO_TOKEN=1`).
3. **Webhook refuses (503) when no secret is configured** instead of processing unsigned payloads.

Regression caught & fixed during review: the initial deny-by-default change also dropped the documented Basic Auth escape hatch in RBAC mode (broke `WSHM_WEB_PASSWORD` / dev proxy / CI curl). Restored — a valid shared password authenticates (no role), role-gated handlers still require RBAC login. Smoke test: no-auth→401, basic-auth→200, wrong-pass→401, webhook-no-secret→503.

## Fixes applied
**Security:** fail-open auth closed; webhook unsigned-reject + `DefaultBodyLimit` + replay dedup extended to Gitea/Forgejo and the single-repo handler; proxy-auth fail-closed; constant-time credential compares; dummy-argon2 on login not-found (anti-enumeration); add_repo path/slug-traversal hardening; secrets AES-GCM decrypt moved out of the mutex scope; license/activate removed from CSRF exemption.

**Performance:** N+1 storms removed via batch `get_all_pr_analyses` / `get_all_triage_results` HashMap loaders (api_issues/pulls/queue/activity, summary no longer 3×-scans PRs); `seed_triage_stubs_from_labels` wrapped in a transaction; `idx_issues_state_reactions` added; `get_issues_needing_triage` short-circuits before hashing; repos RwLock snapshot-and-drop before blocking DB scans; bounded mergeable fan-out; connect-only retry for non-idempotent forge POSTs (no duplicate comments/reviews on EOF).

**Quality:** stop swallowing security-relevant errors (credential-scrub, 0o600 chmod, triage processor DB-error arm); sanitize raw error chains out of public GitHub comments + HTTP bodies; extract `row_to_triage_result`; misc clone/alloc trims.

## Deliberately NOT applied (need a dedicated, runtime-verified change)
- **rusqlite connection pool / `spawn_blocking` migration** — the single `Mutex<Connection>` blocks tokio workers; fixing it touches every DB call site and changes sync→async APIs. Too large to verify safely in an automated loop. **This is the biggest remaining perf item.**
- **SQL-side pagination push-down** (`paginate()` materializes the full per-repo set before slicing) — bounded by operator-controlled data, auth-gated; needs a precomputed score column / per-repo top-N.
- **`issues.content_hash` column** to skip re-hashing unchanged issues each poll cycle.

## Test plan
- [x] build / test (72) / clippy / fmt green; auth + webhook smoke-tested locally.
- [ ] **Functional check of the oauth2-proxy / SSO path on the Pro kube deploy** with the new proxy-auth gating (set `WSHM_PROXY_AUTH_TOKEN` or `WSHM_TRUST_PROXY_AUTH_NO_TOKEN=1`) — blocking for the next Pro release.
- [ ] Confirm any existing deployment relying on implicit-open auth gets credentials configured before rollout.