### PR TITLE
fix(discover): replace proposed domains on re-run + keep specific terms

### DIFF
--- a/src/ai/prompts/discover_domains.rs
+++ b/src/ai/prompts/discover_domains.rs
@@ -6,13 +6,16 @@ pub const SYSTEM: &str = r#"You infer the "grand domains" of a software reposito
 
 You are given, for THIS repo: its languages, top-level structure, key manifest files, a ranked list of the terms that recur most across ALL of its PR and issue titles, and a sample of recent titles.
 
-The ranked recurrent terms are your PRIMARY signal — they show what the project is actually most about. Cluster related terms into broad domains (merge synonyms and spelling variants), and ground every domain in the evidence. Do NOT emit one domain per word, and do NOT invent generic domains the signals do not support. Generic process words (fix, add, update, refactor, release…) are already filtered out; ignore any that slip through.
+The ranked recurrent terms are your PRIMARY signal — they show what the project is actually most about. A term that recurs a lot and names a concrete thing — a tool, integration, subsystem, or technology (e.g. "codex", "bun", "windows", "git") — should become its OWN domain, kept under its own name. Do not bury such a term inside a broad umbrella like "integrations" or "filters": if "codex" is frequent, emit a "codex" domain, not just an "agent-integrations" one.
 
-Propose 5 to 15 grand domains that best partition the work in THIS repo.
+Only merge terms that are genuinely the same thing — plurals, obvious spelling variants, or exact synonyms (e.g. "hook"/"hooks"). Never emit two domains that overlap or nest (no "hooks" AND "hook-rewriting", no "windows" AND "windows-support", no "search" AND "command-filters"): pick the single clearest name and drop the rest. Ground every domain in the evidence; do NOT invent generic domains the signals do not support. Generic process words (fix, add, update, refactor, release…) are already filtered out; ignore any that slip through.
+
+Propose 6 to 12 grand domains that best partition the work in THIS repo — no more. Fewer, sharper, non-overlapping domains are far better than many fuzzy ones.
 
 Rules:
 - Short lowercase slugs, no spaces (use hyphens): "codex", "bun", "web-ui", "c-sharp".
-- Broad areas, not fine-grained labels. Prefer product/subsystem/tech axes.
+- Prefer the recurrent term's own name as the slug when it names a real thing.
+- Each domain must be clearly distinct from every other — no overlap, no nesting.
 - Give each a one-line description.
 
 Respond with JSON only, no markdown:

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -2313,6 +2313,38 @@ async fn api_repo_features_patch(
     Json(resp).into_response()
 }
 
+/// Enrich the stored domains with their live PR/issue volume and sort by it
+/// descending, so the biggest subject-groupings (e.g. "codex" → 25) surface
+/// first. Each entry gains a `count` field. Counts are computed live from the
+/// title corpus, never persisted, so they stay fresh as PRs come and go.
+fn domains_with_counts(
+    db: &dyn crate::db::backend::DatabaseBackend,
+    raw: serde_json::Value,
+) -> serde_json::Value {
+    let domains: Vec<crate::config::DomainDef> = serde_json::from_value(raw).unwrap_or_default();
+    let counts = crate::pipelines::discover_domains::domain_counts(db, &domains);
+    let mut arr: Vec<(usize, serde_json::Value)> = domains
+        .iter()
+        .map(|d| {
+            let c = counts.get(&d.name).copied().unwrap_or(0);
+            (
+                c,
+                json!({
+                    "name": d.name,
+                    "description": d.description,
+                    "validated": d.validated,
+                    "count": c,
+                }),
+            )
+        })
+        .collect();
+    arr.sort_by(|a, b| {
+        b.0.cmp(&a.0)
+            .then_with(|| a.1["name"].as_str().cmp(&b.1["name"].as_str()))
+    });
+    json!(arr.into_iter().map(|(_, v)| v).collect::<Vec<_>>())
+}
+
 /// GET /api/v1/repos/{slug}/domains -- read the review "grand domains" list +
 /// optional custom prompt. DB-backed (app_settings) so it survives on stateless
 /// pods and is shared across replicas — unlike the ConfigMap-seeded global.toml.
@@ -2323,13 +2355,14 @@ async fn api_repo_domains_get(
     let repos = state.multi.repos.read().await;
     match repos.get(&slug) {
         Some(ds) => {
-            let domains: serde_json::Value = ds
+            let raw: serde_json::Value = ds
                 .db
                 .get_app_setting(crate::db::settings::REVIEW_DOMAINS_KEY)
                 .ok()
                 .flatten()
                 .and_then(|s| serde_json::from_str(&s).ok())
                 .unwrap_or_else(|| json!([]));
+            let domains = domains_with_counts(ds.db.as_ref(), raw);
             let prompt = ds
                 .db
                 .get_app_setting(crate::db::settings::REVIEW_PROMPT_KEY)
@@ -2412,13 +2445,14 @@ async fn api_repo_domains_patch(
         }
     }
 
-    let domains: serde_json::Value = ds
+    let raw: serde_json::Value = ds
         .db
         .get_app_setting(crate::db::settings::REVIEW_DOMAINS_KEY)
         .ok()
         .flatten()
         .and_then(|s| serde_json::from_str(&s).ok())
         .unwrap_or_else(|| json!([]));
+    let domains = domains_with_counts(ds.db.as_ref(), raw);
     let prompt = ds
         .db
         .get_app_setting(crate::db::settings::REVIEW_PROMPT_KEY)
@@ -2467,7 +2501,13 @@ async fn api_repo_domains_discover(
     };
     let gh = ds.gh();
     match crate::pipelines::discover_domains::discover(&ds.config, ds.db.as_ref(), &gh, &ai).await {
-        Ok(domains) => Json(json!({ "domains": domains })).into_response(),
+        Ok(domains) => {
+            let enriched = domains_with_counts(
+                ds.db.as_ref(),
+                serde_json::to_value(&domains).unwrap_or_else(|_| json!([])),
+            );
+            Json(json!({ "domains": enriched })).into_response()
+        }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({"error": format!("discovery failed: {e}")})),

--- a/src/pipelines/discover_domains.rs
+++ b/src/pipelines/discover_domains.rs
@@ -165,6 +165,70 @@ fn top_terms(pr_titles: &[String], issue_titles: &[String], n: usize) -> Vec<(St
     ranked
 }
 
+/// Split a title into lowercased word tokens (keeping `#`/`+` so "c#"/"c++"
+/// survive). Shared by the ranker and the domain counter so both see terms the
+/// same way.
+fn title_words(title: &str) -> std::collections::HashSet<String> {
+    title
+        .split(|c: char| !c.is_alphanumeric() && c != '#' && c != '+')
+        .map(|w| w.to_lowercase())
+        .filter(|w| w.len() >= 2)
+        .collect()
+}
+
+/// The whole title corpus (open + recent closed PRs + open issues) as titles.
+fn corpus_titles(db: &dyn DatabaseBackend) -> Vec<String> {
+    let mut titles: Vec<String> = db
+        .get_open_pulls()
+        .unwrap_or_default()
+        .iter()
+        .map(|p| p.title.clone())
+        .collect();
+    titles.extend(
+        db.get_closed_pulls(500)
+            .unwrap_or_default()
+            .iter()
+            .map(|p| p.title.clone()),
+    );
+    titles.extend(
+        db.get_open_issues()
+            .unwrap_or_default()
+            .iter()
+            .map(|i| i.title.clone()),
+    );
+    titles
+}
+
+/// How many PRs/issues each domain groups: the count of corpus titles that
+/// mention it — matching the domain's slug OR any of its hyphen/underscore
+/// parts as a whole word (so "web-ui" matches titles with "web" or "ui").
+/// This is the "25 PRs on codex" volume shown next to each domain; computed
+/// live (never persisted) so it stays fresh as PRs come and go.
+pub fn domain_counts(
+    db: &dyn DatabaseBackend,
+    domains: &[DomainDef],
+) -> std::collections::HashMap<String, usize> {
+    let title_sets: Vec<std::collections::HashSet<String>> =
+        corpus_titles(db).iter().map(|t| title_words(t)).collect();
+    let mut out = std::collections::HashMap::new();
+    for d in domains {
+        let name = d.name.to_lowercase();
+        // The slug itself plus its parts (drop 1-char fragments).
+        let mut toks: Vec<String> = name
+            .split(['-', '_', ' '])
+            .filter(|s| s.len() >= 2)
+            .map(|s| s.to_string())
+            .collect();
+        toks.push(name.clone());
+        let count = title_sets
+            .iter()
+            .filter(|set| toks.iter().any(|tk| set.contains(tk)))
+            .count();
+        out.insert(d.name.clone(), count);
+    }
+    out
+}
+
 /// Run discovery and merge newly-found domains (as proposed) into the DB set.
 /// Existing domains keep their `validated` flag. Returns the full merged set.
 pub async fn discover(

--- a/src/pipelines/discover_domains.rs
+++ b/src/pipelines/discover_domains.rs
@@ -212,7 +212,14 @@ pub async fn discover(
     );
     let out: DomainDiscovery = ai.complete(discover_domains::SYSTEM, &user).await?;
 
-    let mut existing = load_domains(db);
+    // Keep the human-validated domains, but REPLACE all proposed (unvalidated)
+    // ones with this fresh run. Merging instead piles up near-duplicates every
+    // time discover is clicked (hooks + hook-rewriting, search + command-filters…),
+    // which is exactly the mess this avoids.
+    let mut existing: Vec<DomainDef> = load_domains(db)
+        .into_iter()
+        .filter(|d| d.validated)
+        .collect();
     for d in out.domains {
         let name = d.name.trim().to_lowercase();
         if name.is_empty() {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -533,6 +533,8 @@ export interface ReviewDomain {
 	description?: string | null;
 	/** Human-approved. Only validated domains are applied as `domain:*` labels. */
 	validated?: boolean;
+	/** How many PRs/issues this domain groups (live title-corpus match, server-computed). */
+	count?: number;
 }
 /** Per-repo review-domains config, stored in the DB (works on stateless pods). */
 export interface RepoDomains {

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -743,6 +743,13 @@
 										title="validated → applied as a GitHub label"
 									/>
 									<Input class="h-8 w-1/3" placeholder="name" bind:value={d.name} />
+									<Badge
+										variant="secondary"
+										class="shrink-0 tabular-nums"
+										title="pull requests + issues grouped under this domain"
+									>
+										{d.count ?? 0} PR
+									</Badge>
 									<Input
 										class="h-8 flex-1"
 										placeholder="description (helps the AI decide)"


### PR DESCRIPTION
Fixes the messy `rtk-ai/rtk` domain list (≈27 overlapping entries: `hooks`+`hook-rewriting`, `search`+`command-filters`, `windows`+`windows-support`, `i18n-docs`+`docs-i18n`, `rtk-cli`+`cli-core`…, and no standalone `codex`).

**1. Re-discover REPLACES proposals** — keeps human-validated domains, regenerates the rest, so clicking discover no longer accumulates near-duplicates.

**2. Prompt keeps concrete frequent terms standalone** — a recurrent tool/integration/tech (codex, bun, windows, git) becomes its own domain instead of being buried under an umbrella; overlapping/nesting domains forbidden; capped at 6–12 sharp areas.

Unit tests still green; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)