### PR TITLE
fix(daemon): only clone repos at boot when auto-fix needs the checkout

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -555,11 +555,16 @@ pub async fn run_multi_with_extensions(
     let mut repos = HashMap::new();
     let mut web_password_resolved = false;
     for entry in &global.repos {
-        // Stateless deploys mount the repos dir as an emptyDir, so the
-        // checkout may be missing on first boot. Clone it from GitHub
-        // using GITHUB_TOKEN before the rest of the setup runs.
+        // A local checkout is only needed by code-editing features
+        // (auto-fix PR generation). Triage and PR analysis run entirely
+        // off the GitHub API, so skip the boot clone unless auto-fix is
+        // enabled for this repo — it's slow, depends on a valid
+        // GITHUB_TOKEN, and its failure otherwise logs a misleading
+        // "daemon may degrade" for repos that never needed the checkout.
+        // Stateless deploys mount repos/ as an emptyDir, so when it IS
+        // needed the checkout may be missing on first boot; clone it here.
         // Skipped when the entry path already contains a checkout.
-        if !entry.path.join(".git").exists() {
+        if entry.features.auto_pr && !entry.path.join(".git").exists() {
             if let Ok(token) = std::env::var("GITHUB_TOKEN") {
                 let url = format!("https://github.com/{}.git", entry.slug);
                 if let Some(parent) = entry.path.parent() {


### PR DESCRIPTION
The boot-time repo clone (added 2026-05-28 for stateless K8s deploys) ran for **every** configured repo, unconditionally. But the local checkout is only used by code-editing features — **auto-fix PR generation** (`features.auto_pr`). Triage and PR analysis run entirely off the GitHub API.

So on a triage/analysis deployment (auto-fix off — the default), the clone was pure cost:
- added ~minutes to pod startup (git clone of large repos),
- required a valid `GITHUB_TOKEN` for `git clone`,
- and on failure logged a **misleading** `WARN ... daemon may degrade for this repo` even though triage/analysis kept working fine (they don't need the checkout).

This is exactly what we saw live on the Pro pod: both repos failed to clone at boot (`daemon may degrade`), the pod took ~5 min to become Ready, yet labels were being applied normally.

**Fix:** gate the clone on `entry.features.auto_pr`. Repos without auto-fix skip the clone entirely → fast boot, no spurious warning. Repos with auto-fix still get their checkout on first boot.

build/test (72)/clippy -D warnings/fmt green.