### PR TITLE
release: promote develop → main (frequency-aware domain discovery)

### DIFF
--- a/src/ai/prompts/discover_domains.rs
+++ b/src/ai/prompts/discover_domains.rs
@@ -2,14 +2,17 @@
 //! (broad product/tech areas — codex, bun, c#…) from cheap signals so the user
 //! doesn't have to guess them. Output feeds `review_domains` (as PROPOSED).
 
-pub const SYSTEM: &str = r#"You infer the "grand domains" of a software repository — the handful of broad areas the project is organised around (e.g. "codex", "bun", "c#", "web", "api", "billing"). These become macro-labels the review applies to PRs and issues.
+pub const SYSTEM: &str = r#"You infer the "grand domains" of a software repository — the handful of broad areas the project is organised around (e.g. "codex", "bun", "c-sharp", "web", "api", "billing"). These become macro-labels the review applies to PRs and issues.
 
-You are given the repo's languages, top-level structure, key manifest files, and a sample of recent PR/issue titles. Propose 5 to 15 grand domains that best partition the work in THIS repo.
+You are given, for THIS repo: its languages, top-level structure, key manifest files, a ranked list of the terms that recur most across ALL of its PR and issue titles, and a sample of recent titles.
+
+The ranked recurrent terms are your PRIMARY signal — they show what the project is actually most about. Cluster related terms into broad domains (merge synonyms and spelling variants), and ground every domain in the evidence. Do NOT emit one domain per word, and do NOT invent generic domains the signals do not support. Generic process words (fix, add, update, refactor, release…) are already filtered out; ignore any that slip through.
+
+Propose 5 to 15 grand domains that best partition the work in THIS repo.
 
 Rules:
-- Short lowercase slugs (e.g. "codex", "bun", "c#", "web-ui"), no spaces (use hyphens).
+- Short lowercase slugs, no spaces (use hyphens): "codex", "bun", "web-ui", "c-sharp".
 - Broad areas, not fine-grained labels. Prefer product/subsystem/tech axes.
-- Ground them in the signals; do NOT invent generic domains that don't fit.
 - Give each a one-line description.
 
 Respond with JSON only, no markdown:
@@ -25,6 +28,7 @@ pub fn build_user_prompt(
     entries: &[String],
     pr_titles: &[String],
     issue_titles: &[String],
+    top_terms: &[(String, usize)],
 ) -> String {
     let fmt = |items: &[String]| -> String {
         if items.is_empty() {
@@ -57,14 +61,28 @@ pub fn build_user_prompt(
     out.push_str(&format!("Languages: {}\n", fmt(languages)));
     out.push_str(&format!("Top-level entries: {}\n", fmt(entries)));
     out.push_str(&format!("Manifest files: {}\n", fmt(&manifests)));
-    out.push_str("\n### Recent pull request titles\n");
+    out.push_str("\n### Most recurrent terms across ALL PR & issue titles\n");
+    out.push_str(
+        "(ranked by frequency; generic process words already removed — your primary signal)\n",
+    );
+    if top_terms.is_empty() {
+        out.push_str("(not enough history yet — fall back to the structure/titles below)\n");
+    } else {
+        for (term, count) in top_terms {
+            out.push_str(&format!("- {term} ({count})\n"));
+        }
+    }
+
+    out.push_str("\n### Sample of recent pull request titles\n");
     for t in pr_titles.iter().take(40) {
         out.push_str(&format!("- {t}\n"));
     }
-    out.push_str("\n### Recent issue titles\n");
+    out.push_str("\n### Sample of recent issue titles\n");
     for t in issue_titles.iter().take(40) {
         out.push_str(&format!("- {t}\n"));
     }
-    out.push_str("\nPropose the grand domains for this repo as JSON.\n");
+    out.push_str(
+        "\nCluster the recurrent terms into the grand domains for this repo. Respond as JSON.\n",
+    );
     out
 }

--- a/src/pipelines/discover_domains.rs
+++ b/src/pipelines/discover_domains.rs
@@ -29,6 +29,142 @@ fn load_domains(db: &dyn DatabaseBackend) -> Vec<DomainDef> {
         .unwrap_or_default()
 }
 
+/// Frequency-rank the significant words across all PR + issue titles, dropping
+/// stopwords and generic dev-process verbs (fix/add/update/…) that dominate
+/// commit-style titles but say nothing about a repo's *domains*. Tokens keep
+/// `#`/`+` (so "c#", "c++" survive) but anything containing a digit or a `#`
+/// prefix (issue refs, versions) is dropped. Returns the top `n` terms seen at
+/// least twice, most frequent first.
+fn top_terms(pr_titles: &[String], issue_titles: &[String], n: usize) -> Vec<(String, usize)> {
+    use std::collections::{HashMap, HashSet};
+    const STOP: &[&str] = &[
+        // articles / glue
+        "the",
+        "a",
+        "an",
+        "to",
+        "of",
+        "for",
+        "in",
+        "on",
+        "and",
+        "or",
+        "with",
+        "without",
+        "by",
+        "is",
+        "are",
+        "be",
+        "this",
+        "that",
+        "it",
+        "its",
+        "as",
+        "at",
+        "from",
+        "into",
+        "via",
+        "when",
+        "not",
+        "no",
+        "up",
+        "out",
+        "off",
+        "if",
+        "then",
+        "else",
+        "per",
+        "vs",
+        "so",
+        // generic dev-process verbs/nouns — noise, not domains
+        "fix",
+        "fixes",
+        "fixed",
+        "add",
+        "adds",
+        "added",
+        "adding",
+        "update",
+        "updates",
+        "updated",
+        "bump",
+        "chore",
+        "feat",
+        "feature",
+        "features",
+        "refactor",
+        "remove",
+        "removes",
+        "removed",
+        "test",
+        "tests",
+        "testing",
+        "wip",
+        "merge",
+        "release",
+        "docs",
+        "doc",
+        "ci",
+        "cd",
+        "build",
+        "support",
+        "improve",
+        "improvement",
+        "improvements",
+        "use",
+        "using",
+        "used",
+        "make",
+        "makes",
+        "allow",
+        "ensure",
+        "handle",
+        "new",
+        "better",
+        "error",
+        "errors",
+        "issue",
+        "issues",
+        "pr",
+        "prs",
+        "bug",
+        "bugs",
+        "wrong",
+        "broken",
+        "fail",
+        "fails",
+        "failing",
+        "cleanup",
+        "clean",
+        "rework",
+        "change",
+        "changes",
+        "changed",
+        "revert",
+        "wshm",
+        "pro",
+    ];
+    let stop: HashSet<&str> = STOP.iter().copied().collect();
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for t in pr_titles.iter().chain(issue_titles.iter()) {
+        for raw in t.split(|c: char| !c.is_alphanumeric() && c != '#' && c != '+') {
+            let w = raw.to_lowercase();
+            if w.len() < 2
+                || w.starts_with('#')
+                || w.chars().any(|c| c.is_ascii_digit())
+                || stop.contains(w.as_str())
+            {
+                continue;
+            }
+            *counts.entry(w).or_default() += 1;
+        }
+    }
+    let mut ranked: Vec<(String, usize)> = counts.into_iter().filter(|(_, c)| *c >= 2).collect();
+    ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    ranked.truncate(n);
+    ranked
+}
+
 /// Run discovery and merge newly-found domains (as proposed) into the DB set.
 /// Existing domains keep their `validated` flag. Returns the full merged set.
 pub async fn discover(
@@ -39,22 +175,41 @@ pub async fn discover(
 ) -> Result<Vec<DomainDef>> {
     let languages = gh.fetch_languages().await.unwrap_or_default();
     let entries = gh.fetch_root_entries().await.unwrap_or_default();
-    let pr_titles: Vec<String> = db
+
+    // Corpus for frequency + sampling: open PRs plus recent closed PRs, and open
+    // issues (closed issues aren't retained in the DB). Titles only — cheap,
+    // already synced, so this works on stateless pods with no clone.
+    let mut pr_titles: Vec<String> = db
         .get_open_pulls()
         .unwrap_or_default()
         .iter()
-        .take(40)
         .map(|p| p.title.clone())
         .collect();
+    pr_titles.extend(
+        db.get_closed_pulls(500)
+            .unwrap_or_default()
+            .iter()
+            .map(|p| p.title.clone()),
+    );
     let issue_titles: Vec<String> = db
         .get_open_issues()
         .unwrap_or_default()
         .iter()
-        .take(40)
         .map(|i| i.title.clone())
         .collect();
 
-    let user = discover_domains::build_user_prompt(&languages, &entries, &pr_titles, &issue_titles);
+    // Rank the terms that actually recur across the whole corpus so the model
+    // grounds domains in what the repo is *most about*, not a lucky 40-title
+    // sample. Generic dev-process words are filtered out (see `top_terms`).
+    let top_terms = top_terms(&pr_titles, &issue_titles, 30);
+
+    let user = discover_domains::build_user_prompt(
+        &languages,
+        &entries,
+        &pr_titles,
+        &issue_titles,
+        &top_terms,
+    );
     let out: DomainDiscovery = ai.complete(discover_domains::SYSTEM, &user).await?;
 
     let mut existing = load_domains(db);
@@ -105,5 +260,50 @@ pub async fn ensure_discovered(
         tracing::warn!("Auto domain discovery failed: {e}");
         // Mark attempted so we don't retry every batch on a persistent failure.
         let _ = db.set_app_setting(DOMAINS_DISCOVERED_KEY, "1");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::top_terms;
+
+    #[test]
+    fn ranks_domain_terms_and_drops_noise() {
+        let prs = vec![
+            "Fix codex parser crash".to_string(),
+            "feat(codex): add streaming".to_string(),
+            "Improve codex prompts".to_string(),
+            "bun: bump runtime".to_string(),
+            "Update bun lockfile".to_string(),
+            "C# analyzer for billing".to_string(),
+            "billing webhook #123 retry".to_string(),
+        ];
+        let issues = vec![
+            "codex times out".to_string(),
+            "billing invoice wrong total".to_string(),
+        ];
+        let terms = top_terms(&prs, &issues, 10);
+        let map: std::collections::HashMap<_, _> = terms.iter().cloned().collect();
+
+        // Recurrent domain words are counted…
+        assert_eq!(map.get("codex"), Some(&4));
+        assert_eq!(map.get("billing"), Some(&3));
+        assert_eq!(map.get("bun"), Some(&2));
+        // …process verbs and singletons/refs/versions are dropped.
+        assert!(!map.contains_key("fix"));
+        assert!(!map.contains_key("add"));
+        assert!(!map.contains_key("update"));
+        assert!(!map.contains_key("#123"));
+        assert!(!map.contains_key("parser")); // appears once -> below the >=2 floor
+                                              // Ranking is frequency-desc: codex first.
+        assert_eq!(terms.first().map(|(t, _)| t.as_str()), Some("codex"));
+    }
+
+    #[test]
+    fn keeps_hashy_tech_tokens() {
+        // "c#" recurs -> survives tokenization (digit-free, no '#' prefix).
+        let prs = vec!["C# refactor".to_string(), "port to c# core".to_string()];
+        let terms = top_terms(&prs, &[], 10);
+        assert!(terms.iter().any(|(t, c)| t == "c#" && *c == 2));
     }
 }


### PR DESCRIPTION
Promotes #147 (corpus-wide term-frequency grounding for domain discovery) to main so the Pro Docker build picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)