### PR TITLE
fix(auth): dedicated X-Wshm-Proxy-Token header for proxy shared secret

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -526,7 +526,7 @@ pub async fn run_multi_with_extensions(
                 "WSHM_TRUST_PROXY_AUTH=1 but WSHM_PROXY_AUTH_TOKEN is unset. \
                  Forwarded-identity headers will be REJECTED (fail closed). \
                  Set WSHM_PROXY_AUTH_TOKEN to a shared secret your proxy adds as \
-                 X-Auth-Request-Token, or set WSHM_TRUST_PROXY_AUTH_NO_TOKEN=1 to \
+                 X-Wshm-Proxy-Token, or set WSHM_TRUST_PROXY_AUTH_NO_TOKEN=1 to \
                  explicitly rely on network isolation alone."
             );
         }

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -272,8 +272,10 @@ pub fn verify_user_cookie(value: &str) -> Option<i64> {
 /// those headers and authenticate as any email.
 ///
 /// When `WSHM_PROXY_AUTH_TOKEN` is set, the proxy must additionally forward a
-/// matching `X-Auth-Request-Token` header (compared in constant time), so mere
-/// header presence is no longer sufficient.
+/// matching `X-Wshm-Proxy-Token` header (compared in constant time), so mere
+/// header presence is no longer sufficient. A dedicated header name (rather than
+/// the `X-Auth-Request-*` family) avoids any collision with headers oauth2-proxy
+/// sets/strips itself, so the shared secret survives the proxy hop intact.
 ///
 /// Fail-closed by default: if `WSHM_TRUST_PROXY_AUTH` is enabled but no shared
 /// secret is configured, forwarded-identity headers are REJECTED. Trusting
@@ -294,7 +296,7 @@ fn proxy_shared_secret_ok(headers: &HeaderMap) -> bool {
             .is_some();
     }
     let presented = headers
-        .get("x-auth-request-token")
+        .get("x-wshm-proxy-token")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
     ct_eq(presented.as_bytes(), expected.as_bytes())


### PR DESCRIPTION
Follow-up to #114. The proxy shared-secret check read the secret from `X-Auth-Request-Token` — a name inside oauth2-proxy's own `X-Auth-Request-*` namespace, which the proxy may set/strip itself, risking the secret being dropped on the proxy hop.

Switch to a dedicated `X-Wshm-Proxy-Token` header that no proxy touches, so the operator-injected secret reaches the daemon intact. Startup fail-closed warning updated to name the new header.

This is the code prerequisite for the kube rollout (Traefik middleware will inject `X-Wshm-Proxy-Token: <secret>` and the pod sets `WSHM_PROXY_AUTH_TOKEN` to the same value).

build/test/clippy -D warnings/fmt all green.