### PR TITLE
release: cursor pagination + WSHM_MACHINE_ID (for wshm-pro 0.31.36-pro)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -57,7 +57,11 @@ impl Client {
     /// page). Callers paginate by following that URL — never by building
     /// `page=N` URLs, which GitHub rejects on large datasets in favor of
     /// cursor-based pagination (see [`super::parse_link_next`]).
-    pub(crate) async fn get_page(&self, url: &str, label: &str) -> Result<(String, Option<String>)> {
+    pub(crate) async fn get_page(
+        &self,
+        url: &str,
+        label: &str,
+    ) -> Result<(String, Option<String>)> {
         crate::retry::with_retry(label, || async {
             let response = self
                 .octocrab

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -52,6 +52,33 @@ impl Client {
         })
     }
 
+    /// GET one page of a GitHub list endpoint, returning the body and the
+    /// `rel="next"` URL from the `Link` response header (None on the last
+    /// page). Callers paginate by following that URL — never by building
+    /// `page=N` URLs, which GitHub rejects on large datasets in favor of
+    /// cursor-based pagination (see [`super::parse_link_next`]).
+    pub(crate) async fn get_page(&self, url: &str, label: &str) -> Result<(String, Option<String>)> {
+        crate::retry::with_retry(label, || async {
+            let response = self
+                .octocrab
+                ._get(url)
+                .await
+                .with_context(|| format!("Failed to fetch {label}"))?;
+            let next = response
+                .headers()
+                .get("link")
+                .and_then(|v| v.to_str().ok())
+                .and_then(super::parse_link_next);
+            let body = self
+                .octocrab
+                .body_to_string(response)
+                .await
+                .with_context(|| format!("Failed to read {label} response body"))?;
+            Ok((body, next))
+        })
+        .await
+    }
+
     /// Returns Err with a descriptive message when the client is unauthenticated.
     /// Pipelines that mutate the repo (label, comment, create PR) call this
     /// at the top of their function so the daemon logs why an action was

--- a/src/github/issues.rs
+++ b/src/github/issues.rs
@@ -106,38 +106,22 @@ impl Client {
         since: Option<&str>,
     ) -> Result<Vec<Issue>> {
         let mut all_issues = Vec::with_capacity(128);
+        let mut url = format!(
+            "https://api.github.com/repos/{}/{}/issues?state={state}&per_page={pp}",
+            self.owner,
+            self.repo,
+            pp = super::GITHUB_PER_PAGE
+        );
+        if let Some(since) = since {
+            url.push_str(&format!("&since={since}"));
+        }
         let mut page = 1u32;
 
         loop {
-            let mut url =
-                format!(
-                "https://api.github.com/repos/{}/{}/issues?state={state}&per_page={pp}&page={page}",
-                self.owner, self.repo, pp = super::GITHUB_PER_PAGE
-            );
-            if let Some(since) = since {
-                url.push_str(&format!("&since={since}"));
-            }
-
-            let body = crate::retry::with_retry("github: fetch issues", || async {
-                let response = self
-                    .octocrab
-                    ._get(&url)
-                    .await
-                    .context("Failed to fetch issues")?;
-                self.octocrab
-                    .body_to_string(response)
-                    .await
-                    .context("Failed to read issues response body")
-            })
-            .await?;
-
+            let (body, next) = self.get_page(&url, "github: fetch issues").await?;
             let items = super::parse_json_array(&body, "issues")?;
 
             debug!("Fetched page {page} with {} items", items.len());
-
-            if items.is_empty() {
-                break;
-            }
 
             for item in &items {
                 // Skip PRs (the issues endpoint includes them)
@@ -146,8 +130,9 @@ impl Client {
                 }
             }
 
-            if items.len() < 100 || page >= 100 {
-                break; // Last page or safety cap
+            match next {
+                Some(next) if page < super::GITHUB_MAX_PAGES => url = next,
+                _ => break, // Last page or safety cap
             }
             page += 1;
         }
@@ -223,34 +208,18 @@ impl Client {
     /// Returns `Some(comment_id)` if found, `None` otherwise.
     /// Searches for both the custom marker and the legacy `<!-- wshm -->` marker.
     pub async fn find_wshm_comment(&self, number: u64, marker: &str) -> Result<Option<u64>> {
+        let mut url = format!(
+            "https://api.github.com/repos/{}/{}/issues/{number}/comments?per_page={pp}",
+            self.owner,
+            self.repo,
+            pp = super::GITHUB_PER_PAGE
+        );
         let mut page = 1u32;
 
         loop {
-            let url = format!(
-                "https://api.github.com/repos/{}/{}/issues/{number}/comments?per_page={pp}&page={page}",
-                self.owner, self.repo, pp = super::GITHUB_PER_PAGE
-            );
-
-            let body = crate::retry::with_retry("github: fetch comments", || async {
-                let response = self
-                    .octocrab
-                    ._get(&url)
-                    .await
-                    .with_context(|| format!("Failed to fetch comments for issue #{number}"))?;
-                self.octocrab
-                    .body_to_string(response)
-                    .await
-                    .with_context(|| {
-                        format!("Failed to read comments response for issue #{number}")
-                    })
-            })
-            .await?;
-
+            let label = format!("github: fetch comments for issue #{number}");
+            let (body, next) = self.get_page(&url, &label).await?;
             let comments = super::parse_json_array(&body, "comments")?;
-
-            if comments.is_empty() {
-                break;
-            }
 
             for comment in &comments {
                 let comment_body = comment.get("body").and_then(|v| v.as_str()).unwrap_or("");
@@ -262,8 +231,9 @@ impl Client {
                 }
             }
 
-            if comments.len() < 100 {
-                break;
+            match next {
+                Some(next) if page < super::GITHUB_MAX_PAGES => url = next,
+                _ => break,
             }
             page += 1;
         }

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -9,6 +9,29 @@ pub use client::Client;
 /// Maximum items per page for GitHub API pagination.
 pub const GITHUB_PER_PAGE: u32 = 100;
 
+/// Maximum number of pages to follow when paginating a list endpoint.
+/// Safety cap against runaway pagination (100 pages × 100 items = 10k).
+pub const GITHUB_MAX_PAGES: u32 = 100;
+
+/// Extract the `rel="next"` URL from a `Link` response header.
+///
+/// GitHub rejects `page=N` pagination on large datasets ("Pagination with
+/// the page parameter is not supported for large datasets, please use
+/// cursor based pagination (after/before)") and instead hands out an
+/// opaque `after` cursor in this header, so list fetchers must follow it
+/// rather than build page-number URLs themselves.
+pub fn parse_link_next(link: &str) -> Option<String> {
+    link.split(',').find_map(|part| {
+        let (url, params) = part.split_once(';')?;
+        if params.contains(r#"rel="next""#) {
+            let url = url.trim().strip_prefix('<')?.strip_suffix('>')?;
+            Some(url.to_string())
+        } else {
+            None
+        }
+    })
+}
+
 /// Extract label names from a GitHub API JSON object.
 pub fn extract_labels(json: &serde_json::Value) -> Vec<String> {
     json.get("labels")
@@ -68,5 +91,30 @@ pub fn parse_json_array(body: &str, what: &str) -> anyhow::Result<Vec<serde_json
             }
             Err(anyhow::Error::from(e).context(format!("Failed to parse {what} JSON")))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_link_next;
+
+    #[test]
+    fn link_next_with_cursor() {
+        let link = r#"<https://api.github.com/repositories/1/issues?per_page=100&after=Y3Vyc29yOnYy>; rel="next", <https://api.github.com/repositories/1/issues?per_page=100>; rel="prev""#;
+        assert_eq!(
+            parse_link_next(link).as_deref(),
+            Some("https://api.github.com/repositories/1/issues?per_page=100&after=Y3Vyc29yOnYy")
+        );
+    }
+
+    #[test]
+    fn link_next_absent_on_last_page() {
+        let link = r#"<https://api.github.com/repositories/1/issues?page=3>; rel="prev", <https://api.github.com/repositories/1/issues?page=1>; rel="first""#;
+        assert_eq!(parse_link_next(link), None);
+    }
+
+    #[test]
+    fn link_next_empty_header() {
+        assert_eq!(parse_link_next(""), None);
     }
 }

--- a/src/github/pulls.rs
+++ b/src/github/pulls.rs
@@ -60,32 +60,15 @@ impl Client {
     /// Fetch merged pull requests, optionally filtering to those merged since a given ISO date.
     pub async fn fetch_merged_pulls(&self, since: Option<&str>) -> Result<Vec<MergedPullRequest>> {
         let mut all = Vec::with_capacity(128);
+        let mut url = format!(
+            "https://api.github.com/repos/{}/{}/pulls?state=closed&sort=updated&direction=desc&per_page={pp}",
+            self.owner, self.repo, pp = super::GITHUB_PER_PAGE
+        );
         let mut page = 1u32;
 
         loop {
-            let url = format!(
-                "https://api.github.com/repos/{}/{}/pulls?state=closed&sort=updated&direction=desc&per_page={pp}&page={page}",
-                self.owner, self.repo, pp = super::GITHUB_PER_PAGE
-            );
-
-            let body = crate::retry::with_retry("github: list closed PRs", || async {
-                let response = self
-                    .octocrab
-                    ._get(&url)
-                    .await
-                    .context("Failed to fetch closed pull requests")?;
-                self.octocrab
-                    .body_to_string(response)
-                    .await
-                    .context("Failed to read closed pulls response body")
-            })
-            .await?;
-
+            let (body, next) = self.get_page(&url, "github: list closed PRs").await?;
             let items = super::parse_json_array(&body, "closed pulls")?;
-
-            if items.is_empty() {
-                break;
-            }
 
             let mut stop = false;
             for pr in &items {
@@ -114,8 +97,12 @@ impl Client {
                 });
             }
 
-            if stop || items.len() < 100 {
+            if stop {
                 break;
+            }
+            match next {
+                Some(next) if page < super::GITHUB_MAX_PAGES => url = next,
+                _ => break,
             }
             page += 1;
         }
@@ -202,33 +189,16 @@ impl Client {
         since: Option<&str>,
     ) -> Result<Vec<PullRequest>> {
         let mut all_pulls = Vec::with_capacity(64);
+        // sort=updated direction=desc → newest first → we can break early
+        let mut url = format!(
+            "https://api.github.com/repos/{}/{}/pulls?state={state}&sort=updated&direction=desc&per_page={pp}",
+            self.owner, self.repo, pp = super::GITHUB_PER_PAGE
+        );
         let mut page = 1u32;
 
         loop {
-            // sort=updated direction=desc → newest first → we can break early
-            let url = format!(
-                "https://api.github.com/repos/{}/{}/pulls?state={state}&sort=updated&direction=desc&per_page={pp}&page={page}",
-                self.owner, self.repo, pp = super::GITHUB_PER_PAGE
-            );
-
-            let body = crate::retry::with_retry("github: list PRs", || async {
-                let response = self
-                    .octocrab
-                    ._get(&url)
-                    .await
-                    .context("Failed to fetch pull requests")?;
-                self.octocrab
-                    .body_to_string(response)
-                    .await
-                    .context("Failed to read pulls response body")
-            })
-            .await?;
-
+            let (body, next) = self.get_page(&url, "github: list PRs").await?;
             let items = super::parse_json_array(&body, "pulls")?;
-
-            if items.is_empty() {
-                break;
-            }
 
             let mut should_stop = false;
 
@@ -245,8 +215,12 @@ impl Client {
                 all_pulls.push(parse_pull(pr));
             }
 
-            if should_stop || items.len() < 100 || page >= 100 {
-                break; // Hit a PR older than since, last page, or safety cap
+            if should_stop {
+                break; // Hit a PR older than since
+            }
+            match next {
+                Some(next) if page < super::GITHUB_MAX_PAGES => url = next,
+                _ => break, // Last page or safety cap
             }
             page += 1;
         }

--- a/src/license.rs
+++ b/src/license.rs
@@ -352,6 +352,15 @@ fn cache_token(token: &str) -> Result<()> {
 }
 
 pub fn generate_machine_id() -> String {
+    // Explicit override for environments where the hostname is unstable
+    // (K8s pod names change on every rollout — each would otherwise burn
+    // a fresh activation slot on the license server).
+    if let Ok(id) = std::env::var("WSHM_MACHINE_ID") {
+        let id = id.trim().to_string();
+        if !id.is_empty() {
+            return id;
+        }
+    }
     use sha2::{Digest, Sha256};
     let hostname = hostname::get()
         .map(|h| h.to_string_lossy().to_string())


### PR DESCRIPTION
Ship to main so the next wshm-pro image picks these up:

- #133 — cursor-based pagination via Link headers (fixes full issue sync on large repos; verified live against rtk-ai/rtk: 1192 issues + 1741 PRs)
- #134 — `WSHM_MACHINE_ID` override for stable license machine identity on K8s
- crossbeam-epoch 0.9.18 → 0.9.20 (RUSTSEC-2026-0204)

🤖 Generated with [Claude Code](https://claude.com/claude-code)