### PR TITLE
feat(graphs): PR network graph as group → subgroup hierarchy

### DIFF
--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -2534,6 +2534,51 @@ async fn api_repo_domains_discover(
     }
 }
 
+/// GET /api/v1/repos/{slug}/pr-groups -- the PR subject hierarchy for the
+/// network graph: grand groupes (top subjects across ALL PRs) → sous-groupes
+/// (frequent secondary terms) → the PRs each groups. `?groups=N` overrides the
+/// number of grand groupes (defaults to the repo's Top-N discovery limit),
+/// `?subs=M` the subgroups per group (default 6). Deterministic and instant.
+async fn api_repo_pr_groups_get(
+    State(state): State<Arc<WebState>>,
+    axum::extract::Path(slug): axum::extract::Path<String>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> Response {
+    let repos = state.multi.repos.read().await;
+    let ds = match repos.get(&slug) {
+        Some(d) => d.clone(),
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": format!("repo '{slug}' not configured")})),
+            )
+                .into_response();
+        }
+    };
+    drop(repos);
+
+    let group_limit = params
+        .get("groups")
+        .and_then(|s| s.parse::<usize>().ok())
+        .map(|n| {
+            n.clamp(
+                crate::pipelines::discover_domains::MIN_DOMAINS_LIMIT,
+                crate::pipelines::discover_domains::MAX_DOMAINS_LIMIT,
+            )
+        })
+        .unwrap_or_else(|| crate::pipelines::discover_domains::resolve_limit(ds.db.as_ref()));
+    let sub_limit = params
+        .get("subs")
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(6)
+        .clamp(1, 12);
+
+    let groups =
+        crate::pipelines::pr_groups::build(&ds.config, ds.db.as_ref(), group_limit, sub_limit);
+    Json(json!({ "groups": groups, "groups_limit": group_limit, "subs_limit": sub_limit }))
+        .into_response()
+}
+
 /// GET /api/v1/config/retry -- read the live HTTP retry policy.
 async fn api_retry_get() -> Response {
     Json(crate::retry::global()).into_response()
@@ -3570,6 +3615,10 @@ pub fn oss_api_routes() -> Router<Arc<WebState>> {
         .route(
             "/api/v1/repos/{slug}/domains/discover",
             post(api_repo_domains_discover),
+        )
+        .route(
+            "/api/v1/repos/{slug}/pr-groups",
+            get(api_repo_pr_groups_get),
         )
         .route("/api/v1/auth/status", get(api_auth_status))
         .route(

--- a/src/pipelines/discover_domains.rs
+++ b/src/pipelines/discover_domains.rs
@@ -35,7 +35,7 @@ fn load_domains(db: &dyn DatabaseBackend) -> Vec<DomainDef> {
 /// "filters"/"filter" collapse into one domain. Strips a single trailing "s" on
 /// words of length >= 4 that don't end in "ss" (keeps "class"/"css"). Leaves
 /// non-plural tech tokens ("codex", "grep", "c#") untouched.
-fn singular(w: &str) -> String {
+pub(crate) fn singular(w: &str) -> String {
     if w.len() >= 4 && w.ends_with('s') && !w.ends_with("ss") {
         w[..w.len() - 1].to_string()
     } else {
@@ -43,7 +43,7 @@ fn singular(w: &str) -> String {
     }
 }
 
-fn top_terms(
+pub(crate) fn top_terms(
     pr_titles: &[String],
     issue_titles: &[String],
     extra_stop: &std::collections::HashSet<String>,
@@ -187,7 +187,7 @@ fn top_terms(
 /// Split a title into lowercased word tokens (keeping `#`/`+` so "c#"/"c++"
 /// survive). Shared by the ranker and the domain counter so both see terms the
 /// same way.
-fn title_words(title: &str) -> std::collections::HashSet<String> {
+pub(crate) fn title_words(title: &str) -> std::collections::HashSet<String> {
     title
         .split(|c: char| !c.is_alphanumeric() && c != '#' && c != '+')
         .map(|w| w.to_lowercase())

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -2,6 +2,7 @@ pub mod backup;
 pub mod context;
 pub mod discover_domains;
 pub mod migrate;
+pub mod pr_groups;
 pub mod revert;
 
 /// Truncate a string to `max` chars, appending "…" if truncated.

--- a/src/pipelines/pr_groups.rs
+++ b/src/pipelines/pr_groups.rs
@@ -1,0 +1,128 @@
+//! PR subject hierarchy for the network graph.
+//!
+//! Over ALL pull requests in the DB (open + closed), rank the "grand groupes" —
+//! the most frequent subjects across PR titles — and, within each group's PRs,
+//! rank the frequent secondary terms as "sous-groupes", each carrying the PRs
+//! it groups. Titles only, DB-wide, deterministic; same tokenisation as domain
+//! discovery (singularised, repo-name excluded), so groups line up with the
+//! discovered domains.
+
+use serde::Serialize;
+use std::collections::HashSet;
+
+use crate::config::Config;
+use crate::db::backend::DatabaseBackend;
+use crate::pipelines::discover_domains::{singular, title_words, top_terms};
+
+/// Effective "all PRs" cap (title-only, so cheap even in the tens of thousands).
+const CLOSED_CAP: usize = 100_000;
+/// Cap the PR list carried by each subgroup so the payload stays bounded on
+/// very large groups; the `count` is always the true total.
+const PR_CAP_PER_SUBGROUP: usize = 300;
+
+/// A pull request reference (enough for the graph's PR list on click).
+#[derive(Serialize)]
+pub struct PrRef {
+    pub number: u64,
+    pub title: String,
+}
+
+/// A secondary subject inside a grand groupe.
+#[derive(Serialize)]
+pub struct SubGroup {
+    pub name: String,
+    /// Distinct PRs in the parent group whose title mentions this term.
+    pub count: usize,
+    /// Up to `PR_CAP_PER_SUBGROUP` of those PRs.
+    pub prs: Vec<PrRef>,
+}
+
+/// A grand groupe (top-level subject) and its subgroups.
+#[derive(Serialize)]
+pub struct Group {
+    pub name: String,
+    /// Distinct PRs whose title mentions this subject.
+    pub count: usize,
+    pub subgroups: Vec<SubGroup>,
+}
+
+/// The repo's own owner/name — self-referential noise, excluded from ranking.
+fn repo_stop(config: &Config) -> HashSet<String> {
+    let mut s = HashSet::new();
+    for part in config.repo_slug().to_lowercase().split('/') {
+        if part.len() >= 2 {
+            s.insert(part.to_string());
+            s.insert(singular(part));
+        }
+    }
+    s
+}
+
+/// Build the group → subgroup → PRs hierarchy across every PR in the DB.
+/// `group_limit` = number of grand groupes, `sub_limit` = subgroups per group.
+pub fn build(
+    config: &Config,
+    db: &dyn DatabaseBackend,
+    group_limit: usize,
+    sub_limit: usize,
+) -> Vec<Group> {
+    // (number, title, singularised word-set) for every PR — open + all closed.
+    let mut prs: Vec<(u64, String, HashSet<String>)> = Vec::new();
+    for p in db.get_open_pulls().unwrap_or_default() {
+        let w = title_words(&p.title);
+        prs.push((p.number, p.title, w));
+    }
+    for p in db.get_closed_pulls(CLOSED_CAP).unwrap_or_default() {
+        let w = title_words(&p.title);
+        prs.push((p.number, p.title, w));
+    }
+
+    let all_titles: Vec<String> = prs.iter().map(|(_, t, _)| t.clone()).collect();
+    let stop = repo_stop(config);
+
+    // Grand groupes: the top subjects across all PR titles.
+    let group_terms = top_terms(&all_titles, &[], &stop, group_limit);
+
+    let mut groups = Vec::with_capacity(group_terms.len());
+    for (g, _) in group_terms {
+        let members: Vec<&(u64, String, HashSet<String>)> =
+            prs.iter().filter(|(_, _, w)| w.contains(&g)).collect();
+        let g_count = members.len();
+
+        // Sous-groupes: frequent secondary terms among this group's PRs,
+        // excluding the group term itself and the repo name.
+        let member_titles: Vec<String> = members.iter().map(|(_, t, _)| t.clone()).collect();
+        let mut sub_stop = stop.clone();
+        sub_stop.insert(g.clone());
+        let sub_terms = top_terms(&member_titles, &[], &sub_stop, sub_limit);
+
+        let mut subgroups = Vec::with_capacity(sub_terms.len());
+        for (s, _) in sub_terms {
+            let mut list = Vec::new();
+            let mut count = 0usize;
+            for (num, title, w) in members.iter().copied() {
+                if w.contains(&s) {
+                    count += 1;
+                    if list.len() < PR_CAP_PER_SUBGROUP {
+                        list.push(PrRef {
+                            number: *num,
+                            title: title.clone(),
+                        });
+                    }
+                }
+            }
+            subgroups.push(SubGroup {
+                name: s,
+                count,
+                prs: list,
+            });
+        }
+
+        groups.push(Group {
+            name: g,
+            count: g_count,
+            subgroups,
+        });
+    }
+    groups
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -586,6 +586,50 @@ export async function discoverRepoDomains(slug: string, limit?: number): Promise
 	return res.json();
 }
 
+/** A pull request referenced by a subgroup in the PR network graph. */
+export interface PrGroupPr {
+	number: number;
+	title: string;
+}
+/** A secondary subject inside a grand groupe. */
+export interface PrSubGroup {
+	name: string;
+	count: number;
+	prs: PrGroupPr[];
+}
+/** A grand groupe (top-level subject) and its subgroups. */
+export interface PrGroup {
+	name: string;
+	count: number;
+	subgroups: PrSubGroup[];
+}
+export interface PrGroupsResponse {
+	groups: PrGroup[];
+	groups_limit: number;
+	subs_limit: number;
+}
+
+/**
+ * PR subject hierarchy for the network graph, computed server-side across ALL
+ * PRs in the DB. `groups` overrides the number of grand groupes, `subs` the
+ * subgroups per group.
+ */
+export async function fetchPrGroups(
+	slug: string,
+	opts: { groups?: number; subs?: number } = {}
+): Promise<PrGroupsResponse> {
+	const qs = new URLSearchParams();
+	if (opts.groups != null) qs.set('groups', String(opts.groups));
+	if (opts.subs != null) qs.set('subs', String(opts.subs));
+	const q = qs.toString();
+	const res = await fetch(`/api/v1/repos/${encodeURIComponent(slug)}/pr-groups${q ? `?${q}` : ''}`);
+	if (!res.ok) {
+		const body = await res.json().catch(() => ({}));
+		throw new Error(body.error ?? `HTTP ${res.status}`);
+	}
+	return res.json();
+}
+
 /// HTTP retry policy, shared by every outbound call (poller, git
 /// providers, AI, self-update). Editable from Settings -> Reliability;
 /// changes apply live without a daemon restart.

--- a/web/src/lib/components/PrGroupGraph.svelte
+++ b/web/src/lib/components/PrGroupGraph.svelte
@@ -1,0 +1,287 @@
+<script lang="ts">
+	/**
+	 * Group → subgroup network graph. Each grand groupe is a large hub node
+	 * (radius ∝ number of PRs), each sous-groupe a medium satellite linked to its
+	 * parent (radius ∝ its PR count), coloured by group. Clicking a subgroup
+	 * surfaces its PRs via `onSelect`. Data is computed server-side across the
+	 * whole DB, so this reflects every PR, not a client sample.
+	 *
+	 * Dependency-free force sim (repulsion + link springs + collision + centering)
+	 * on a rAF loop. Node count is small (~groups × subs), so plain SVG is ample.
+	 */
+	import { onMount } from 'svelte';
+	import type { PrGroup, PrSubGroup } from '$lib/api';
+
+	let {
+		groups = [],
+		selectedId = null,
+		onSelect
+	}: {
+		groups: PrGroup[];
+		selectedId?: string | null;
+		onSelect?: (payload: { group: PrGroup; sub: PrSubGroup; id: string }) => void;
+	} = $props();
+
+	const W = 960;
+	const H = 640;
+
+	type Node = {
+		id: string;
+		kind: 'group' | 'sub';
+		name: string;
+		count: number;
+		r: number;
+		hue: number;
+		parent?: string;
+		group: PrGroup;
+		sub?: PrSubGroup;
+		x: number;
+		y: number;
+		vx: number;
+		vy: number;
+		fx: number | null;
+		fy: number | null;
+	};
+
+	let nodes = $state<Node[]>([]);
+	let links = $state<{ a: Node; b: Node }[]>([]);
+	let raf = 0;
+
+	function hueFor(s: string): number {
+		let h = 0;
+		for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) % 360;
+		return h;
+	}
+
+	// Rebuild whenever the incoming groups change.
+	let signature = $derived(groups.map((g) => `${g.name}:${g.count}:${g.subgroups.length}`).join('|'));
+	let builtFor = '';
+	$effect(() => {
+		if (signature !== builtFor) {
+			builtFor = signature;
+			build();
+		}
+	});
+
+	function build() {
+		const ns: Node[] = [];
+		const cx = W / 2;
+		const cy = H / 2;
+		const n = Math.max(1, groups.length);
+		groups.forEach((g, gi) => {
+			const hue = hueFor(g.name);
+			const ang = (gi / n) * Math.PI * 2;
+			const gx = cx + Math.cos(ang) * 210;
+			const gy = cy + Math.sin(ang) * 190;
+			const gid = `g:${g.name}`;
+			ns.push({
+				id: gid,
+				kind: 'group',
+				name: g.name,
+				count: g.count,
+				r: 18 + Math.sqrt(g.count) * 1.7,
+				hue,
+				group: g,
+				x: gx,
+				y: gy,
+				vx: 0,
+				vy: 0,
+				fx: null,
+				fy: null
+			});
+			const m = Math.max(1, g.subgroups.length);
+			g.subgroups.forEach((s, si) => {
+				const sa = ang + (si - (m - 1) / 2) * 0.5;
+				ns.push({
+					id: `${gid}/s:${s.name}`,
+					kind: 'sub',
+					name: s.name,
+					count: s.count,
+					r: 8 + Math.sqrt(s.count) * 1.25,
+					hue,
+					parent: gid,
+					group: g,
+					sub: s,
+					x: gx + Math.cos(sa) * 85,
+					y: gy + Math.sin(sa) * 85,
+					vx: 0,
+					vy: 0,
+					fx: null,
+					fy: null
+				});
+			});
+		});
+		nodes = ns;
+		const byId = new Map(ns.map((nd) => [nd.id, nd]));
+		links = ns
+			.filter((nd) => nd.parent)
+			.map((nd) => ({ a: byId.get(nd.parent!)!, b: nd }))
+			.filter((l) => l.a && l.b);
+		startSim();
+	}
+
+	function startSim() {
+		cancelAnimationFrame(raf);
+		let alpha = 1;
+		const tick = () => {
+			const arr = nodes;
+			// Repulsion + collision (O(n²), fine for a small node count).
+			for (let i = 0; i < arr.length; i++) {
+				const a = arr[i];
+				for (let j = i + 1; j < arr.length; j++) {
+					const b = arr[j];
+					let dx = a.x - b.x;
+					let dy = a.y - b.y;
+					let d2 = dx * dx + dy * dy || 0.01;
+					let d = Math.sqrt(d2);
+					const ux = dx / d;
+					const uy = dy / d;
+					const rep = ((a.r * b.r * 0.9) / d2) * 55 * alpha;
+					a.vx += ux * rep;
+					a.vy += uy * rep;
+					b.vx -= ux * rep;
+					b.vy -= uy * rep;
+					const min = a.r + b.r + 8;
+					if (d < min) {
+						const o = (min - d) * 0.5;
+						a.x += ux * o;
+						a.y += uy * o;
+						b.x -= ux * o;
+						b.y -= uy * o;
+					}
+				}
+			}
+			// Link springs pull subgroups to their parent.
+			for (const l of links) {
+				const a = l.a;
+				const b = l.b;
+				let dx = b.x - a.x;
+				let dy = b.y - a.y;
+				let d = Math.hypot(dx, dy) || 0.01;
+				const target = a.r + b.r + 26;
+				const f = (d - target) * 0.03 * alpha;
+				const ux = dx / d;
+				const uy = dy / d;
+				a.vx += ux * f;
+				a.vy += uy * f;
+				b.vx -= ux * f;
+				b.vy -= uy * f;
+			}
+			// Centering + integrate.
+			for (const nd of arr) {
+				if (nd.fx != null) {
+					nd.x = nd.fx;
+					nd.y = nd.fy!;
+					nd.vx = 0;
+					nd.vy = 0;
+					continue;
+				}
+				nd.vx += (W / 2 - nd.x) * 0.0011 * alpha;
+				nd.vy += (H / 2 - nd.y) * 0.0011 * alpha;
+				nd.vx *= 0.86;
+				nd.vy *= 0.86;
+				nd.x += nd.vx;
+				nd.y += nd.vy;
+				nd.x = Math.max(nd.r, Math.min(W - nd.r, nd.x));
+				nd.y = Math.max(nd.r, Math.min(H - nd.r, nd.y));
+			}
+			alpha *= 0.994;
+			if (alpha > 0.02) raf = requestAnimationFrame(tick);
+		};
+		raf = requestAnimationFrame(tick);
+	}
+
+	onMount(() => () => cancelAnimationFrame(raf));
+
+	// Drag.
+	let dragging: Node | null = null;
+	let svgEl: SVGSVGElement;
+	function toSvg(e: PointerEvent) {
+		const rect = svgEl.getBoundingClientRect();
+		return {
+			x: ((e.clientX - rect.left) / rect.width) * W,
+			y: ((e.clientY - rect.top) / rect.height) * H
+		};
+	}
+	function onDown(nd: Node, e: PointerEvent) {
+		dragging = nd;
+		const p = toSvg(e);
+		nd.fx = p.x;
+		nd.fy = p.y;
+		svgEl.setPointerCapture(e.pointerId);
+		startSim();
+	}
+	function onMove(e: PointerEvent) {
+		if (!dragging) return;
+		const p = toSvg(e);
+		dragging.fx = p.x;
+		dragging.fy = p.y;
+		dragging.x = p.x;
+		dragging.y = p.y;
+	}
+	function onUp() {
+		if (dragging) {
+			dragging.fx = null;
+			dragging.fy = null;
+			dragging = null;
+		}
+	}
+
+	function pick(nd: Node) {
+		if (nd.kind === 'sub' && nd.sub) onSelect?.({ group: nd.group, sub: nd.sub, id: nd.id });
+	}
+</script>
+
+<svg
+	bind:this={svgEl}
+	viewBox="0 0 {W} {H}"
+	class="w-full touch-none select-none rounded-lg border bg-card"
+	style="aspect-ratio: {W}/{H};"
+	onpointermove={onMove}
+	onpointerup={onUp}
+	onpointerleave={onUp}
+	role="presentation"
+>
+	{#each links as l}
+		<line
+			x1={l.a.x}
+			y1={l.a.y}
+			x2={l.b.x}
+			y2={l.b.y}
+			stroke="hsl({l.a.hue} 45% 55% / 0.35)"
+			stroke-width="1.5"
+		/>
+	{/each}
+	{#each nodes as nd (nd.id)}
+		<g
+			class="cursor-pointer"
+			onpointerdown={(e) => onDown(nd, e)}
+			onclick={() => pick(nd)}
+			onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && pick(nd)}
+			role="button"
+			tabindex="-1"
+		>
+			<circle
+				cx={nd.x}
+				cy={nd.y}
+				r={nd.r}
+				fill="hsl({nd.hue} {nd.kind === 'group' ? 60 : 55}% {nd.kind === 'group' ? 48 : 62}% / {nd.kind ===
+				'group'
+					? 0.9
+					: 0.8})"
+				stroke={selectedId === nd.id ? 'hsl(var(--foreground))' : 'white'}
+				stroke-width={selectedId === nd.id ? 3 : nd.kind === 'group' ? 2 : 1}
+			/>
+			<text
+				x={nd.x}
+				y={nd.y - nd.r - 3}
+				text-anchor="middle"
+				class="pointer-events-none fill-foreground font-medium"
+				style="font-size: {nd.kind === 'group' ? 13 : 10}px;"
+			>
+				{nd.name}
+				<tspan class="fill-muted-foreground">· {nd.count}</tspan>
+			</text>
+		</g>
+	{/each}
+</svg>

--- a/web/src/routes/graphs/+page.svelte
+++ b/web/src/routes/graphs/+page.svelte
@@ -1,17 +1,47 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { selectedRepo } from '$lib/stores';
-	import { fetchPulls, fetchIssues, type PullRequest, type Issue } from '$lib/api';
+	import { fetchIssues, type Issue } from '$lib/api';
 	import * as Tabs from '$lib/components/ui/tabs';
 	import * as Dialog from '$lib/components/ui/dialog';
-	import PrDetail from '$lib/components/PrDetail.svelte';
 	import IssueDetail from '$lib/components/IssueDetail.svelte';
 	import LabelGraphPanel from '$lib/components/LabelGraphPanel.svelte';
+	import PrGroupGraph from '$lib/components/PrGroupGraph.svelte';
+	import { fetchPrGroups, type PrGroup, type PrSubGroup } from '$lib/api';
 
-	let prs = $state<PullRequest[]>([]);
 	let issues = $state<Issue[]>([]);
-	let prLoading = $state(true);
 	let issueLoading = $state(true);
+
+	// Server-side PR subject hierarchy (grand groupes → sous-groupes) over the
+	// WHOLE DB — powers the PR network graph. Independent of the client PR sample.
+	let prGroups = $state<PrGroup[]>([]);
+	let groupsLoading = $state(true);
+	let groupsCount = $state(12);
+	let groupsError = $state<string | null>(null);
+	let selectedSub = $state<{ group: PrGroup; sub: PrSubGroup; id: string } | null>(null);
+
+	let groupToken = 0;
+	async function loadGroups(slug: string | null) {
+		if (!slug) {
+			prGroups = [];
+			groupsLoading = false;
+			return;
+		}
+		const mine = ++groupToken;
+		groupsLoading = true;
+		groupsError = null;
+		try {
+			const r = await fetchPrGroups(slug, { groups: groupsCount });
+			if (mine !== groupToken) return;
+			prGroups = r.groups;
+			groupsCount = r.groups_limit;
+			selectedSub = null;
+		} catch (e) {
+			if (mine === groupToken) groupsError = e instanceof Error ? e.message : 'failed to load groups';
+		} finally {
+			if (mine === groupToken) groupsLoading = false;
+		}
+	}
 
 	// Aggregate history — daily snapshots. The trend endpoints are a Pro
 	// feature; in OSS they 404, so we swallow errors and show "no history".
@@ -22,26 +52,8 @@
 	let token = 0;
 	async function loadAll() {
 		const mine = ++token;
-		prLoading = true;
 		issueLoading = true;
-		// PRs
-		try {
-			const all: PullRequest[] = [];
-			let offset = 0;
-			for (;;) {
-				const page = await fetchPulls({ limit: 250, offset });
-				if (mine !== token) return;
-				all.push(...page.items);
-				if (all.length >= page.total || page.items.length === 0 || all.length >= 2000) break;
-				offset += page.items.length;
-			}
-			prs = all;
-		} catch {
-			/* ignore */
-		} finally {
-			if (mine === token) prLoading = false;
-		}
-		// Issues
+		// Issues (the issue-graph tab still groups a client sample by label)
 		try {
 			const all: Issue[] = [];
 			let offset = 0;
@@ -74,13 +86,13 @@
 	}
 
 	onMount(() => {
-		loadAll();
-		const unsub = selectedRepo.subscribe(() => loadAll());
+		const unsub = selectedRepo.subscribe((slug) => {
+			loadAll();
+			loadGroups(slug);
+		});
 		return unsub;
 	});
 
-	let prModal = $state(false);
-	let activePr = $state<PullRequest | null>(null);
 	let issueModal = $state(false);
 	let activeIssue = $state<Issue | null>(null);
 
@@ -119,15 +131,74 @@
 	</Tabs.List>
 
 	<Tabs.Content value="pr">
-		<LabelGraphPanel
-			items={prs}
-			loading={prLoading}
-			emptyLabel="pull requests"
-			onSelect={(p) => {
-				activePr = p as unknown as PullRequest;
-				prModal = true;
-			}}
-		/>
+		<div class="mb-3 flex flex-wrap items-center gap-3">
+			<span class="text-xs font-medium text-muted-foreground">Grands groupes</span>
+			<input
+				type="range"
+				min="5"
+				max="30"
+				step="1"
+				bind:value={groupsCount}
+				onchange={() => loadGroups($selectedRepo)}
+				class="w-44 accent-primary"
+			/>
+			<span class="tabular-nums text-xs">{groupsCount}</span>
+			{#if groupsLoading}
+				<span class="text-xs text-muted-foreground">chargement…</span>
+			{/if}
+			<span class="text-xs text-muted-foreground"
+				>· sujets des PRs sur toute la base — clique un sous-groupe pour ses PRs</span
+			>
+		</div>
+		{#if groupsError}
+			<p class="text-sm text-destructive">{groupsError}</p>
+		{:else if !groupsLoading && prGroups.length === 0}
+			<p class="py-10 text-center text-sm text-muted-foreground">
+				Aucun groupe — pas encore de pull requests synchronisées pour ce dépôt.
+			</p>
+		{:else}
+			<div class="grid gap-4 lg:grid-cols-[1fr_320px]">
+				<PrGroupGraph
+					groups={prGroups}
+					selectedId={selectedSub?.id ?? null}
+					onSelect={(p) => (selectedSub = p)}
+				/>
+				<div class="rounded-lg border bg-card p-3">
+					{#if selectedSub}
+						<div class="mb-2">
+							<div class="text-sm font-semibold">
+								{selectedSub.group.name} → {selectedSub.sub.name}
+							</div>
+							<div class="text-xs text-muted-foreground">
+								{selectedSub.sub.count} PR{selectedSub.sub.count > 1 ? 's' : ''} dans « {selectedSub
+									.group.name} »
+							</div>
+						</div>
+						<div class="max-h-[560px] space-y-0.5 overflow-y-auto">
+							{#each selectedSub.sub.prs as pr}
+								<a
+									href="/prs/{pr.number}"
+									class="block rounded px-2 py-1 text-xs hover:bg-muted"
+								>
+									<span class="mono text-muted-foreground">#{pr.number}</span>
+									{pr.title}
+								</a>
+							{/each}
+							{#if selectedSub.sub.count > selectedSub.sub.prs.length}
+								<p class="px-2 pt-1 text-[0.7rem] text-muted-foreground">
+									+ {selectedSub.sub.count - selectedSub.sub.prs.length} de plus…
+								</p>
+							{/if}
+						</div>
+					{:else}
+						<p class="text-xs text-muted-foreground">
+							Clique un <strong>sous-groupe</strong> (petite bulle) dans le graphe pour lister ses pull
+							requests ici.
+						</p>
+					{/if}
+				</div>
+			</div>
+		{/if}
 	</Tabs.Content>
 
 	<Tabs.Content value="issue">
@@ -171,23 +242,6 @@
 		</div>
 	</Tabs.Content>
 </Tabs.Root>
-
-<Dialog.Root bind:open={prModal}>
-	<Dialog.Content class="sm:max-w-[80vw] max-h-[85vh] overflow-y-auto">
-		<Dialog.Header>
-			<Dialog.Title class="flex w-full items-center gap-3 pr-2 text-base font-semibold">
-				<span class="mono text-muted-foreground text-sm font-normal">#{activePr?.number}</span>
-				<span class="truncate">{activePr?.title}</span>
-			</Dialog.Title>
-		</Dialog.Header>
-		{#if activePr}
-			<PrDetail pr={activePr} />
-			<div class="text-right pt-2">
-				<a href="/prs/{activePr.number}" class="text-xs text-primary hover:underline">Open full page →</a>
-			</div>
-		{/if}
-	</Dialog.Content>
-</Dialog.Root>
 
 <Dialog.Root bind:open={issueModal}>
 	<Dialog.Content class="sm:max-w-[80vw] max-h-[85vh] overflow-y-auto">


### PR DESCRIPTION
Rebuilds the PR network graph around the **grands groupes de PRs calculés sur toute la BDD**, with **groupe → sous-groupe**, as requested.

**Backend** — `pipelines/pr_groups.rs` + `GET /repos/{slug}/pr-groups`: ranks grand groupes (top subjects over ALL PRs) and, within each group, frequent secondary terms as sous-groupes, each carrying its PRs (number+title, capped). Same singularised, repo-name-filtered tokenisation as domain discovery. `?groups=N` (defaults to Top-N limit), `?subs=M` (default 6).

**Frontend** — `PrGroupGraph.svelte`: force graph of grand-groupe (large) + sous-groupe (medium) bubbles, size ∝ PR count, colour by group; click a subgroup → side panel lists its PRs. The graphs PR tab now uses this server-driven view + a "grands groupes" slider (5–30), replacing the 2000-cap client label panel.

Backend clippy `-D warnings` + fmt clean; both webs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)