### PR TITLE
feat(domains): configurable "Top N" discovery slider (5–30)

### DIFF
--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -2368,7 +2368,9 @@ async fn api_repo_domains_get(
                 .get_app_setting(crate::db::settings::REVIEW_PROMPT_KEY)
                 .ok()
                 .flatten();
-            Json(json!({ "domains": domains, "review_prompt": prompt })).into_response()
+            let limit = crate::pipelines::discover_domains::resolve_limit(ds.db.as_ref());
+            Json(json!({ "domains": domains, "review_prompt": prompt, "limit": limit }))
+                .into_response()
         }
         None => (
             StatusCode::NOT_FOUND,
@@ -2444,6 +2446,17 @@ async fn api_repo_domains_patch(
                 .into_response();
         }
     }
+    // "Top N" discovery limit — clamped to the slider range before persisting.
+    if let Some(l) = body.get("limit").and_then(|v| v.as_u64()) {
+        let clamped = (l as usize).clamp(
+            crate::pipelines::discover_domains::MIN_DOMAINS_LIMIT,
+            crate::pipelines::discover_domains::MAX_DOMAINS_LIMIT,
+        );
+        let _ = ds.db.set_app_setting(
+            crate::db::settings::REVIEW_DOMAINS_LIMIT_KEY,
+            &clamped.to_string(),
+        );
+    }
 
     let raw: serde_json::Value = ds
         .db
@@ -2458,7 +2471,8 @@ async fn api_repo_domains_patch(
         .get_app_setting(crate::db::settings::REVIEW_PROMPT_KEY)
         .ok()
         .flatten();
-    Json(json!({ "domains": domains, "review_prompt": prompt })).into_response()
+    let limit = crate::pipelines::discover_domains::resolve_limit(ds.db.as_ref());
+    Json(json!({ "domains": domains, "review_prompt": prompt, "limit": limit })).into_response()
 }
 
 /// POST /api/v1/repos/{slug}/domains/discover -- infer the repo's grand domains
@@ -2469,6 +2483,7 @@ async fn api_repo_domains_discover(
     State(state): State<Arc<WebState>>,
     user: axum::Extension<Option<crate::auth::User>>,
     axum::extract::Path(slug): axum::extract::Path<String>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
 ) -> Response {
     if state.users.is_some() {
         if let Err(e) = require_admin(&user) {
@@ -2489,13 +2504,27 @@ async fn api_repo_domains_discover(
     };
     drop(repos);
 
+    // Optional `?limit=N` slider value — persist it (clamped) so this and future
+    // discovers use it.
+    if let Some(n) = params.get("limit").and_then(|s| s.parse::<usize>().ok()) {
+        let clamped = n.clamp(
+            crate::pipelines::discover_domains::MIN_DOMAINS_LIMIT,
+            crate::pipelines::discover_domains::MAX_DOMAINS_LIMIT,
+        );
+        let _ = ds.db.set_app_setting(
+            crate::db::settings::REVIEW_DOMAINS_LIMIT_KEY,
+            &clamped.to_string(),
+        );
+    }
+
     match crate::pipelines::discover_domains::discover(&ds.config, ds.db.as_ref()).await {
         Ok(domains) => {
             let enriched = domains_with_counts(
                 ds.db.as_ref(),
                 serde_json::to_value(&domains).unwrap_or_else(|_| json!([])),
             );
-            Json(json!({ "domains": enriched })).into_response()
+            let limit = crate::pipelines::discover_domains::resolve_limit(ds.db.as_ref());
+            Json(json!({ "domains": enriched, "limit": limit })).into_response()
         }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/db/settings.rs
+++ b/src/db/settings.rs
@@ -19,6 +19,8 @@ use crate::db::Database;
 pub const REVIEW_DOMAINS_KEY: &str = "review_domains";
 /// Setting key: an optional custom review prompt fragment (plain string).
 pub const REVIEW_PROMPT_KEY: &str = "review_prompt";
+/// Setting key: how many top subjects `discover` proposes (stringified usize).
+pub const REVIEW_DOMAINS_LIMIT_KEY: &str = "review_domains_limit";
 
 impl Database {
     /// Read a setting value, or `None` if unset.

--- a/src/pipelines/discover_domains.rs
+++ b/src/pipelines/discover_domains.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 
 use crate::config::{Config, DomainDef};
 use crate::db::backend::DatabaseBackend;
-use crate::db::settings::REVIEW_DOMAINS_KEY;
+use crate::db::settings::{REVIEW_DOMAINS_KEY, REVIEW_DOMAINS_LIMIT_KEY};
 
 /// Marker so auto-discovery runs at most once per repo (the button forces a
 /// fresh run regardless). Stored alongside the domains in `app_settings`.
@@ -255,8 +255,22 @@ pub fn domain_counts(
     out
 }
 
-/// How many domains discovery proposes: the top subjects by PR/issue volume.
-const MAX_DISCOVERED: usize = 12;
+/// Default number of domains discovery proposes when the repo has no override.
+pub const DEFAULT_DOMAINS_LIMIT: usize = 12;
+/// Slider bounds for the configurable "Top N" discovery limit.
+pub const MIN_DOMAINS_LIMIT: usize = 5;
+pub const MAX_DOMAINS_LIMIT: usize = 30;
+
+/// The repo's configured "Top N" discovery limit, clamped to the slider range,
+/// falling back to the default when unset or unparsable.
+pub fn resolve_limit(db: &dyn DatabaseBackend) -> usize {
+    db.get_app_setting(REVIEW_DOMAINS_LIMIT_KEY)
+        .ok()
+        .flatten()
+        .and_then(|s| s.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT_DOMAINS_LIMIT)
+        .clamp(MIN_DOMAINS_LIMIT, MAX_DOMAINS_LIMIT)
+}
 
 /// Discover a repo's grand domains from the *frequency of subjects across ALL
 /// its PRs and issues* — the terms the most pull requests are actually about
@@ -281,7 +295,7 @@ pub async fn discover(config: &Config, db: &dyn DatabaseBackend) -> Result<Vec<D
             extra_stop.insert(singular(part));
         }
     }
-    let ranked = top_terms(&titles, &[], &extra_stop, MAX_DISCOVERED);
+    let ranked = top_terms(&titles, &[], &extra_stop, resolve_limit(db));
 
     // Keep human-validated domains; REPLACE the proposed set with this fresh run
     // so re-discovering dedupes instead of accumulating near-duplicates.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -540,6 +540,8 @@ export interface ReviewDomain {
 export interface RepoDomains {
 	domains: ReviewDomain[];
 	review_prompt: string | null;
+	/** How many top subjects `discover` proposes (the "Top N" slider). */
+	limit?: number;
 }
 
 export async function fetchRepoDomains(slug: string): Promise<RepoDomains> {
@@ -553,7 +555,7 @@ export async function fetchRepoDomains(slug: string): Promise<RepoDomains> {
 
 export async function updateRepoDomains(
 	slug: string,
-	patch: { domains?: ReviewDomain[]; review_prompt?: string }
+	patch: { domains?: ReviewDomain[]; review_prompt?: string; limit?: number }
 ): Promise<RepoDomains> {
 	const res = await fetch(`/api/v1/repos/${encodeURIComponent(slug)}/domains`, {
 		method: 'PATCH',
@@ -567,9 +569,13 @@ export async function updateRepoDomains(
 	return res.json();
 }
 
-/** Infer the repo's grand domains (AI) and merge them in as proposed. */
-export async function discoverRepoDomains(slug: string): Promise<RepoDomains> {
-	const res = await fetch(`/api/v1/repos/${encodeURIComponent(slug)}/domains/discover`, {
+/**
+ * Regenerate the repo's grand domains from PR/issue subject frequency and merge
+ * them in as proposed. `limit` overrides (and persists) the "Top N" slider.
+ */
+export async function discoverRepoDomains(slug: string, limit?: number): Promise<RepoDomains> {
+	const qs = limit != null ? `?limit=${encodeURIComponent(limit)}` : '';
+	const res = await fetch(`/api/v1/repos/${encodeURIComponent(slug)}/domains/discover${qs}`, {
 		method: 'POST',
 		headers: CSRF_HEADERS
 	});

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -269,6 +269,7 @@
 	let domainsRepo: string = $state('');
 	let domainsDraft: ReviewDomain[] = $state([]);
 	let reviewPromptDraft: string = $state('');
+	let domainsLimit: number = $state(12);
 	let domainsLoading: boolean = $state(false);
 	let domainsSaving: boolean = $state(false);
 	let domainsMessage: string | null = $state(null);
@@ -285,6 +286,7 @@
 			const d = await fetchRepoDomains(slug);
 			domainsDraft = d.domains ?? [];
 			reviewPromptDraft = d.review_prompt ?? '';
+			domainsLimit = d.limit ?? 12;
 		} catch (e) {
 			domainsMessage = e instanceof Error ? e.message : 'Failed to load domains';
 			domainsMessageErr = true;
@@ -298,7 +300,8 @@
 		try {
 			await updateRepoDomains(domainsRepo, {
 				domains: domainsDraft.filter((d) => d.name.trim() !== ''),
-				review_prompt: reviewPromptDraft
+				review_prompt: reviewPromptDraft,
+				limit: domainsLimit
 			});
 			domainsMessage = 'Saved.';
 			domainsMessageErr = false;
@@ -338,9 +341,10 @@
 		domainsDiscovering = true;
 		domainsMessage = null;
 		try {
-			const d = await discoverRepoDomains(domainsRepo);
+			const d = await discoverRepoDomains(domainsRepo, domainsLimit);
 			domainsDraft = d.domains ?? [];
 			reviewPromptDraft = d.review_prompt ?? reviewPromptDraft;
+			domainsLimit = d.limit ?? domainsLimit;
 		} catch (e) {
 			domainsMessage = e instanceof Error ? e.message : 'discovery failed';
 			domainsMessageErr = true;
@@ -714,6 +718,24 @@
 						{#if domainsLoading}
 							<p class="text-xs text-muted-foreground">{$t('common.loading')}</p>
 						{:else}
+								<!-- "Top N" slider: how many top subjects discover proposes. -->
+								<div class="flex items-center gap-3 rounded-md border bg-muted/30 px-3 py-2">
+									<Label class="text-xs whitespace-nowrap">Top domains</Label>
+									<input
+										type="range"
+										min="5"
+										max="30"
+										step="1"
+										class="flex-1 accent-primary"
+										bind:value={domainsLimit}
+									/>
+									<Badge variant="secondary" class="tabular-nums shrink-0">{domainsLimit}</Badge>
+								</div>
+								<p class="text-[0.7rem] text-muted-foreground -mt-1">
+									How many top subjects <strong>discover</strong> proposes (by PR/issue volume). Applied on the
+									next discover; saved with the domains.
+								</p>
+
 							<div class="flex items-center justify-between">
 								<h5 class="text-xs uppercase text-muted-foreground font-semibold">Domains</h5>
 								<div class="flex items-center gap-2">


### PR DESCRIPTION
Adds a per-repo **DB-backed "Top N"** limit for how many top subjects `discover` proposes, with a **slider** in Settings → Domains (default 12, range 5–30).

Persisted in `app_settings`; returned by `GET`/`PATCH /domains` as `limit`; passable to discover via `?limit=N` (clamped 5–30 on both the query and PATCH paths). Lets you widen the set (e.g. so `codex` appears) or keep it tight without code changes.

Backend clippy `-D warnings` + fmt clean; both webs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)