### PR TITLE
fix(graphs): PR group graph works with no repo selected

### DIFF
--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -2534,28 +2534,51 @@ async fn api_repo_domains_discover(
     }
 }
 
-/// GET /api/v1/repos/{slug}/pr-groups -- the PR subject hierarchy for the
-/// network graph: grand groupes (top subjects across ALL PRs) → sous-groupes
-/// (frequent secondary terms) → the PRs each groups. `?groups=N` overrides the
-/// number of grand groupes (defaults to the repo's Top-N discovery limit),
-/// `?subs=M` the subgroups per group (default 6). Deterministic and instant.
-async fn api_repo_pr_groups_get(
+/// GET /api/v1/pr-groups -- the PR subject hierarchy for the network graph:
+/// grand groupes (top subjects across PRs) → sous-groupes (frequent secondary
+/// terms) → the PRs each groups. Follows the list-endpoint convention: `?repo=`
+/// scopes to one repo, and when absent it aggregates PRs across ALL configured
+/// repos (so the graph works with no repo selected). `?groups=N` overrides the
+/// number of grand groupes (defaults to the Top-N discovery limit), `?subs=M`
+/// the subgroups per group (default 6). Deterministic and instant.
+async fn api_pr_groups_get(
     State(state): State<Arc<WebState>>,
-    axum::extract::Path(slug): axum::extract::Path<String>,
     axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
 ) -> Response {
-    let repos = state.multi.repos.read().await;
-    let ds = match repos.get(&slug) {
-        Some(d) => d.clone(),
-        None => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": format!("repo '{slug}' not configured")})),
-            )
-                .into_response();
-        }
+    let repo_filter = params.get("repo").filter(|s| !s.is_empty());
+
+    // Snapshot the matching repos, then gather (number, title) for their PRs and
+    // the owner/name tokens to exclude. One-repo when `?repo=` is set, else all.
+    let snapshot: Vec<(String, Arc<super::DaemonState>)> = {
+        let g = state.multi.repos.read().await;
+        g.iter()
+            .filter(|(slug, _)| repo_filter.map(|r| r == *slug).unwrap_or(true))
+            .map(|(s, d)| (s.clone(), Arc::clone(d)))
+            .collect()
     };
-    drop(repos);
+
+    let mut prs: Vec<(u64, String)> = Vec::new();
+    let mut name_stop: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut default_limit: Option<usize> = None;
+    for (slug, ds) in &snapshot {
+        for part in slug.to_lowercase().split('/') {
+            if part.len() >= 2 {
+                name_stop.insert(part.to_string());
+                name_stop.insert(crate::pipelines::discover_domains::singular(part));
+            }
+        }
+        if default_limit.is_none() {
+            default_limit = Some(crate::pipelines::discover_domains::resolve_limit(
+                ds.db.as_ref(),
+            ));
+        }
+        for p in ds.db.get_open_pulls().unwrap_or_default() {
+            prs.push((p.number, p.title));
+        }
+        for p in ds.db.get_closed_pulls(100_000).unwrap_or_default() {
+            prs.push((p.number, p.title));
+        }
+    }
 
     let group_limit = params
         .get("groups")
@@ -2566,15 +2589,15 @@ async fn api_repo_pr_groups_get(
                 crate::pipelines::discover_domains::MAX_DOMAINS_LIMIT,
             )
         })
-        .unwrap_or_else(|| crate::pipelines::discover_domains::resolve_limit(ds.db.as_ref()));
+        .or(default_limit)
+        .unwrap_or(crate::pipelines::discover_domains::DEFAULT_DOMAINS_LIMIT);
     let sub_limit = params
         .get("subs")
         .and_then(|s| s.parse::<usize>().ok())
         .unwrap_or(6)
         .clamp(1, 12);
 
-    let groups =
-        crate::pipelines::pr_groups::build(&ds.config, ds.db.as_ref(), group_limit, sub_limit);
+    let groups = crate::pipelines::pr_groups::build_from(&prs, &name_stop, group_limit, sub_limit);
     Json(json!({ "groups": groups, "groups_limit": group_limit, "subs_limit": sub_limit }))
         .into_response()
 }
@@ -3616,10 +3639,7 @@ pub fn oss_api_routes() -> Router<Arc<WebState>> {
             "/api/v1/repos/{slug}/domains/discover",
             post(api_repo_domains_discover),
         )
-        .route(
-            "/api/v1/repos/{slug}/pr-groups",
-            get(api_repo_pr_groups_get),
-        )
+        .route("/api/v1/pr-groups", get(api_pr_groups_get))
         .route("/api/v1/auth/status", get(api_auth_status))
         .route(
             "/api/v1/auth/github",

--- a/src/pipelines/pr_groups.rs
+++ b/src/pipelines/pr_groups.rs
@@ -1,26 +1,22 @@
 //! PR subject hierarchy for the network graph.
 //!
-//! Over ALL pull requests in the DB (open + closed), rank the "grand groupes" —
-//! the most frequent subjects across PR titles — and, within each group's PRs,
-//! rank the frequent secondary terms as "sous-groupes", each carrying the PRs
-//! it groups. Titles only, DB-wide, deterministic; same tokenisation as domain
-//! discovery (singularised, repo-name excluded), so groups line up with the
-//! discovered domains.
+//! Over a set of pull requests (open + closed, one repo or all), rank the
+//! "grand groupes" — the most frequent subjects across PR titles — and, within
+//! each group's PRs, rank the frequent secondary terms as "sous-groupes", each
+//! carrying the PRs it groups. Titles only, deterministic; same tokenisation as
+//! domain discovery (singularised, repo-name excluded), so groups line up with
+//! the discovered domains.
 
 use serde::Serialize;
 use std::collections::HashSet;
 
-use crate::config::Config;
-use crate::db::backend::DatabaseBackend;
-use crate::pipelines::discover_domains::{singular, title_words, top_terms};
+use crate::pipelines::discover_domains::{title_words, top_terms};
 
-/// Effective "all PRs" cap (title-only, so cheap even in the tens of thousands).
-const CLOSED_CAP: usize = 100_000;
 /// Cap the PR list carried by each subgroup so the payload stays bounded on
 /// very large groups; the `count` is always the true total.
-const PR_CAP_PER_SUBGROUP: usize = 300;
+const PR_CAP_PER_SUBGROUP: usize = 200;
 
-/// A pull request reference (enough for the graph's PR list on click).
+/// A pull request referenced by a subgroup.
 #[derive(Serialize)]
 pub struct PrRef {
     pub number: u64,
@@ -31,9 +27,7 @@ pub struct PrRef {
 #[derive(Serialize)]
 pub struct SubGroup {
     pub name: String,
-    /// Distinct PRs in the parent group whose title mentions this term.
     pub count: usize,
-    /// Up to `PR_CAP_PER_SUBGROUP` of those PRs.
     pub prs: Vec<PrRef>,
 }
 
@@ -41,65 +35,48 @@ pub struct SubGroup {
 #[derive(Serialize)]
 pub struct Group {
     pub name: String,
-    /// Distinct PRs whose title mentions this subject.
     pub count: usize,
     pub subgroups: Vec<SubGroup>,
 }
 
-/// The repo's own owner/name — self-referential noise, excluded from ranking.
-fn repo_stop(config: &Config) -> HashSet<String> {
-    let mut s = HashSet::new();
-    for part in config.repo_slug().to_lowercase().split('/') {
-        if part.len() >= 2 {
-            s.insert(part.to_string());
-            s.insert(singular(part));
-        }
-    }
-    s
-}
-
-/// Build the group → subgroup → PRs hierarchy across every PR in the DB.
-/// `group_limit` = number of grand groupes, `sub_limit` = subgroups per group.
-pub fn build(
-    config: &Config,
-    db: &dyn DatabaseBackend,
+/// Build the group → subgroup → PRs hierarchy from a PR set.
+///
+/// `prs` is (number, title) for every PR to consider; `name_stop` holds the
+/// repo owner/name tokens to exclude as self-referential noise. `group_limit` =
+/// number of grand groupes, `sub_limit` = subgroups per group.
+pub fn build_from(
+    prs: &[(u64, String)],
+    name_stop: &HashSet<String>,
     group_limit: usize,
     sub_limit: usize,
 ) -> Vec<Group> {
-    // (number, title, singularised word-set) for every PR — open + all closed.
-    let mut prs: Vec<(u64, String, HashSet<String>)> = Vec::new();
-    for p in db.get_open_pulls().unwrap_or_default() {
-        let w = title_words(&p.title);
-        prs.push((p.number, p.title, w));
-    }
-    for p in db.get_closed_pulls(CLOSED_CAP).unwrap_or_default() {
-        let w = title_words(&p.title);
-        prs.push((p.number, p.title, w));
-    }
-
-    let all_titles: Vec<String> = prs.iter().map(|(_, t, _)| t.clone()).collect();
-    let stop = repo_stop(config);
+    // (number, title, singularised word-set) per PR.
+    let items: Vec<(u64, String, HashSet<String>)> = prs
+        .iter()
+        .map(|(n, t)| (*n, t.clone(), title_words(t)))
+        .collect();
+    let all_titles: Vec<String> = items.iter().map(|(_, t, _)| t.clone()).collect();
 
     // Grand groupes: the top subjects across all PR titles.
-    let group_terms = top_terms(&all_titles, &[], &stop, group_limit);
+    let group_terms = top_terms(&all_titles, &[], name_stop, group_limit);
 
     let mut groups = Vec::with_capacity(group_terms.len());
     for (g, _) in group_terms {
         let members: Vec<&(u64, String, HashSet<String>)> =
-            prs.iter().filter(|(_, _, w)| w.contains(&g)).collect();
+            items.iter().filter(|(_, _, w)| w.contains(&g)).collect();
         let g_count = members.len();
 
         // Sous-groupes: frequent secondary terms among this group's PRs,
         // excluding the group term itself and the repo name.
         let member_titles: Vec<String> = members.iter().map(|(_, t, _)| t.clone()).collect();
-        let mut sub_stop = stop.clone();
+        let mut sub_stop = name_stop.clone();
         sub_stop.insert(g.clone());
         let sub_terms = top_terms(&member_titles, &[], &sub_stop, sub_limit);
 
         let mut subgroups = Vec::with_capacity(sub_terms.len());
         for (s, _) in sub_terms {
-            let mut list = Vec::new();
             let mut count = 0usize;
+            let mut list: Vec<PrRef> = Vec::new();
             for (num, title, w) in members.iter().copied() {
                 if w.contains(&s) {
                     count += 1;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -615,14 +615,14 @@ export interface PrGroupsResponse {
  * subgroups per group.
  */
 export async function fetchPrGroups(
-	slug: string,
-	opts: { groups?: number; subs?: number } = {}
+	opts: { repo?: string | null; groups?: number; subs?: number } = {}
 ): Promise<PrGroupsResponse> {
 	const qs = new URLSearchParams();
+	if (opts.repo) qs.set('repo', opts.repo);
 	if (opts.groups != null) qs.set('groups', String(opts.groups));
 	if (opts.subs != null) qs.set('subs', String(opts.subs));
 	const q = qs.toString();
-	const res = await fetch(`/api/v1/repos/${encodeURIComponent(slug)}/pr-groups${q ? `?${q}` : ''}`);
+	const res = await fetch(`/api/v1/pr-groups${q ? `?${q}` : ''}`);
 	if (!res.ok) {
 		const body = await res.json().catch(() => ({}));
 		throw new Error(body.error ?? `HTTP ${res.status}`);

--- a/web/src/routes/graphs/+page.svelte
+++ b/web/src/routes/graphs/+page.svelte
@@ -22,16 +22,13 @@
 
 	let groupToken = 0;
 	async function loadGroups(slug: string | null) {
-		if (!slug) {
-			prGroups = [];
-			groupsLoading = false;
-			return;
-		}
 		const mine = ++groupToken;
 		groupsLoading = true;
 		groupsError = null;
 		try {
-			const r = await fetchPrGroups(slug, { groups: groupsCount });
+			// No repo selected → the endpoint aggregates across all repos, so the
+			// graph still works "de base" (same convention as the other lists).
+			const r = await fetchPrGroups({ repo: slug ?? undefined, groups: groupsCount });
 			if (mine !== groupToken) return;
 			prGroups = r.groups;
 			groupsCount = r.groups_limit;


### PR DESCRIPTION
The PR network graph was empty **de base**: its endpoint required the repo in the path, so with no repo selected the client bailed and rendered nothing — while the issue graph still worked (list endpoints aggregate across repos when `?repo=` is absent). That is why "les issues ont des grands groupes mais pas les PRs".

Fix: `GET /api/v1/pr-groups?repo=` (optional) — aggregates across all repos when omitted (excluding each repo name), scopes to one when set. `pr_groups` gains a repo-agnostic `build_from`. Frontend `fetchPrGroups({repo?,groups?,subs?})`; graphs page loads even when `selectedRepo` is null.

clippy `-D warnings` + fmt clean; both webs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)