### PR TITLE
feat(prs): PR label network graph + 👍 reaction sizing

### DIFF
--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -117,6 +117,14 @@ pub trait DatabaseBackend: Send + Sync {
         Ok(0)
     }
 
+    /// Apply 👍 (+1) reaction counts to open PRs (number → count). Sizes the
+    /// PR node in the label graph. Default no-op returning 0 so backends
+    /// without the column keep compiling — real backends override it.
+    fn set_pull_reactions(&self, reactions: &std::collections::HashMap<u64, u32>) -> Result<u64> {
+        let _ = reactions;
+        Ok(0)
+    }
+
     // ── Admin / maintenance ─────────────────────────────────────
 
     /// Wipe every triage result and PR analysis. Used by the `revert` flow
@@ -377,6 +385,10 @@ impl DatabaseBackend for super::Database {
         decisions: &std::collections::HashMap<u64, Option<String>>,
     ) -> Result<u64> {
         self.set_review_decisions(decisions)
+    }
+
+    fn set_pull_reactions(&self, reactions: &std::collections::HashMap<u64, u32>) -> Result<u64> {
+        self.set_pull_reactions(reactions)
     }
 
     fn clear_triage_and_analyses(&self) -> Result<()> {

--- a/src/db/pulls.rs
+++ b/src/db/pulls.rs
@@ -29,6 +29,12 @@ pub struct PullRequest {
     /// (updated_at > review_decision_at) without per-review API calls.
     #[serde(default)]
     pub review_decision_at: Option<String>,
+    /// GitHub 👍 (+1) reaction count on the PR. Like `review_decision`, this is
+    /// NOT set by the regular upsert (GitHub's `/pulls` list endpoint carries no
+    /// reactions) — a dedicated sync pass (`set_pull_reactions`) fills it from
+    /// the Search API. Defaults to 0. Sizes the PR node in the label graph.
+    #[serde(default)]
+    pub reactions_plus1: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -167,6 +173,31 @@ impl Database {
         self.with_conn(|conn| get_pull(conn, number))
     }
 
+    /// Apply freshly-synced 👍 (+1) reaction counts to open PRs. Mirrors
+    /// `set_review_decisions`: maintained by a dedicated sync pass, NOT the
+    /// upsert (GitHub's `/pulls` list carries no reactions). `reactions` maps
+    /// PR number → +1 count. Returns the number of PRs whose count changed.
+    pub fn set_pull_reactions(
+        &self,
+        reactions: &std::collections::HashMap<u64, u32>,
+    ) -> Result<u64> {
+        self.with_conn(|conn| {
+            let tx = conn.unchecked_transaction()?;
+            let mut changed = 0u64;
+            {
+                let mut update = tx.prepare(
+                    "UPDATE pull_requests SET reactions_plus1 = ?1
+                     WHERE number = ?2 AND reactions_plus1 != ?1",
+                )?;
+                for (number, plus1) in reactions {
+                    changed += update.execute(params![plus1, number])? as u64;
+                }
+            }
+            tx.commit()?;
+            Ok(changed)
+        })
+    }
+
     pub fn get_open_pulls(&self) -> Result<Vec<PullRequest>> {
         self.with_conn(get_open_pulls)
     }
@@ -182,7 +213,7 @@ impl Database {
     pub fn get_closed_pulls(&self, limit: usize) -> Result<Vec<PullRequest>> {
         self.with_conn(|conn| {
             let mut stmt = conn.prepare(
-                "SELECT number, title, body, state, labels, author, head_sha, base_sha, head_ref, base_ref, mergeable, ci_status, created_at, updated_at, review_decision, review_decision_at
+                "SELECT number, title, body, state, labels, author, head_sha, base_sha, head_ref, base_ref, mergeable, ci_status, created_at, updated_at, review_decision, review_decision_at, reactions_plus1
                  FROM pull_requests WHERE state = 'closed'
                  ORDER BY updated_at DESC LIMIT ?1",
             )?;
@@ -283,12 +314,13 @@ fn row_to_pull(row: &rusqlite::Row) -> rusqlite::Result<PullRequest> {
         updated_at: row.get(13)?,
         review_decision: row.get(14)?,
         review_decision_at: row.get(15)?,
+        reactions_plus1: row.get(16)?,
     })
 }
 
 pub fn get_pull(conn: &Connection, number: u64) -> Result<Option<PullRequest>> {
     let mut stmt = conn.prepare(
-        "SELECT number, title, body, state, labels, author, head_sha, base_sha, head_ref, base_ref, mergeable, ci_status, created_at, updated_at, review_decision, review_decision_at
+        "SELECT number, title, body, state, labels, author, head_sha, base_sha, head_ref, base_ref, mergeable, ci_status, created_at, updated_at, review_decision, review_decision_at, reactions_plus1
          FROM pull_requests WHERE number = ?1",
     )?;
 
@@ -303,7 +335,7 @@ pub fn get_pull(conn: &Connection, number: u64) -> Result<Option<PullRequest>> {
 
 pub fn get_open_pulls(conn: &Connection) -> Result<Vec<PullRequest>> {
     let mut stmt = conn.prepare(
-        "SELECT number, title, body, state, labels, author, head_sha, base_sha, head_ref, base_ref, mergeable, ci_status, created_at, updated_at, review_decision, review_decision_at
+        "SELECT number, title, body, state, labels, author, head_sha, base_sha, head_ref, base_ref, mergeable, ci_status, created_at, updated_at, review_decision, review_decision_at, reactions_plus1
          FROM pull_requests WHERE state = 'open' ORDER BY number DESC",
     )?;
 
@@ -315,7 +347,7 @@ pub fn get_open_pulls(conn: &Connection) -> Result<Vec<PullRequest>> {
 
 pub fn get_unanalyzed_pulls(conn: &Connection) -> Result<Vec<PullRequest>> {
     let mut stmt = conn.prepare(
-        "SELECT p.number, p.title, p.body, p.state, p.labels, p.author, p.head_sha, p.base_sha, p.head_ref, p.base_ref, p.mergeable, p.ci_status, p.created_at, p.updated_at, p.review_decision, p.review_decision_at
+        "SELECT p.number, p.title, p.body, p.state, p.labels, p.author, p.head_sha, p.base_sha, p.head_ref, p.base_ref, p.mergeable, p.ci_status, p.created_at, p.updated_at, p.review_decision, p.review_decision_at, p.reactions_plus1
          FROM pull_requests p
          LEFT JOIN pr_analyses a ON p.number = a.pr_number
          WHERE p.state = 'open' AND a.pr_number IS NULL
@@ -336,7 +368,7 @@ pub fn get_pulls_needing_analysis(conn: &Connection) -> Result<Vec<PullRequest>>
     use crate::db::schema::compute_pr_hash;
 
     let mut stmt = conn.prepare(
-        "SELECT p.number, p.title, p.body, p.state, p.labels, p.author, p.head_sha, p.base_sha, p.head_ref, p.base_ref, p.mergeable, p.ci_status, p.created_at, p.updated_at, p.review_decision, p.review_decision_at,
+        "SELECT p.number, p.title, p.body, p.state, p.labels, p.author, p.head_sha, p.base_sha, p.head_ref, p.base_ref, p.mergeable, p.ci_status, p.created_at, p.updated_at, p.review_decision, p.review_decision_at, p.reactions_plus1,
                 a.content_hash
          FROM pull_requests p
          LEFT JOIN pr_analyses a ON p.number = a.pr_number
@@ -346,7 +378,7 @@ pub fn get_pulls_needing_analysis(conn: &Connection) -> Result<Vec<PullRequest>>
 
     let rows = stmt.query_map([], |row| {
         let pr = row_to_pull(row)?;
-        let stored_hash: Option<String> = row.get(16)?;
+        let stored_hash: Option<String> = row.get(17)?;
         Ok((pr, stored_hash))
     })?;
 
@@ -390,6 +422,7 @@ mod tests {
             updated_at: "2026-01-01T00:00:00Z".to_string(),
             review_decision: None,
             review_decision_at: None,
+            reactions_plus1: 0,
         }
     }
 
@@ -430,6 +463,32 @@ mod tests {
         db.upsert_pull(&test_pull(2, "b updated")).unwrap();
         let p2 = db.get_pull(2).unwrap().unwrap();
         assert_eq!(p2.review_decision.as_deref(), Some("approved"));
+    }
+
+    #[test]
+    fn pull_reactions_set_and_survive_upsert() {
+        use std::collections::HashMap;
+        let db = Database::open_memory().unwrap();
+        db.upsert_pull(&test_pull(1, "a")).unwrap();
+        db.upsert_pull(&test_pull(2, "b")).unwrap();
+
+        // Fresh PRs default to 0 reactions.
+        assert_eq!(db.get_pull(1).unwrap().unwrap().reactions_plus1, 0);
+
+        // Apply counts: PR 1 → 7, PR 2 → 3.
+        let mut r: HashMap<u64, u32> = HashMap::new();
+        r.insert(1, 7);
+        r.insert(2, 3);
+        assert_eq!(db.set_pull_reactions(&r).unwrap(), 2);
+        assert_eq!(db.get_pull(1).unwrap().unwrap().reactions_plus1, 7);
+
+        // Same counts again: no change reported.
+        assert_eq!(db.set_pull_reactions(&r).unwrap(), 0);
+
+        // A regular PR sync (upsert) must NOT wipe the reaction count — it is
+        // maintained solely by set_pull_reactions, like review_decision.
+        db.upsert_pull(&test_pull(1, "a updated")).unwrap();
+        assert_eq!(db.get_pull(1).unwrap().unwrap().reactions_plus1, 7);
     }
 
     /// Insert a pr_analyses row with the given content hash (mirrors the

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -129,6 +129,17 @@ pub fn run_migrations(conn: &Connection) -> Result<()> {
         )?;
     }
 
+    // Migration: add 👍 (+1) reaction count to pull_requests (sizes the PR
+    // node in the label graph). Filled by the set_pull_reactions sync pass.
+    let has_pull_reactions: bool = conn
+        .prepare("SELECT reactions_plus1 FROM pull_requests LIMIT 0")
+        .is_ok();
+    if !has_pull_reactions {
+        conn.execute_batch(
+            "ALTER TABLE pull_requests ADD COLUMN reactions_plus1 INTEGER NOT NULL DEFAULT 0;",
+        )?;
+    }
+
     // Migration: add content_hash to triage_results and pr_analyses (for LLM call deduplication)
     let has_triage_hash: bool = conn
         .prepare("SELECT content_hash FROM triage_results LIMIT 0")

--- a/src/git_provider/azure_devops.rs
+++ b/src/git_provider/azure_devops.rs
@@ -296,6 +296,7 @@ impl GitProvider for AzureDevOpsProvider {
                 // Populated by the dedicated review-decision sync pass, not here.
                 review_decision: None,
                 review_decision_at: None,
+                reactions_plus1: 0,
             })
             .collect())
     }

--- a/src/git_provider/gitea.rs
+++ b/src/git_provider/gitea.rs
@@ -305,6 +305,7 @@ impl GitProvider for GiteaProvider {
                 // Populated by the dedicated review-decision sync pass, not here.
                 review_decision: None,
                 review_decision_at: None,
+                reactions_plus1: 0,
             })
             .collect())
     }

--- a/src/git_provider/gitlab.rs
+++ b/src/git_provider/gitlab.rs
@@ -320,6 +320,7 @@ impl GitProvider for GitLabProvider {
                 // Populated by the dedicated review-decision sync pass, not here.
                 review_decision: None,
                 review_decision_at: None,
+                reactions_plus1: 0,
             })
             .collect())
     }

--- a/src/github/pulls.rs
+++ b/src/github/pulls.rs
@@ -53,6 +53,9 @@ fn parse_pull(pr: &serde_json::Value) -> PullRequest {
         // Populated by the dedicated review-decision sync pass, not here.
         review_decision: None,
         review_decision_at: None,
+        // GitHub's /pulls list carries no reactions — filled by the dedicated
+        // fetch_pull_reactions / set_pull_reactions pass.
+        reactions_plus1: 0,
     }
 }
 
@@ -167,6 +170,56 @@ impl Client {
                 }
                 page += 1;
             }
+        }
+        Ok(map)
+    }
+
+    /// Fetch 👍 (+1) reaction counts for every open PR, number → count.
+    ///
+    /// GitHub's `/pulls` list endpoint carries no reactions, but the Search
+    /// API returns a `reactions` object per item — so this mirrors
+    /// `fetch_review_decisions` (same endpoint, retry, and 1000-result cap).
+    /// Best-effort: callers treat a failure as "keep previous counts".
+    pub async fn fetch_pull_reactions(&self) -> Result<std::collections::HashMap<u64, u32>> {
+        let mut map = std::collections::HashMap::new();
+        let query = format!("repo:{}/{} is:pr is:open", self.owner, self.repo);
+        let mut page = 1u32;
+        loop {
+            let url = format!(
+                "https://api.github.com/search/issues?q={}&per_page=100&page={page}",
+                urlencoding::encode(&query)
+            );
+            let body = crate::retry::with_retry("github: search pr reactions", || async {
+                let resp = self
+                    .octocrab
+                    ._get(&url)
+                    .await
+                    .context("Failed to search PR reactions")?;
+                self.octocrab
+                    .body_to_string(resp)
+                    .await
+                    .context("Failed to read search response body")
+            })
+            .await?;
+            let json: serde_json::Value = serde_json::from_str(&body)
+                .context("Failed to parse pr-reactions search response")?;
+            let items = json["items"].as_array().cloned().unwrap_or_default();
+            let n = items.len();
+            for item in &items {
+                if let Some(number) = item["number"].as_u64() {
+                    let plus1 = item
+                        .get("reactions")
+                        .and_then(|r| r.get("+1"))
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0) as u32;
+                    map.insert(number, plus1);
+                }
+            }
+            // The Search API caps results at 1000 (10 pages of 100).
+            if n < 100 || page >= 10 {
+                break;
+            }
+            page += 1;
         }
         Ok(map)
     }

--- a/src/github/sync.rs
+++ b/src/github/sync.rs
@@ -196,6 +196,18 @@ async fn sync_pulls_finalize(
         Err(e) => tracing::warn!("Failed to fetch review decisions: {e}"),
     }
 
+    // 👍 (+1) reaction counts size the PR nodes in the label graph. Same
+    // best-effort contract as review decisions: a Search API failure leaves
+    // the previous counts untouched.
+    match gh.fetch_pull_reactions().await {
+        Ok(reactions) => match db.set_pull_reactions(&reactions) {
+            Ok(0) => {}
+            Ok(n) => info!("PR reactions updated for {n} PR(s)"),
+            Err(e) => tracing::warn!("Failed to store PR reactions: {e}"),
+        },
+        Err(e) => tracing::warn!("Failed to fetch PR reactions: {e}"),
+    }
+
     let now = Utc::now().to_rfc3339();
     db.update_sync_entry("pulls", &now, None)?;
 

--- a/src/pipelines/pr_health.rs
+++ b/src/pipelines/pr_health.rs
@@ -604,6 +604,7 @@ mod tests {
             updated_at: iso_days_ago(0),
             review_decision: None,
             review_decision_at: None,
+            reactions_plus1: 0,
         }
     }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -99,6 +99,9 @@ export interface PullRequest {
 	review_decision?: string | null;
 	/** When the current review decision was first observed (RFC3339). */
 	review_decision_at?: string | null;
+	/** GitHub 👍 (+1) reaction count on the PR. Optional — filled by the
+	 *  pulls-reactions sync pass; sizes the PR node in the label graph. */
+	reactions_plus1?: number | null;
 }
 
 export interface TriageResult {

--- a/web/src/lib/components/PrLabelGraph.svelte
+++ b/web/src/lib/components/PrLabelGraph.svelte
@@ -1,0 +1,486 @@
+<script lang="ts">
+	/**
+	 * Bipartite force-directed graph: each label is a hub node (radius ∝ number
+	 * of PRs carrying it), each PR is a small satellite linked to every label it
+	 * wears. Answers "how many PRs sit under label X" at a glance (e.g. codex).
+	 *
+	 * Dependency-free. PERF: the SVG structure is rendered ONCE per graph rebuild
+	 * (keyed each on `graphVersion`); the rAF sim then moves elements
+	 * IMPERATIVELY via setAttribute on refs stored on each node/link. Going back
+	 * through Svelte's reactivity every frame (re-slicing deriveds + reconciling
+	 * ~hundreds of nodes) is what made this jank in dev — this avoids it entirely.
+	 * A tiny velocity-Verlet sim (charge + link spring + gravity) cools via alpha
+	 * decay. O(n²) charge is fine for the few-hundred open PRs a repo carries.
+	 */
+	import { untrack } from 'svelte';
+	import type { PullRequest } from '$lib/api';
+
+	type Props = {
+		pulls: PullRequest[];
+		/** When non-empty, restrict the graph to these labels. */
+		focus?: string[];
+		colorFor: (label: string) => string;
+		onSelectPr?: (pr: PullRequest) => void;
+		onToggleLabel?: (label: string) => void;
+	};
+	let { pulls, focus = [], colorFor, onSelectPr, onToggleLabel }: Props = $props();
+
+	const NODE_SOFT_CAP = 600;
+
+	type Node = {
+		id: string;
+		kind: 'label' | 'pr';
+		/** Label name (label nodes) or dominant label (pr nodes) — drives color. */
+		label: string;
+		text: string;
+		r: number;
+		mass: number;
+		count: number;
+		pr?: PullRequest;
+		x: number;
+		y: number;
+		vx: number;
+		vy: number;
+		fx: number | null;
+		fy: number | null;
+		/** DOM ref for imperative positioning: <circle> for PRs, <g> for hubs. */
+		el?: SVGGraphicsElement;
+	};
+	type Link = { source: Node; target: Node; el?: SVGLineElement };
+
+	let width = $state(800);
+	let height = $state(600);
+	let view = $state({ k: 1, tx: 0, ty: 0 });
+	/** Bumped only when the graph is rebuilt, to re-render the SVG structure.
+	 *  NOT bumped per frame — positions move imperatively. */
+	let graphVersion = $state(0);
+	let truncated = $state(false);
+
+	// Plain (non-reactive) sim state; `sim` is a const so array swaps never trip
+	// Svelte reactivity. Rendering keys off graphVersion instead.
+	const sim: { nodes: Node[]; links: Link[] } = { nodes: [], links: [] };
+	let alpha = 0;
+	let raf = 0;
+
+	let renderNodes = $derived.by(() => {
+		void graphVersion;
+		return sim.nodes;
+	});
+	let renderLinks = $derived.by(() => {
+		void graphVersion;
+		return sim.links;
+	});
+
+	function labelRadius(count: number): number {
+		return Math.min(46, 12 + Math.sqrt(count) * 6);
+	}
+
+	/** PR satellite radius grows with its 👍 (+1) reaction count. sqrt keeps a
+	 *  25-vote PR readable next to a 0-vote one without dwarfing the hubs. */
+	function prRadius(votes: number): number {
+		return Math.min(22, 5 + Math.sqrt(Math.max(0, votes)) * 2.4);
+	}
+
+	function dominantLabel(prLabels: string[], counts: Map<string, number>): string {
+		let best = prLabels[0];
+		let bestC = -1;
+		for (const l of prLabels) {
+			const c = counts.get(l) ?? 0;
+			if (c > bestC) {
+				bestC = c;
+				best = l;
+			}
+		}
+		return best;
+	}
+
+	// Rebuild only when the DATA or FOCUS changes — NOT on resize. Tracking
+	// width/height here would rebuild + reheat the whole graph on every 1px
+	// container jitter (scrollbar, HMR), which reads as constant lag; the sim
+	// re-centers on live width/height inside tick() instead.
+	$effect(() => {
+		void pulls;
+		void focus;
+		return untrack(() => rebuild());
+	});
+
+	function rebuild() {
+		const focusSet = new Set(focus);
+		const active = (l: string) => focusSet.size === 0 || focusSet.has(l);
+
+		const counts = new Map<string, number>();
+		for (const pr of pulls) {
+			for (const l of pr.labels) if (active(l)) counts.set(l, (counts.get(l) ?? 0) + 1);
+		}
+
+		const cx = width / 2;
+		const cy = height / 2;
+		const labelNames = [...counts.keys()];
+		const labelNode = new Map<string, Node>();
+		labelNames.forEach((name, i) => {
+			const ang = (i / Math.max(1, labelNames.length)) * Math.PI * 2;
+			labelNode.set(name, {
+				id: `label:${name}`,
+				kind: 'label',
+				label: name,
+				text: name,
+				r: labelRadius(counts.get(name) ?? 0),
+				mass: 6,
+				count: counts.get(name) ?? 0,
+				x: cx + Math.cos(ang) * 120,
+				y: cy + Math.sin(ang) * 120,
+				vx: 0,
+				vy: 0,
+				fx: null,
+				fy: null
+			});
+		});
+
+		const nextNodes: Node[] = [...labelNode.values()];
+		const nextLinks: Link[] = [];
+		let dropped = false;
+		for (const pr of pulls) {
+			const own = pr.labels.filter(active);
+			if (own.length === 0) continue;
+			if (nextNodes.length >= NODE_SOFT_CAP) {
+				dropped = true;
+				break;
+			}
+			const dom = dominantLabel(own, counts);
+			const seed = labelNode.get(dom)!;
+			const votes = pr.reactions_plus1 ?? 0;
+			const prNode: Node = {
+				id: `pr:${pr.repo}#${pr.number}`,
+				kind: 'pr',
+				label: dom,
+				text: `#${pr.number}`,
+				r: prRadius(votes),
+				mass: 1 + Math.sqrt(votes) * 0.15,
+				count: votes,
+				pr,
+				x: seed.x + (Math.random() - 0.5) * 60,
+				y: seed.y + (Math.random() - 0.5) * 60,
+				vx: 0,
+				vy: 0,
+				fx: null,
+				fy: null
+			};
+			nextNodes.push(prNode);
+			for (const l of own) {
+				const ln = labelNode.get(l);
+				if (ln) nextLinks.push({ source: prNode, target: ln });
+			}
+		}
+
+		sim.nodes = nextNodes;
+		sim.links = nextLinks;
+		truncated = dropped;
+		alpha = 0.85;
+		graphVersion++;
+		startSim();
+
+		return () => {
+			if (raf) cancelAnimationFrame(raf);
+			raf = 0;
+		};
+	}
+
+	function startSim() {
+		if (raf) return;
+		const loop = () => {
+			tick();
+			paint();
+			if (alpha > 0.02) {
+				raf = requestAnimationFrame(loop);
+			} else {
+				raf = 0;
+			}
+		};
+		raf = requestAnimationFrame(loop);
+	}
+
+	function tick() {
+		const cx = width / 2;
+		const cy = height / 2;
+		const N = sim.nodes;
+		const n = N.length;
+		if (n === 0) return;
+
+		for (let i = 0; i < n; i++) {
+			const a = N[i];
+			for (let j = i + 1; j < n; j++) {
+				const b = N[j];
+				let dx = a.x - b.x;
+				let dy = a.y - b.y;
+				let d2 = dx * dx + dy * dy;
+				if (d2 < 1) {
+					dx = Math.random() - 0.5;
+					dy = Math.random() - 0.5;
+					d2 = 1;
+				}
+				const chargeA = a.kind === 'label' ? 1400 : 240;
+				const chargeB = b.kind === 'label' ? 1400 : 240;
+				const d = Math.sqrt(d2);
+				const f = (Math.sqrt(chargeA * chargeB) / d2) * alpha;
+				const fx = (dx / d) * f;
+				const fy = (dy / d) * f;
+				a.vx += fx / a.mass;
+				a.vy += fy / a.mass;
+				b.vx -= fx / b.mass;
+				b.vy -= fy / b.mass;
+			}
+		}
+
+		for (const l of sim.links) {
+			const s = l.source;
+			const t = l.target;
+			const dx = t.x - s.x;
+			const dy = t.y - s.y;
+			const d = Math.sqrt(dx * dx + dy * dy) || 1;
+			const rest = t.r + 42;
+			const f = (d - rest) * 0.06 * alpha;
+			const fx = (dx / d) * f;
+			const fy = (dy / d) * f;
+			s.vx += fx / s.mass;
+			s.vy += fy / s.mass;
+			t.vx -= fx / t.mass;
+			t.vy -= fy / t.mass;
+		}
+
+		for (const nd of N) {
+			nd.vx += (cx - nd.x) * 0.015 * alpha;
+			nd.vy += (cy - nd.y) * 0.015 * alpha;
+			if (nd.fx !== null) {
+				nd.x = nd.fx;
+				nd.vx = 0;
+			} else {
+				nd.vx *= 0.82;
+				nd.x += nd.vx;
+			}
+			if (nd.fy !== null) {
+				nd.y = nd.fy;
+				nd.vy = 0;
+			} else {
+				nd.vy *= 0.82;
+				nd.y += nd.vy;
+			}
+		}
+
+		// Hard collision: separate any overlapping pair by their radii (+pad),
+		// distributing the push by inverse mass so PR satellites yield to the
+		// heavier hubs. Position-based (like d3 forceCollide) — resolves overlap
+		// the charge force alone leaves when the link spring packs nodes onto a
+		// hub. Runs regardless of alpha so the final frame is overlap-free.
+		const PAD = 3;
+		for (let i = 0; i < n; i++) {
+			const a = N[i];
+			for (let j = i + 1; j < n; j++) {
+				const b = N[j];
+				const dx = b.x - a.x;
+				const dy = b.y - a.y;
+				const d = Math.sqrt(dx * dx + dy * dy) || 0.01;
+				const min = a.r + b.r + PAD;
+				if (d < min) {
+					const ux = dx / d;
+					const uy = dy / d;
+					const overlap = min - d;
+					const wa = a.fx !== null ? 0 : b.mass / (a.mass + b.mass);
+					const wb = b.fx !== null ? 0 : a.mass / (a.mass + b.mass);
+					a.x -= ux * overlap * wa;
+					a.y -= uy * overlap * wa;
+					b.x += ux * overlap * wb;
+					b.y += uy * overlap * wb;
+				}
+			}
+		}
+
+		alpha *= 0.975;
+	}
+
+	/** Push positions to the DOM imperatively — no framework reconciliation. */
+	function paint() {
+		for (const nd of sim.nodes) {
+			const el = nd.el;
+			if (!el) continue;
+			if (nd.kind === 'pr') {
+				el.setAttribute('cx', String(nd.x));
+				el.setAttribute('cy', String(nd.y));
+			} else {
+				el.setAttribute('transform', `translate(${nd.x} ${nd.y})`);
+			}
+		}
+		for (const l of sim.links) {
+			const el = l.el;
+			if (!el) continue;
+			el.setAttribute('x1', String(l.source.x));
+			el.setAttribute('y1', String(l.source.y));
+			el.setAttribute('x2', String(l.target.x));
+			el.setAttribute('y2', String(l.target.y));
+		}
+	}
+
+	// ---- Interaction: pan / zoom / node drag ----------------------------------
+	let svgEl: SVGSVGElement;
+	let dragNode: Node | null = null;
+	let panning = $state(false);
+	let pointerStart = { x: 0, y: 0 };
+	let moved = false;
+
+	function toGraph(clientX: number, clientY: number) {
+		const rect = svgEl.getBoundingClientRect();
+		return {
+			x: (clientX - rect.left - view.tx) / view.k,
+			y: (clientY - rect.top - view.ty) / view.k
+		};
+	}
+
+	function onWheel(e: WheelEvent) {
+		e.preventDefault();
+		const rect = svgEl.getBoundingClientRect();
+		const px = e.clientX - rect.left;
+		const py = e.clientY - rect.top;
+		const factor = e.deltaY < 0 ? 1.1 : 1 / 1.1;
+		const k = Math.min(4, Math.max(0.2, view.k * factor));
+		view = {
+			k,
+			tx: px - ((px - view.tx) * k) / view.k,
+			ty: py - ((py - view.ty) * k) / view.k
+		};
+	}
+
+	function nodePointerDown(e: PointerEvent, node: Node) {
+		e.stopPropagation();
+		(e.target as Element).setPointerCapture?.(e.pointerId);
+		dragNode = node;
+		moved = false;
+		pointerStart = { x: e.clientX, y: e.clientY };
+		const g = toGraph(e.clientX, e.clientY);
+		node.fx = g.x;
+		node.fy = g.y;
+	}
+
+	function bgPointerDown(e: PointerEvent) {
+		panning = true;
+		moved = false;
+		pointerStart = { x: e.clientX, y: e.clientY };
+	}
+
+	function onPointerMove(e: PointerEvent) {
+		if (Math.abs(e.clientX - pointerStart.x) + Math.abs(e.clientY - pointerStart.y) > 4) {
+			moved = true;
+		}
+		if (dragNode) {
+			const g = toGraph(e.clientX, e.clientY);
+			dragNode.fx = g.x;
+			dragNode.fy = g.y;
+			alpha = Math.max(alpha, 0.3);
+			startSim();
+		} else if (panning) {
+			view = { ...view, tx: view.tx + e.movementX, ty: view.ty + e.movementY };
+		}
+	}
+
+	function onPointerUp(node?: Node) {
+		if (dragNode) {
+			dragNode.fx = null;
+			dragNode.fy = null;
+			dragNode = null;
+		}
+		panning = false;
+		if (!moved && node) {
+			if (node.kind === 'pr' && node.pr) onSelectPr?.(node.pr);
+			else if (node.kind === 'label') onToggleLabel?.(node.label);
+		}
+	}
+</script>
+
+<div class="relative h-full w-full" bind:clientWidth={width} bind:clientHeight={height}>
+	{#if truncated}
+		<div
+			class="absolute left-2 top-2 z-10 rounded border border-yellow-500/40 bg-yellow-500/10 px-2 py-1 text-[0.7rem] text-yellow-600 dark:text-yellow-400"
+		>
+			Showing first {NODE_SOFT_CAP} nodes — narrow the filter to see the rest.
+		</div>
+	{/if}
+	<svg
+		bind:this={svgEl}
+		class="h-full w-full touch-none select-none"
+		style="cursor: {panning ? 'grabbing' : 'grab'}"
+		onwheel={onWheel}
+		onpointerdown={bgPointerDown}
+		onpointermove={onPointerMove}
+		onpointerup={() => onPointerUp()}
+		role="application"
+		aria-label="Pull request label network graph"
+	>
+		<g transform="translate({view.tx} {view.ty}) scale({view.k})">
+			{#each renderLinks as l (l.source.id + '->' + l.target.id)}
+				<line
+					bind:this={l.el}
+					x1={l.source.x}
+					y1={l.source.y}
+					x2={l.target.x}
+					y2={l.target.y}
+					stroke="var(--border)"
+					stroke-width={0.6}
+					opacity={0.5}
+				/>
+			{/each}
+
+			{#each renderNodes as node (node.id)}
+				{#if node.kind === 'pr'}
+					<circle
+						bind:this={node.el}
+						cx={node.x}
+						cy={node.y}
+						r={node.r}
+						fill={colorFor(node.label)}
+						fill-opacity={0.85}
+						stroke="var(--background)"
+						stroke-width={1}
+						style="cursor: pointer"
+						onpointerdown={(e) => nodePointerDown(e, node)}
+						onpointerup={() => onPointerUp(node)}
+						role="button"
+						tabindex="-1"
+					>
+						<title>#{node.pr?.number} — {node.pr?.title}{node.count ? ` · 👍 ${node.count}` : ''}</title>
+					</circle>
+				{:else}
+					<g
+						bind:this={node.el}
+						transform="translate({node.x} {node.y})"
+						style="cursor: pointer"
+						onpointerdown={(e) => nodePointerDown(e, node)}
+						onpointerup={() => onPointerUp(node)}
+						role="button"
+						tabindex="-1"
+					>
+						<circle
+							r={node.r}
+							fill={colorFor(node.label)}
+							fill-opacity={0.2}
+							stroke={colorFor(node.label)}
+							stroke-width={2}
+						/>
+						<text
+							y={-2}
+							text-anchor="middle"
+							font-size="12"
+							font-weight="600"
+							fill="var(--foreground)"
+							style="pointer-events: none">{node.text}</text
+						>
+						<text
+							y={12}
+							text-anchor="middle"
+							font-size="11"
+							fill="var(--muted-foreground)"
+							style="pointer-events: none">{node.count}</text
+						>
+					</g>
+				{/if}
+			{/each}
+		</g>
+	</svg>
+</div>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -56,7 +56,7 @@
 	}
 
 	type IconName =
-		| 'dashboard' | 'summary' | 'issues' | 'prs' | 'review' | 'triage' | 'queue'
+		| 'dashboard' | 'summary' | 'issues' | 'prs' | 'prGraph' | 'review' | 'triage' | 'queue'
 		| 'changelog' | 'revert' | 'backups' | 'activity' | 'actions' | 'logs'
 		| 'search' | 'settings' | 'insights' | 'issueInsights';
 
@@ -78,6 +78,7 @@
 		{ href: '/search', label: 'Search', icon: 'search', section: 'Work', feature: 'search' },
 		{ href: '/issues', label: 'Issues', icon: 'issues', section: 'Work' },
 		{ href: '/prs', label: 'Pull Requests', icon: 'prs', section: 'Work' },
+		{ href: '/prs/graph', label: 'PR Graph', icon: 'prGraph', section: 'Work' },
 		{ href: '/review', label: 'To Validate', icon: 'review', section: 'Work' },
 		{ href: '/triage', label: 'Triage', icon: 'triage', section: 'Work' },
 		{ href: '/queue', label: 'Merge Queue', icon: 'queue', section: 'Work' },
@@ -266,6 +267,11 @@
 			<path d="M4 4h16v4H4z" />
 			<path d="M4 12h16v4H4z" />
 			<path d="M4 20h10" />
+		{:else if icon === 'prGraph'}
+			<circle cx="5" cy="6" r="2.5" />
+			<circle cx="19" cy="7" r="2.5" />
+			<circle cx="12" cy="18" r="2.5" />
+			<path d="M7.2 7.2 10 16M16.9 8.4 13.4 16.4M7.3 6.4h9.4" />
 		{:else if icon === 'insights'}
 			<circle cx="12" cy="12" r="9" />
 			<path d="M12 3v9l6.5 6.5" />

--- a/web/src/routes/prs/graph/+page.svelte
+++ b/web/src/routes/prs/graph/+page.svelte
@@ -1,0 +1,207 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { selectedRepo } from '$lib/stores';
+	import { fetchPulls, type PullRequest } from '$lib/api';
+	import { Badge } from '$lib/components/ui/badge';
+	import { Input } from '$lib/components/ui/input';
+	import * as Dialog from '$lib/components/ui/dialog';
+	import PrDetail from '$lib/components/PrDetail.svelte';
+	import PrLabelGraph from '$lib/components/PrLabelGraph.svelte';
+
+	let pulls = $state<PullRequest[]>([]);
+	let error: string | null = $state(null);
+	let loading = $state(true);
+
+	// Selected labels the graph is narrowed to (empty = show every label).
+	let focus = $state<string[]>([]);
+	let legendQuery = $state('');
+
+	/** Stable hue per label so a label keeps its color across renders and both
+	 *  themes (mid S/L reads on light and dark). */
+	function hueFor(label: string): number {
+		let h = 0;
+		for (let i = 0; i < label.length; i++) h = (h * 31 + label.charCodeAt(i)) % 360;
+		return h;
+	}
+	function colorFor(label: string): string {
+		return `hsl(${hueFor(label)} 65% 55%)`;
+	}
+
+	type LabelStat = { name: string; count: number };
+	let labelStats: LabelStat[] = $derived.by(() => {
+		const counts = new Map<string, number>();
+		for (const pr of pulls) for (const l of pr.labels) counts.set(l, (counts.get(l) ?? 0) + 1);
+		return [...counts.entries()]
+			.map(([name, count]) => ({ name, count }))
+			.sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+	});
+	let unlabeled = $derived(pulls.filter((p) => p.labels.length === 0).length);
+	let visibleLegend = $derived(
+		legendQuery.trim()
+			? labelStats.filter((l) => l.name.toLowerCase().includes(legendQuery.trim().toLowerCase()))
+			: labelStats
+	);
+
+	function toggleLabel(name: string) {
+		focus = focus.includes(name) ? focus.filter((l) => l !== name) : [...focus, name];
+	}
+	function clearFocus() {
+		focus = [];
+	}
+
+	// Fetch every open PR: /pulls clamps limit to 250, so page through until we
+	// have `total` (hard-capped so a pathological repo can't spin forever).
+	let loadToken = 0;
+	async function loadAll() {
+		const myToken = ++loadToken;
+		loading = true;
+		error = null;
+		try {
+			const all: PullRequest[] = [];
+			let offset = 0;
+			const limit = 250;
+			for (;;) {
+				const page = await fetchPulls({ limit, offset });
+				if (myToken !== loadToken) return;
+				all.push(...page.items);
+				if (all.length >= page.total || page.items.length === 0 || all.length >= 2000) break;
+				offset += page.items.length;
+			}
+			pulls = all;
+		} catch (e) {
+			if (myToken !== loadToken) return;
+			error = e instanceof Error ? e.message : 'Failed to load pull requests';
+		} finally {
+			if (myToken === loadToken) loading = false;
+		}
+	}
+
+	onMount(() => {
+		loadAll();
+		const unsub = selectedRepo.subscribe(() => {
+			focus = [];
+			loadAll();
+		});
+		return unsub;
+	});
+
+	let modalOpen = $state(false);
+	let activePr = $state<PullRequest | null>(null);
+	function openPr(pr: PullRequest) {
+		activePr = pr;
+		modalOpen = true;
+	}
+</script>
+
+<svelte:head>
+	<title>wshm - PR Label Graph</title>
+</svelte:head>
+
+<div class="mb-4">
+	<h2 class="text-xl font-semibold text-foreground mb-1">PR Label Graph</h2>
+	<p class="text-sm text-muted-foreground">
+		Open pull requests clustered by label. Node size = number of PRs. Click a label to focus, a PR
+		to open it. Scroll to zoom, drag to pan.
+	</p>
+</div>
+
+{#if error}
+	<div class="rounded-lg border border-red-500/50 bg-card p-5">
+		<p class="text-red-600 dark:text-red-400">{error}</p>
+	</div>
+{:else}
+	<div class="grid grid-cols-[260px_1fr] gap-4">
+		<!-- Legend / filter -->
+		<div class="rounded-lg border bg-card p-3 h-[calc(100vh-220px)] min-h-[480px] flex flex-col">
+			<div class="flex items-center justify-between mb-2">
+				<span class="text-xs uppercase text-muted-foreground">Labels ({labelStats.length})</span>
+				{#if focus.length}
+					<button class="text-xs text-primary hover:underline" onclick={clearFocus}>clear</button>
+				{/if}
+			</div>
+			<Input
+				type="text"
+				bind:value={legendQuery}
+				placeholder="filter labels…"
+				class="h-8 px-2 text-xs mb-2"
+			/>
+			<div class="flex-1 overflow-y-auto -mx-1 px-1">
+				{#each visibleLegend as l}
+					<button
+						class="flex w-full items-center gap-2 rounded px-1.5 py-1 text-left text-xs hover:bg-accent {focus.includes(
+							l.name
+						)
+							? 'bg-accent'
+							: ''}"
+						onclick={() => toggleLabel(l.name)}
+					>
+						<span
+							class="inline-block h-3 w-3 shrink-0 rounded-full"
+							style="background: {colorFor(l.name)}"
+						></span>
+						<span class="truncate flex-1">{l.name}</span>
+						<span class="mono text-muted-foreground">{l.count}</span>
+					</button>
+				{:else}
+					<p class="text-xs text-muted-foreground px-1.5 py-1">
+						{loading ? 'Loading…' : 'No labels'}
+					</p>
+				{/each}
+			</div>
+			<div class="mt-2 border-t pt-2 text-[0.7rem] text-muted-foreground">
+				{pulls.length} open PR{pulls.length === 1 ? '' : 's'}
+				{#if unlabeled}· {unlabeled} unlabeled (hidden){/if}
+			</div>
+		</div>
+
+		<!-- Graph canvas -->
+		<div class="rounded-lg border bg-card h-[calc(100vh-220px)] min-h-[480px] overflow-hidden">
+			{#if loading}
+				<div class="flex h-full items-center justify-center text-sm text-muted-foreground">
+					Loading pull requests…
+				</div>
+			{:else if labelStats.length === 0}
+				<div class="flex h-full items-center justify-center text-sm text-muted-foreground">
+					No labelled pull requests to graph
+				</div>
+			{:else}
+				<PrLabelGraph {pulls} {focus} {colorFor} onSelectPr={openPr} onToggleLabel={toggleLabel} />
+			{/if}
+		</div>
+	</div>
+
+	{#if focus.length}
+		<div class="mt-3 flex flex-wrap items-center gap-1.5 text-xs">
+			<span class="text-muted-foreground">Focused:</span>
+			{#each focus as f}
+				<Badge
+					variant="outline"
+					class="cursor-pointer"
+					style="border-color: {colorFor(f)}"
+					onclick={() => toggleLabel(f)}
+				>
+					{f} ✕
+				</Badge>
+			{/each}
+		</div>
+	{/if}
+
+	<Dialog.Root bind:open={modalOpen}>
+		<Dialog.Content class="sm:max-w-[80vw] max-h-[85vh] overflow-y-auto">
+			<Dialog.Header>
+				<Dialog.Title class="flex w-full items-center gap-3 pr-2 text-base font-semibold">
+					<span class="mono text-muted-foreground text-sm font-normal">#{activePr?.number}</span>
+					<span class="truncate">{activePr?.title}</span>
+				</Dialog.Title>
+			</Dialog.Header>
+			{#if activePr}
+				<PrDetail pr={activePr} />
+				<div class="text-right pt-2">
+					<a href="/prs/{activePr.number}" class="text-xs text-primary hover:underline">
+						Open full page →
+					</a>
+				</div>
+			{/if}
+		</Dialog.Content>
+	</Dialog.Root>
+{/if}


### PR DESCRIPTION
## What

Adds a **bipartite label→PRs network graph** at `/prs/graph`: each label is a hub node (radius ∝ number of PRs carrying it), each PR a satellite linked to its labels. Answers "how many PRs sit under label X" at a glance. PR node radius grows with its 👍 (+1) reaction count.

## Frontend (`web/`)
- `lib/components/PrLabelGraph.svelte` — dependency-free force-directed SVG (charge + link spring + gravity + **hard collision**). Positions updated **imperatively** on rAF (no per-frame reconciliation) → smooth at a repo's scale; pan/zoom/node-drag.
- `routes/prs/graph/+page.svelte` — paginates all open PRs, label legend/filter sidebar, reuses the `PrDetail` modal.
- Nav entry + icon in `+layout.svelte`; `reactions_plus1?` added to the `PullRequest` type.

## Backend (SQLite / core)
- `reactions_plus1: u32` on `PullRequest`, maintained by a **dedicated sync pass** `set_pull_reactions` — **not** the upsert, since GitHub's `/pulls` list carries no reactions and a `0` would clobber it (same pattern as `review_decision`).
- `fetch_pull_reactions` reads counts from the Search API (`is:pr is:open`, `reactions.+1`), wired into `github/sync.rs` after the review-decision pass (best-effort).
- SQLite migration (`schema.rs`) + selects/row mapping updated. Postgres side is in the corresponding `wshm-pro` PR.

## Testing
- `cargo test` — **77 pass**, incl. new `pull_reactions_set_and_survive_upsert` (verifies a regular upsert does not wipe the count) and `test_get_pulls_needing_analysis` (validates the column-index shift).
- `bun run check` clean on changed files; `bun run build` OK (web-dist regenerated/embedded).

## Deploy note
The `wshm-pro` Docker image re-syncs the web UI from **this repo's default branch** — so this must land on `main` **before** the `wshm-pro` image is built, or the graph route/nav get overwritten with the pre-feature OSS UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)