### PR TITLE
fix(license): WSHM_MACHINE_ID override for stable machine identity

### DIFF
--- a/src/license.rs
+++ b/src/license.rs
@@ -352,6 +352,15 @@ fn cache_token(token: &str) -> Result<()> {
 }
 
 pub fn generate_machine_id() -> String {
+    // Explicit override for environments where the hostname is unstable
+    // (K8s pod names change on every rollout — each would otherwise burn
+    // a fresh activation slot on the license server).
+    if let Ok(id) = std::env::var("WSHM_MACHINE_ID") {
+        let id = id.trim().to_string();
+        if !id.is_empty() {
+            return id;
+        }
+    }
     use sha2::{Digest, Sha256};
     let hostname = hostname::get()
         .map(|h| h.to_string_lossy().to_string())


### PR DESCRIPTION
On Kubernetes the hostname is the pod name, which changes on every rollout — so every activation/auto-renew from a fresh pod presents a new machine_id and consumes a new activation slot on the license server. An explicit `WSHM_MACHINE_ID` env var now takes precedence over the hostname hash.

Needed by the wshm-pro license auto-renew fix (the kube deployment will set `WSHM_MACHINE_ID=k8s-wshm-pro-prd-rtk-cld-01`, matching its existing activation slot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)