### PR TITLE
feat(release): publish macOS binaries (arm64 + x86_64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,36 @@ jobs:
             wshm-aarch64-unknown-linux-gnu.tar.gz
             wshm_*_arm64.deb
 
+  build-macos:
+    name: Build macOS (arm64 + x86_64)
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Build Web UI
+        run: cd web && bun install --frozen-lockfile && bun run build
+      # Apple's toolchain cross-compiles x86_64 from the arm64 runner, so one
+      # (free) runner covers both architectures — Intel runners are paid/EOL.
+      - name: Build (aarch64)
+        run: cargo build --locked --release --bin wshm --target aarch64-apple-darwin
+      - name: Build (x86_64)
+        run: cargo build --locked --release --bin wshm --target x86_64-apple-darwin
+      - name: Package tar.gz
+        run: |
+          for t in aarch64-apple-darwin x86_64-apple-darwin; do
+            tar -C target/$t/release -czf wshm-$t.tar.gz wshm
+          done
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wshm-apple-darwin
+          retention-days: 7
+          path: wshm-*-apple-darwin.tar.gz
+
   build-windows:
     name: Build Windows x86_64
     runs-on: windows-latest
@@ -136,6 +166,7 @@ jobs:
     needs:
       - build-linux-x86
       - build-linux-arm
+      - build-macos
       - build-windows
     runs-on: ubuntu-latest
     steps:
@@ -167,6 +198,8 @@ jobs:
           VERSION="${TAG#v}"
           SHA_X86=$(sha256sum wshm-x86_64-unknown-linux-gnu.tar.gz | awk '{print $1}')
           SHA_ARM=$(sha256sum wshm-aarch64-unknown-linux-gnu.tar.gz | awk '{print $1}')
+          SHA_MAC_ARM=$(sha256sum wshm-aarch64-apple-darwin.tar.gz | awk '{print $1}')
+          SHA_MAC_X86=$(sha256sum wshm-x86_64-apple-darwin.tar.gz | awk '{print $1}')
 
           cat > wshm.rb << 'FORMULA'
           class Wshm < Formula
@@ -174,6 +207,17 @@ jobs:
             homepage "https://wshm.dev"
             version "VERSION_PLACEHOLDER"
             license "SSPL-1.0"
+
+            on_macos do
+              on_arm do
+                url "https://github.com/wshm-dev/wshm/releases/download/TAG_PLACEHOLDER/wshm-aarch64-apple-darwin.tar.gz"
+                sha256 "SHA_MAC_ARM_PLACEHOLDER"
+              end
+              on_intel do
+                url "https://github.com/wshm-dev/wshm/releases/download/TAG_PLACEHOLDER/wshm-x86_64-apple-darwin.tar.gz"
+                sha256 "SHA_MAC_X86_PLACEHOLDER"
+              end
+            end
 
             on_linux do
               on_intel do
@@ -197,6 +241,8 @@ jobs:
           FORMULA
           sed -i "s/VERSION_PLACEHOLDER/$VERSION/g" wshm.rb
           sed -i "s/TAG_PLACEHOLDER/$TAG/g" wshm.rb
+          sed -i "s/SHA_MAC_ARM_PLACEHOLDER/$SHA_MAC_ARM/g" wshm.rb
+          sed -i "s/SHA_MAC_X86_PLACEHOLDER/$SHA_MAC_X86/g" wshm.rb
           sed -i "s/SHA_X86_PLACEHOLDER/$SHA_X86/g" wshm.rb
           sed -i "s/SHA_ARM_PLACEHOLDER/$SHA_ARM/g" wshm.rb
           sed -i 's/^          //' wshm.rb

--- a/install.sh
+++ b/install.sh
@@ -13,9 +13,9 @@
 # Supported platforms (matches the GitHub release pipeline):
 #   - Linux x86_64  (x86_64-unknown-linux-gnu)
 #   - Linux aarch64 (aarch64-unknown-linux-gnu)
+#   - macOS arm64   (aarch64-apple-darwin)
+#   - macOS x86_64  (x86_64-apple-darwin)
 #   - Windows x86_64 via Git Bash / MSYS / Cygwin (x86_64-pc-windows-msvc)
-# macOS is not currently published as a binary release — see
-# https://github.com/wshm-dev/wshm/issues/22 for tracking.
 
 set -eu
 
@@ -77,8 +77,8 @@ detect_os() {
     case "$(uname -s)" in
         Linux*)  OS="linux";   TARGET_SUFFIX="unknown-linux-gnu";;
         MINGW*|MSYS*|CYGWIN*) OS="windows"; TARGET_SUFFIX="pc-windows-msvc";;
-        Darwin*) error "macOS is not published as a binary release yet. Track https://github.com/wshm-dev/wshm/issues/22 for updates.";;
-        *)       error "Unsupported OS: $(uname -s). wshm supports Linux and Windows binary releases.";;
+        Darwin*) OS="macos";   TARGET_SUFFIX="apple-darwin";;
+        *)       error "Unsupported OS: $(uname -s). wshm supports Linux, macOS, and Windows binary releases.";;
     esac
 }
 


### PR DESCRIPTION
## Summary

Adds native macOS binaries to the release pipeline, closing the gap that made `brew install wshm` fail on macOS (#132).

- **New `build-macos` job** on `macos-15` (arm64, free tier): builds `aarch64-apple-darwin` natively and cross-compiles `x86_64-apple-darwin` with the same Apple toolchain — no paid/EOL Intel runner needed.
- **Release assets**: `wshm-aarch64-apple-darwin.tar.gz` + `wshm-x86_64-apple-darwin.tar.gz`, included in `checksums.txt`.
- **Homebrew formula template**: gains `on_macos` blocks (arm + intel). Note: the release job regenerates `wshm.rb` from this inline template, so without this change the next release would have silently overwritten the `depends_on :linux` guard merged in wshm-dev/homebrew-tap#3 — after this PR the formula installs natively on macOS instead of refusing.
- **install.sh**: `Darwin` is now a supported platform (`apple-darwin` target suffix); the rest of the script is already generic (tar.gz + checksums).

## Verification

- `cargo build --locked --release --bin wshm` passes on macOS arm64 (M-series, local).
- `bash -n install.sh` and YAML validation pass.
- The x86_64 cross-slice and the full pipeline get exercised by the first tagged release; the workflow can also be smoke-run via `workflow_dispatch` with a pre-release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)