### PR TITLE
feat(review): configurable grand domains (DB-backed) + graph filters

### DIFF
--- a/src/ai/prompts/issue_classify.rs
+++ b/src/ai/prompts/issue_classify.rs
@@ -38,8 +38,13 @@ Response format (JSON only, no markdown):
   "suggested_labels": ["enhancement", "priority:medium", "area:cli"],
   "is_duplicate_of": null or issue_number,
   "is_simple_fix": true/false,
-  "relevant_files": ["path/to/file.rs"]
+  "relevant_files": ["path/to/file.rs"],
+  "domains": ["domain1", "domain2"]
 }
+
+The "domains" array tags the issue with the grand domains it touches. Use ONLY
+the domains listed in the Grand domains section below (if that section is absent,
+return an empty array). An issue may belong to several domains.
 
 Be precise and varied in your confidence scores. Use the full range:
 - 0.95+ only for obvious, clear-cut cases

--- a/src/ai/prompts/pr_analyze.rs
+++ b/src/ai/prompts/pr_analyze.rs
@@ -18,8 +18,13 @@ Response format (JSON only, no markdown):
     "breaking_change": true/false,
     "docs_updated": true/false
   },
-  "suggested_labels": ["label1", "label2"]
+  "suggested_labels": ["label1", "label2"],
+  "domains": ["domain1", "domain2"]
 }
+
+The "domains" array tags the PR with the grand domains it touches. Use ONLY the
+domains listed in the Grand domains section below (if that section is absent, return
+an empty array). A PR may belong to several domains.
 
 Detect linked issues from patterns like "fixes #X", "closes #X", "resolves #X" in the PR body.
 

--- a/src/ai/schemas.rs
+++ b/src/ai/schemas.rs
@@ -31,6 +31,10 @@ pub struct IssueClassification {
     pub is_simple_fix: bool,
     #[serde(default, deserialize_with = "null_as_default")]
     pub relevant_files: Vec<String>,
+    /// "Grand domains" this issue touches (e.g. codex, bun, c#). Chosen from the
+    /// per-repo configured domain list; multi-valued. Empty when none configured.
+    #[serde(default, deserialize_with = "null_as_default")]
+    pub domains: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -44,6 +48,10 @@ pub struct PrAnalysis {
     pub review_checklist: ReviewChecklist,
     #[serde(default)]
     pub suggested_labels: Vec<String>,
+    /// "Grand domains" this PR touches (e.g. codex, bun, c#). Chosen from the
+    /// per-repo configured domain list; multi-valued. Empty when none configured.
+    #[serde(default, deserialize_with = "null_as_default")]
+    pub domains: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -639,6 +639,48 @@ impl Config {
     }
 }
 
+/// Build the AI-prompt fragment listing the configured "grand domains".
+///
+/// Source is the DB (K/V setting) — NOT the TOML config — because wshm-pro runs
+/// as stateless pods (see the `app_settings` table). The pipeline fetches the
+/// domain list + optional custom prompt from the DB and passes them here.
+/// Returns empty when no domains are configured (the review omits the step).
+pub fn domains_prompt(domains: &[DomainDef], custom: Option<&str>) -> String {
+    if domains.is_empty() {
+        return String::new();
+    }
+    if let Some(custom) = custom {
+        if !custom.trim().is_empty() {
+            return format!("\n{custom}\n");
+        }
+    }
+    let mut out = String::from(
+        "\n## Grand domains (tag the PR/issue with EVERY domain it touches, use ONLY these):\n",
+    );
+    for d in domains {
+        out.push_str(&format!("- **{}**", d.name));
+        if let Some(ref desc) = d.description {
+            out.push_str(&format!(": {desc}"));
+        }
+        out.push('\n');
+    }
+    out.push_str("\nReturn the matching domains in the `domains` array. Do NOT invent domains outside this list.\n");
+    out
+}
+
+/// A "grand domain" — a broad area of the codebase/product (e.g. codex, bun,
+/// c#). Multi-valued per PR/issue, assigned by the AI review, and surfaced as
+/// filters in the PR network graph. Mirrors [`LabelDef`] minus the color/when.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DomainDef {
+    /// Domain name (e.g. "codex", "bun", "c#").
+    pub name: String,
+
+    /// What this domain covers — helps the AI decide when it applies.
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
 // ── Assign config ─────────────────────────────────────────────
 
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -1231,6 +1231,7 @@ async fn api_issues(
                     "priority": triage.as_ref().and_then(|t| t.priority.as_deref()),
                     "confidence": triage.as_ref().map(|t| t.confidence),
                     "category": triage.as_ref().map(|t| t.category.as_str()),
+                    "domains": triage.as_ref().map(|t| &t.domains),
                     "score": score,
                     "score_breakdown": score_breakdown,
                     "pr_status": pr_status,
@@ -1312,6 +1313,7 @@ async fn api_pulls(
                     "risk_level": analysis.map(|a| a.risk_level.as_str()),
                     "pr_type": analysis.map(|a| a.pr_type.as_str()),
                     "summary": analysis.map(|a| a.summary.as_str()),
+                    "domains": analysis.map(|a| &a.domains),
                     "url": crate::git_provider::web_url_for_pr(&ds.config, pr.number),
                 }));
             }
@@ -2309,6 +2311,120 @@ async fn api_repo_features_patch(
         obj.insert("apply".to_string(), json!(ds.apply()));
     }
     Json(resp).into_response()
+}
+
+/// GET /api/v1/repos/{slug}/domains -- read the review "grand domains" list +
+/// optional custom prompt. DB-backed (app_settings) so it survives on stateless
+/// pods and is shared across replicas — unlike the ConfigMap-seeded global.toml.
+async fn api_repo_domains_get(
+    State(state): State<Arc<WebState>>,
+    axum::extract::Path(slug): axum::extract::Path<String>,
+) -> Response {
+    let repos = state.multi.repos.read().await;
+    match repos.get(&slug) {
+        Some(ds) => {
+            let domains: serde_json::Value = ds
+                .db
+                .get_app_setting(crate::db::settings::REVIEW_DOMAINS_KEY)
+                .ok()
+                .flatten()
+                .and_then(|s| serde_json::from_str(&s).ok())
+                .unwrap_or_else(|| json!([]));
+            let prompt = ds
+                .db
+                .get_app_setting(crate::db::settings::REVIEW_PROMPT_KEY)
+                .ok()
+                .flatten();
+            Json(json!({ "domains": domains, "review_prompt": prompt })).into_response()
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": format!("repo '{slug}' not configured")})),
+        )
+            .into_response(),
+    }
+}
+
+/// PATCH /api/v1/repos/{slug}/domains -- set the review domains + prompt. Body:
+/// `{ "domains": [{ "name", "description" }], "review_prompt": "..." }` (either
+/// field optional). Persists to the DB (app_settings), effective on the next
+/// review pass across every pod.
+async fn api_repo_domains_patch(
+    State(state): State<Arc<WebState>>,
+    user: axum::Extension<Option<crate::auth::User>>,
+    axum::extract::Path(slug): axum::extract::Path<String>,
+    Json(body): Json<serde_json::Value>,
+) -> Response {
+    if state.users.is_some() {
+        if let Err(e) = require_admin(&user) {
+            return e;
+        }
+    }
+
+    let repos = state.multi.repos.read().await;
+    let ds = match repos.get(&slug) {
+        Some(d) => d.clone(),
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": format!("repo '{slug}' not configured")})),
+            )
+                .into_response();
+        }
+    };
+    drop(repos);
+
+    if let Some(d) = body.get("domains") {
+        match serde_json::from_value::<Vec<crate::config::DomainDef>>(d.clone()) {
+            Ok(parsed) => {
+                let json_str = serde_json::to_string(&parsed).unwrap_or_else(|_| "[]".into());
+                if let Err(e) = ds
+                    .db
+                    .set_app_setting(crate::db::settings::REVIEW_DOMAINS_KEY, &json_str)
+                {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({"error": e.to_string()})),
+                    )
+                        .into_response();
+                }
+            }
+            Err(e) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": format!("invalid domains: {e}")})),
+                )
+                    .into_response();
+            }
+        }
+    }
+    if let Some(p) = body.get("review_prompt") {
+        let val = p.as_str().unwrap_or("");
+        if let Err(e) = ds
+            .db
+            .set_app_setting(crate::db::settings::REVIEW_PROMPT_KEY, val)
+        {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": e.to_string()})),
+            )
+                .into_response();
+        }
+    }
+
+    let domains: serde_json::Value = ds
+        .db
+        .get_app_setting(crate::db::settings::REVIEW_DOMAINS_KEY)
+        .ok()
+        .flatten()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_else(|| json!([]));
+    let prompt = ds
+        .db
+        .get_app_setting(crate::db::settings::REVIEW_PROMPT_KEY)
+        .ok()
+        .flatten();
+    Json(json!({ "domains": domains, "review_prompt": prompt })).into_response()
 }
 
 /// GET /api/v1/config/retry -- read the live HTTP retry policy.
@@ -3339,6 +3455,10 @@ pub fn oss_api_routes() -> Router<Arc<WebState>> {
         .route(
             "/api/v1/repos/{slug}/features",
             get(api_repo_features_get).patch(api_repo_features_patch),
+        )
+        .route(
+            "/api/v1/repos/{slug}/domains",
+            get(api_repo_domains_get).patch(api_repo_domains_patch),
         )
         .route("/api/v1/auth/status", get(api_auth_status))
         .route(

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -125,6 +125,19 @@ pub trait DatabaseBackend: Send + Sync {
         Ok(0)
     }
 
+    /// Read a runtime K/V setting (DB-backed so it survives on stateless pods
+    /// and is shared across replicas). Default: unset. Real backends override.
+    fn get_app_setting(&self, key: &str) -> Result<Option<String>> {
+        let _ = key;
+        Ok(None)
+    }
+
+    /// Upsert a runtime K/V setting. Default no-op; real backends override.
+    fn set_app_setting(&self, key: &str, value: &str) -> Result<()> {
+        let _ = (key, value);
+        Ok(())
+    }
+
     // ── Admin / maintenance ─────────────────────────────────────
 
     /// Wipe every triage result and PR analysis. Used by the `revert` flow
@@ -389,6 +402,14 @@ impl DatabaseBackend for super::Database {
 
     fn set_pull_reactions(&self, reactions: &std::collections::HashMap<u64, u32>) -> Result<u64> {
         self.set_pull_reactions(reactions)
+    }
+
+    fn get_app_setting(&self, key: &str) -> Result<Option<String>> {
+        self.get_app_setting(key)
+    }
+
+    fn set_app_setting(&self, key: &str, value: &str) -> Result<()> {
+        self.set_app_setting(key, value)
     }
 
     fn clear_triage_and_analyses(&self) -> Result<()> {

--- a/src/db/issues.rs
+++ b/src/db/issues.rs
@@ -342,6 +342,7 @@ mod tests {
             is_duplicate_of: None,
             is_simple_fix: false,
             relevant_files: vec![],
+            domains: vec![],
         }
     }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -5,6 +5,7 @@ pub mod licenses;
 pub mod pulls;
 pub mod schema;
 pub mod search;
+pub mod settings;
 pub mod sync;
 pub mod triage;
 pub mod usage;

--- a/src/db/pulls.rs
+++ b/src/db/pulls.rs
@@ -44,6 +44,9 @@ pub struct PrAnalysisRow {
     pub risk_level: String,
     pub pr_type: String,
     pub review_notes: Option<String>,
+    /// "Grand domains" the AI review tagged this PR with (codex, bun, …).
+    #[serde(default)]
+    pub domains: Vec<String>,
     pub analyzed_at: String,
     #[serde(default)]
     pub content_hash: Option<String>,
@@ -55,7 +58,7 @@ impl Database {
     pub fn get_pr_analysis(&self, pr_number: u64) -> Result<Option<PrAnalysisRow>> {
         self.with_conn(|conn| {
             let mut stmt = conn.prepare(
-                "SELECT pr_number, summary, risk_level, pr_type, review_notes, analyzed_at, content_hash
+                "SELECT pr_number, summary, risk_level, pr_type, review_notes, analyzed_at, content_hash, domains
                  FROM pr_analyses WHERE pr_number = ?1",
             )?;
 
@@ -68,6 +71,7 @@ impl Database {
                     review_notes: row.get(4)?,
                     analyzed_at: row.get(5)?,
                     content_hash: row.get(6)?,
+                    domains: super::parse_labels_json(&row.get::<_, String>(7)?),
                 })
             });
 
@@ -87,7 +91,7 @@ impl Database {
     pub fn get_all_pr_analyses(&self) -> Result<std::collections::HashMap<u64, PrAnalysisRow>> {
         self.with_conn(|conn| {
             let mut stmt = conn.prepare(
-                "SELECT pr_number, summary, risk_level, pr_type, review_notes, analyzed_at, content_hash
+                "SELECT pr_number, summary, risk_level, pr_type, review_notes, analyzed_at, content_hash, domains
                  FROM pr_analyses",
             )?;
             let rows = stmt
@@ -100,6 +104,7 @@ impl Database {
                         review_notes: row.get(4)?,
                         analyzed_at: row.get(5)?,
                         content_hash: row.get(6)?,
+                        domains: super::parse_labels_json(&row.get::<_, String>(7)?),
                     })
                 })?
                 .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -229,16 +234,18 @@ impl Database {
     /// than reaching into a SQLite-specific `with_conn`.
     pub fn upsert_pr_analysis(&self, row: &PrAnalysisRow) -> Result<()> {
         self.with_conn(|conn| {
+            let domains_json = serde_json::to_string(&row.domains).unwrap_or_else(|_| "[]".into());
             conn.execute(
-                "INSERT INTO pr_analyses (pr_number, summary, risk_level, pr_type, review_notes, analyzed_at, content_hash)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                "INSERT INTO pr_analyses (pr_number, summary, risk_level, pr_type, review_notes, analyzed_at, content_hash, domains)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
                  ON CONFLICT(pr_number) DO UPDATE SET
                     summary = excluded.summary,
                     risk_level = excluded.risk_level,
                     pr_type = excluded.pr_type,
                     review_notes = excluded.review_notes,
                     analyzed_at = excluded.analyzed_at,
-                    content_hash = excluded.content_hash",
+                    content_hash = excluded.content_hash,
+                    domains = excluded.domains",
                 params![
                     row.pr_number,
                     row.summary,
@@ -247,6 +254,7 @@ impl Database {
                     row.review_notes,
                     row.analyzed_at,
                     row.content_hash,
+                    domains_json,
                 ],
             )?;
             Ok(())

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -86,6 +86,11 @@ pub fn run_migrations(conn: &Connection) -> Result<()> {
             processed_at TEXT
         );
 
+        CREATE TABLE IF NOT EXISTS app_settings (
+            key   TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+
         CREATE INDEX IF NOT EXISTS idx_issues_state ON issues(state);
         CREATE INDEX IF NOT EXISTS idx_pulls_state ON pull_requests(state);
         CREATE INDEX IF NOT EXISTS idx_comments_issue ON comments(issue_number);
@@ -153,6 +158,25 @@ pub fn run_migrations(conn: &Connection) -> Result<()> {
         .is_ok();
     if !has_pr_hash {
         conn.execute_batch("ALTER TABLE pr_analyses ADD COLUMN content_hash TEXT;")?;
+    }
+
+    // Migration: add `domains` (JSON array) to pr_analyses + triage_results —
+    // the "grand domains" the AI review tags each PR/issue with (codex, bun…).
+    let has_pr_domains: bool = conn
+        .prepare("SELECT domains FROM pr_analyses LIMIT 0")
+        .is_ok();
+    if !has_pr_domains {
+        conn.execute_batch(
+            "ALTER TABLE pr_analyses ADD COLUMN domains TEXT NOT NULL DEFAULT '[]';",
+        )?;
+    }
+    let has_triage_domains: bool = conn
+        .prepare("SELECT domains FROM triage_results LIMIT 0")
+        .is_ok();
+    if !has_triage_domains {
+        conn.execute_batch(
+            "ALTER TABLE triage_results ADD COLUMN domains TEXT NOT NULL DEFAULT '[]';",
+        )?;
     }
 
     // One-shot migration: recompute every existing triage_results.content_hash

--- a/src/db/settings.rs
+++ b/src/db/settings.rs
@@ -1,0 +1,49 @@
+//! Runtime key/value settings, persisted in the DB rather than a TOML file.
+//!
+//! wshm-pro runs as **stateless K8s pods**, so config edited at runtime (e.g.
+//! the review "grand domains" list + prompt) cannot live on the pod filesystem
+//! — `~/.wshm/global.toml` is seeded read-only from a ConfigMap and any local
+//! write is lost on restart and not shared across replicas. This K/V table is
+//! the shared source of truth every pod reads from.
+//!
+//! Values are opaque strings (callers store JSON for structured settings). The
+//! SQLite table is single-repo (one row per key); the Postgres backend scopes
+//! the same keys per-repo. See `DatabaseBackend::{get,set}_app_setting`.
+
+use anyhow::Result;
+use rusqlite::{params, OptionalExtension};
+
+use crate::db::Database;
+
+/// Setting key: the configured review domains as a JSON array of `DomainDef`.
+pub const REVIEW_DOMAINS_KEY: &str = "review_domains";
+/// Setting key: an optional custom review prompt fragment (plain string).
+pub const REVIEW_PROMPT_KEY: &str = "review_prompt";
+
+impl Database {
+    /// Read a setting value, or `None` if unset.
+    pub fn get_app_setting(&self, key: &str) -> Result<Option<String>> {
+        self.with_conn(|conn| {
+            let v = conn
+                .query_row(
+                    "SELECT value FROM app_settings WHERE key = ?1",
+                    params![key],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?;
+            Ok(v)
+        })
+    }
+
+    /// Upsert a setting value.
+    pub fn set_app_setting(&self, key: &str, value: &str) -> Result<()> {
+        self.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO app_settings (key, value) VALUES (?1, ?2)
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                params![key, value],
+            )?;
+            Ok(())
+        })
+    }
+}

--- a/src/db/triage.rs
+++ b/src/db/triage.rs
@@ -37,6 +37,7 @@ fn row_to_triage_result(row: &rusqlite::Row) -> rusqlite::Result<TriageResultRow
         is_simple_fix: row.get(5)?,
         acted_at: row.get(6)?,
         content_hash: row.get(7)?,
+        domains: super::parse_labels_json(&row.get::<_, String>(8)?),
     })
 }
 
@@ -51,6 +52,9 @@ pub struct TriageResultRow {
     pub acted_at: String,
     #[serde(default)]
     pub content_hash: Option<String>,
+    /// "Grand domains" the AI review tagged this issue with (codex, bun, …).
+    #[serde(default)]
+    pub domains: Vec<String>,
 }
 
 impl Database {
@@ -71,11 +75,12 @@ impl Database {
         self.with_conn(|conn| {
             let suggested_labels = serde_json::to_string(&result.suggested_labels)?;
             let relevant_files = serde_json::to_string(&result.relevant_files)?;
+            let domains = serde_json::to_string(&result.domains)?;
             let now = chrono::Utc::now().to_rfc3339();
 
             conn.execute(
-                "INSERT INTO triage_results (issue_number, category, confidence, priority, summary, suggested_labels, is_duplicate_of, is_simple_fix, relevant_files, acted_at, content_hash)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+                "INSERT INTO triage_results (issue_number, category, confidence, priority, summary, suggested_labels, is_duplicate_of, is_simple_fix, relevant_files, acted_at, content_hash, domains)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
                  ON CONFLICT(issue_number) DO UPDATE SET
                     category = excluded.category,
                     confidence = excluded.confidence,
@@ -86,7 +91,8 @@ impl Database {
                     is_simple_fix = excluded.is_simple_fix,
                     relevant_files = excluded.relevant_files,
                     acted_at = excluded.acted_at,
-                    content_hash = excluded.content_hash",
+                    content_hash = excluded.content_hash,
+                    domains = excluded.domains",
                 params![
                     issue_number,
                     result.category,
@@ -99,6 +105,7 @@ impl Database {
                     relevant_files,
                     now,
                     content_hash,
+                    domains,
                 ],
             )?;
             Ok(())
@@ -108,7 +115,7 @@ impl Database {
     pub fn get_triage_result(&self, issue_number: u64) -> Result<Option<TriageResultRow>> {
         self.with_conn(|conn| {
             let mut stmt = conn.prepare(
-                "SELECT issue_number, category, confidence, priority, summary, is_simple_fix, acted_at, content_hash
+                "SELECT issue_number, category, confidence, priority, summary, is_simple_fix, acted_at, content_hash, domains
                  FROM triage_results WHERE issue_number = ?1",
             )?;
 
@@ -129,7 +136,7 @@ impl Database {
             let cutoff_str = cutoff.to_rfc3339();
 
             let mut stmt = conn.prepare(
-                "SELECT t.issue_number, t.category, t.confidence, t.priority, t.summary, t.is_simple_fix, t.acted_at, t.content_hash
+                "SELECT t.issue_number, t.category, t.confidence, t.priority, t.summary, t.is_simple_fix, t.acted_at, t.content_hash, t.domains
                  FROM triage_results t
                  JOIN issues i ON t.issue_number = i.number
                  WHERE i.state = 'open' AND t.acted_at < ?1
@@ -154,7 +161,7 @@ impl Database {
     ) -> Result<std::collections::HashMap<u64, TriageResultRow>> {
         self.with_conn(|conn| {
             let mut stmt = conn.prepare(
-                "SELECT issue_number, category, confidence, priority, summary, is_simple_fix, acted_at, content_hash
+                "SELECT issue_number, category, confidence, priority, summary, is_simple_fix, acted_at, content_hash, domains
                  FROM triage_results",
             )?;
             let rows = stmt
@@ -211,7 +218,7 @@ impl Database {
     pub fn recent_activity(&self, limit: usize) -> Result<Vec<TriageResultRow>> {
         self.with_conn(|conn| {
             let mut stmt = conn.prepare(
-                "SELECT t.issue_number, t.category, t.confidence, t.priority, t.summary, t.is_simple_fix, t.acted_at, t.content_hash
+                "SELECT t.issue_number, t.category, t.confidence, t.priority, t.summary, t.is_simple_fix, t.acted_at, t.content_hash, t.domains
                  FROM triage_results t
                  ORDER BY t.acted_at DESC
                  LIMIT ?1",

--- a/src/pipelines/pr_analysis.rs
+++ b/src/pipelines/pr_analysis.rs
@@ -141,6 +141,7 @@ async fn analyze_pr(
                 linked_issues: Vec::new(),
                 review_checklist,
                 suggested_labels: Vec::new(),
+                domains: existing.domains,
             });
         }
     }
@@ -168,6 +169,23 @@ async fn analyze_pr(
         user_prompt.push_str(&labels_prompt);
     }
 
+    // Inject the configured "grand domains" so the AI can tag the PR with them.
+    // Source is the DB (stateless pods — see db::settings), not TOML config.
+    let review_domains: Vec<crate::config::DomainDef> = db
+        .get_app_setting(crate::db::settings::REVIEW_DOMAINS_KEY)
+        .ok()
+        .flatten()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default();
+    let review_prompt = db
+        .get_app_setting(crate::db::settings::REVIEW_PROMPT_KEY)
+        .ok()
+        .flatten();
+    let domains_prompt = crate::config::domains_prompt(&review_domains, review_prompt.as_deref());
+    if !domains_prompt.is_empty() {
+        user_prompt.push_str(&domains_prompt);
+    }
+
     if !icm_context.is_empty() {
         user_prompt.push_str(&format!(
             "\n\n## Past PR analysis context (from memory)\n{icm_context}"
@@ -193,6 +211,7 @@ async fn analyze_pr(
         risk_level: analysis.risk_level.clone(),
         pr_type: analysis.pr_type.clone(),
         review_notes: Some(serde_json::to_string(&analysis.review_checklist)?),
+        domains: analysis.domains.clone(),
         analyzed_at: now,
         content_hash: Some(content_hash),
     })?;

--- a/src/pipelines/pr_health.rs
+++ b/src/pipelines/pr_health.rs
@@ -719,6 +719,7 @@ mod tests {
             is_simple_fix: false,
             acted_at: chrono::Utc::now().to_rfc3339(),
             content_hash: None,
+            domains: vec![],
         }
     }
 

--- a/src/pipelines/triage.rs
+++ b/src/pipelines/triage.rs
@@ -344,6 +344,7 @@ async fn triage_issue(
                 is_duplicate_of: None,
                 is_simple_fix: existing.is_simple_fix,
                 relevant_files: Vec::new(),
+                domains: existing.domains,
             });
         }
     }
@@ -364,6 +365,23 @@ async fn triage_issue(
     let labels_prompt = config.labels_prompt();
     if !labels_prompt.is_empty() {
         user_prompt.push_str(&labels_prompt);
+    }
+
+    // Inject the configured "grand domains" so the AI can tag the issue.
+    // Source is the DB (stateless pods — see db::settings), not TOML config.
+    let review_domains: Vec<crate::config::DomainDef> = db
+        .get_app_setting(crate::db::settings::REVIEW_DOMAINS_KEY)
+        .ok()
+        .flatten()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default();
+    let review_prompt = db
+        .get_app_setting(crate::db::settings::REVIEW_PROMPT_KEY)
+        .ok()
+        .flatten();
+    let domains_prompt = crate::config::domains_prompt(&review_domains, review_prompt.as_deref());
+    if !domains_prompt.is_empty() {
+        user_prompt.push_str(&domains_prompt);
     }
 
     if !icm_context.is_empty() {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -102,6 +102,10 @@ export interface PullRequest {
 	/** GitHub 👍 (+1) reaction count on the PR. Optional — filled by the
 	 *  pulls-reactions sync pass; sizes the PR node in the label graph. */
 	reactions_plus1?: number | null;
+	/** "Grand domains" the AI review tagged this PR with (codex, bun, …).
+	 *  Optional — present once the PR has been analyzed. Drives the domain
+	 *  filters in the PR network graph. */
+	domains?: string[] | null;
 }
 
 export interface TriageResult {
@@ -508,6 +512,42 @@ export async function updateRepoFeatures(
 	patch: Partial<RepoFeatures>
 ): Promise<RepoFeatures> {
 	const res = await fetch(`/api/v1/repos/${encodeURIComponent(slug)}/features`, {
+		method: 'PATCH',
+		headers: { 'Content-Type': 'application/json', ...CSRF_HEADERS },
+		body: JSON.stringify(patch)
+	});
+	if (!res.ok) {
+		const body = await res.json().catch(() => ({}));
+		throw new Error(body.error ?? `HTTP ${res.status}`);
+	}
+	return res.json();
+}
+
+/** A configured review "grand domain" (codex, bun, c#…). */
+export interface ReviewDomain {
+	name: string;
+	description?: string | null;
+}
+/** Per-repo review-domains config, stored in the DB (works on stateless pods). */
+export interface RepoDomains {
+	domains: ReviewDomain[];
+	review_prompt: string | null;
+}
+
+export async function fetchRepoDomains(slug: string): Promise<RepoDomains> {
+	const res = await fetch(`/api/v1/repos/${encodeURIComponent(slug)}/domains`);
+	if (!res.ok) {
+		const body = await res.json().catch(() => ({}));
+		throw new Error(body.error ?? `HTTP ${res.status}`);
+	}
+	return res.json();
+}
+
+export async function updateRepoDomains(
+	slug: string,
+	patch: { domains?: ReviewDomain[]; review_prompt?: string }
+): Promise<RepoDomains> {
+	const res = await fetch(`/api/v1/repos/${encodeURIComponent(slug)}/domains`, {
 		method: 'PATCH',
 		headers: { 'Content-Type': 'application/json', ...CSRF_HEADERS },
 		body: JSON.stringify(patch)

--- a/web/src/routes/prs/graph/+page.svelte
+++ b/web/src/routes/prs/graph/+page.svelte
@@ -16,6 +16,15 @@
 	let focus = $state<string[]>([]);
 	let legendQuery = $state('');
 
+	// Domain filters — narrow the graph to PRs the AI review tagged with the
+	// selected "grand domains" (codex, bun, …). Multi-select; empty = all PRs.
+	let domainFilter = $state<string[]>([]);
+	let filteredPulls = $derived(
+		domainFilter.length === 0
+			? pulls
+			: pulls.filter((p) => (p.domains ?? []).some((d) => domainFilter.includes(d)))
+	);
+
 	/** Stable hue per label so a label keeps its color across renders and both
 	 *  themes (mid S/L reads on light and dark). */
 	function hueFor(label: string): number {
@@ -30,12 +39,28 @@
 	type LabelStat = { name: string; count: number };
 	let labelStats: LabelStat[] = $derived.by(() => {
 		const counts = new Map<string, number>();
-		for (const pr of pulls) for (const l of pr.labels) counts.set(l, (counts.get(l) ?? 0) + 1);
+		for (const pr of filteredPulls) for (const l of pr.labels) counts.set(l, (counts.get(l) ?? 0) + 1);
 		return [...counts.entries()]
 			.map(([name, count]) => ({ name, count }))
 			.sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
 	});
-	let unlabeled = $derived(pulls.filter((p) => p.labels.length === 0).length);
+	let unlabeled = $derived(filteredPulls.filter((p) => p.labels.length === 0).length);
+
+	// Distinct domains across ALL loaded PRs (stable list to pick from), with
+	// how many PRs carry each. Populated once PRs have been AI-reviewed.
+	type DomainStat = { name: string; count: number };
+	let domainStats: DomainStat[] = $derived.by(() => {
+		const counts = new Map<string, number>();
+		for (const pr of pulls) for (const d of pr.domains ?? []) counts.set(d, (counts.get(d) ?? 0) + 1);
+		return [...counts.entries()]
+			.map(([name, count]) => ({ name, count }))
+			.sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+	});
+	function toggleDomain(name: string) {
+		domainFilter = domainFilter.includes(name)
+			? domainFilter.filter((d) => d !== name)
+			: [...domainFilter, name];
+	}
 	let visibleLegend = $derived(
 		legendQuery.trim()
 			? labelStats.filter((l) => l.name.toLowerCase().includes(legendQuery.trim().toLowerCase()))
@@ -80,6 +105,7 @@
 		loadAll();
 		const unsub = selectedRepo.subscribe(() => {
 			focus = [];
+			domainFilter = [];
 			loadAll();
 		});
 		return unsub;
@@ -100,8 +126,9 @@
 <div class="mb-4">
 	<h2 class="text-xl font-semibold text-foreground mb-1">PR Label Graph</h2>
 	<p class="text-sm text-muted-foreground">
-		Open pull requests clustered by label. Node size = number of PRs. Click a label to focus, a PR
-		to open it. Scroll to zoom, drag to pan.
+		Open pull requests clustered by label. Node size = number of PRs. Filter by one or more
+		<strong>domains</strong> (assigned by the AI review), click a label to focus, a PR to open it.
+		Scroll to zoom, drag to pan.
 	</p>
 </div>
 
@@ -113,6 +140,32 @@
 	<div class="grid grid-cols-[260px_1fr] gap-4">
 		<!-- Legend / filter -->
 		<div class="rounded-lg border bg-card p-3 h-[calc(100vh-220px)] min-h-[480px] flex flex-col">
+			{#if domainStats.length}
+				<div class="mb-3 border-b pb-3">
+					<div class="flex items-center justify-between mb-1.5">
+						<span class="text-xs uppercase text-muted-foreground">Domains</span>
+						{#if domainFilter.length}
+							<button class="text-xs text-primary hover:underline" onclick={() => (domainFilter = [])}>
+								clear
+							</button>
+						{/if}
+					</div>
+					<div class="flex flex-wrap gap-1">
+						{#each domainStats as d}
+							<button
+								class="rounded-full border px-2 py-0.5 text-[0.7rem] transition-colors {domainFilter.includes(
+									d.name
+								)
+									? 'bg-primary text-primary-foreground border-primary'
+									: 'hover:bg-accent'}"
+								onclick={() => toggleDomain(d.name)}
+							>
+								{d.name} <span class="opacity-70">{d.count}</span>
+							</button>
+						{/each}
+					</div>
+				</div>
+			{/if}
 			<div class="flex items-center justify-between mb-2">
 				<span class="text-xs uppercase text-muted-foreground">Labels ({labelStats.length})</span>
 				{#if focus.length}
@@ -149,7 +202,7 @@
 				{/each}
 			</div>
 			<div class="mt-2 border-t pt-2 text-[0.7rem] text-muted-foreground">
-				{pulls.length} open PR{pulls.length === 1 ? '' : 's'}
+				{filteredPulls.length}{#if domainFilter.length}/{pulls.length}{/if} open PR{filteredPulls.length === 1 ? '' : 's'}
 				{#if unlabeled}· {unlabeled} unlabeled (hidden){/if}
 			</div>
 		</div>
@@ -165,7 +218,7 @@
 					No labelled pull requests to graph
 				</div>
 			{:else}
-				<PrLabelGraph {pulls} {focus} {colorFor} onSelectPr={openPr} onToggleLabel={toggleLabel} />
+				<PrLabelGraph pulls={filteredPulls} {focus} {colorFor} onSelectPr={openPr} onToggleLabel={toggleLabel} />
 			{/if}
 		</div>
 	</div>

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -38,8 +38,11 @@
 		deleteUser,
 		fetchRepoFeatures,
 		updateRepoFeatures,
+		fetchRepoDomains,
+		updateRepoDomains,
 		fetchRetrySettings,
 		updateRetrySettings,
+		type ReviewDomain,
 		type RepoFeatures,
 		type RetrySettings,
 		type LicenseInfo,
@@ -260,18 +263,35 @@
 	let featuresMessage: string | null = $state(null);
 	let featuresMessageErr: boolean = $state(false);
 
+	// Review "grand domains" (codex, bun, …) + prompt. DB-backed (works on
+	// stateless pods), edited alongside the per-repo features in the same modal.
+	let domainsDraft: ReviewDomain[] = $state([]);
+	let reviewPromptDraft: string = $state('');
+
 	async function openFeaturesModal(slug: string) {
 		featuresSlug = slug;
 		featuresDraft = null;
+		domainsDraft = [];
+		reviewPromptDraft = '';
 		featuresMessage = null;
 		featuresMessageErr = false;
 		featuresModalOpen = true;
 		try {
 			featuresDraft = await fetchRepoFeatures(slug);
+			const d = await fetchRepoDomains(slug);
+			domainsDraft = d.domains ?? [];
+			reviewPromptDraft = d.review_prompt ?? '';
 		} catch (e) {
 			featuresMessage = e instanceof Error ? e.message : 'Failed to load features';
 			featuresMessageErr = true;
 		}
+	}
+
+	function addDomain() {
+		domainsDraft = [...domainsDraft, { name: '', description: '' }];
+	}
+	function removeDomain(i: number) {
+		domainsDraft = domainsDraft.filter((_, idx) => idx !== i);
 	}
 
 	async function handleSaveFeatures() {
@@ -279,6 +299,11 @@
 		featuresSaving = true;
 		try {
 			await updateRepoFeatures(featuresSlug, featuresDraft);
+			// Persist the review domains + prompt (DB) — drop blank-name rows.
+			await updateRepoDomains(featuresSlug, {
+				domains: domainsDraft.filter((d) => d.name.trim() !== ''),
+				review_prompt: reviewPromptDraft
+			});
 			featuresMessage = tr('settings.features.saved');
 			featuresMessageErr = false;
 			featuresModalOpen = false;
@@ -1644,6 +1669,48 @@
 						</div>
 					</div>
 				</details>
+
+				<!-- Review "grand domains" — stored in the DB (works on stateless
+				     pods, shared across replicas), not in the ConfigMap TOML. -->
+				<div class="mt-4 border-t pt-3">
+					<div class="flex items-center justify-between mb-1">
+						<h5 class="text-xs uppercase text-muted-foreground font-semibold">Review domains</h5>
+						<button type="button" class="text-xs text-primary hover:underline" onclick={addDomain}>
+							+ add
+						</button>
+					</div>
+					<p class="text-[0.7rem] text-muted-foreground mb-2">
+						Broad areas the AI review tags each PR/issue with (codex, bun, c#…). Multi-valued and
+						filterable in the PR network graph.
+					</p>
+					{#each domainsDraft as d, i}
+						<div class="flex gap-1 mb-1">
+							<Input class="h-8 w-1/3" placeholder="name" bind:value={d.name} />
+							<Input
+								class="h-8 flex-1"
+								placeholder="description (helps the AI decide)"
+								value={d.description ?? ''}
+								oninput={(e) => (d.description = (e.currentTarget as HTMLInputElement).value)}
+							/>
+							<button
+								type="button"
+								class="px-2 text-muted-foreground hover:text-destructive"
+								onclick={() => removeDomain(i)}
+								aria-label="remove domain"
+							>
+								✕
+							</button>
+						</div>
+					{:else}
+						<p class="text-[0.7rem] text-muted-foreground">No domains configured yet.</p>
+					{/each}
+					<Label class="text-xs mb-1 mt-3">Custom review prompt (optional)</Label>
+					<textarea
+						class="w-full rounded-md border bg-background px-2 py-1 text-xs min-h-[64px]"
+						placeholder="Overrides the default domain instruction sent to the AI. Leave empty to use the built-in one."
+						bind:value={reviewPromptDraft}
+					></textarea>
+				</div>
 
 				<div class="flex gap-2 pt-2">
 					<Button variant="outline" size="sm" class="flex-1"


### PR DESCRIPTION
Per-repo review **grand domains** (codex, bun, c#…): the AI review tags each PR and issue with the domains it touches (multi-valued, like labels), surfaced as **filters in the PR network graph**.

## Config is DB-backed (stateless-pod safe)
wshm-pro runs as stateless K8s pods — a ConfigMap-seeded `global.toml` can't hold runtime-editable settings (lost on restart, not shared across replicas). So this adds:
- `app_settings` K/V table + `DatabaseBackend::{get,set}_app_setting` (SQLite here; Postgres in the wshm-pro PR).
- Keys `review_domains` (JSON list of `{name, description}`) + `review_prompt`, **per repo**.

## Pipeline / storage / API
- pr_analysis + triage fetch domains from the DB, inject into the prompt, and parse a `domains: string[]` into `pr_analyses` / `triage_results` (new JSON column + migration).
- `/pulls` + `/issues` surface `domains`; new admin `GET/PATCH /api/v1/repos/{slug}/domains`.

## Web
- Settings features modal: domains editor (name/description rows) + review-prompt textarea → saved to the DB (first setting that actually persists on stateless pods).
- `/prs/graph`: multi-select **Domains** filter.

**77 tests pass**; both crates compile; OSS + Pro web build.

> Merge this before the wshm-pro PR — its CI builds against wshm-core `develop` and needs the new trait methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)