### PR TITLE
fix(graphs): PR group graph layout (subgroups hug parent)

### DIFF
--- a/web/src/lib/components/PrGroupGraph.svelte
+++ b/web/src/lib/components/PrGroupGraph.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 	/**
 	 * Group → subgroup network graph. Each grand groupe is a large hub node
-	 * (radius ∝ number of PRs), each sous-groupe a medium satellite linked to its
-	 * parent (radius ∝ its PR count), coloured by group. Clicking a subgroup
+	 * (radius ∝ number of PRs); each sous-groupe is a medium satellite that hugs
+	 * its parent (radius ∝ its PR count), coloured by group. Clicking a subgroup
 	 * surfaces its PRs via `onSelect`. Data is computed server-side across the
 	 * whole DB, so this reflects every PR, not a client sample.
 	 *
-	 * Dependency-free force sim (repulsion + link springs + collision + centering)
-	 * on a rAF loop. Node count is small (~groups × subs), so plain SVG is ample.
+	 * Dependency-free force sim: a STRONG spring pins each subgroup near its
+	 * parent, groups repel each other to spread out, and a collision pass keeps
+	 * bubbles from overlapping. Small node count → plain reactive SVG is ample.
 	 */
 	import { onMount } from 'svelte';
 	import type { PrGroup, PrSubGroup } from '$lib/api';
@@ -19,7 +20,7 @@
 	}: {
 		groups: PrGroup[];
 		selectedId?: string | null;
-		onSelect?: (payload: { group: PrGroup; sub: PrSubGroup; id: string }) => void;
+		onSelect?: (group: PrGroup, sub: PrSubGroup) => void;
 	} = $props();
 
 	const W = 960;
@@ -32,9 +33,9 @@
 		count: number;
 		r: number;
 		hue: number;
-		parent?: string;
+		parent: string | null;
 		group: PrGroup;
-		sub?: PrSubGroup;
+		sub: PrSubGroup | null;
 		x: number;
 		y: number;
 		vx: number;
@@ -44,7 +45,9 @@
 	};
 
 	let nodes = $state<Node[]>([]);
-	let links = $state<{ a: Node; b: Node }[]>([]);
+	// Links are index pairs into `nodes`, resolved in the template so the lines
+	// track the reactive node positions as the sim moves them.
+	let links = $state<{ a: number; b: number }[]>([]);
 	let raf = 0;
 
 	function hueFor(s: string): number {
@@ -53,8 +56,13 @@
 		return h;
 	}
 
+	const groupR = (count: number) => 18 + Math.sqrt(count) * 1.7;
+	const subR = (count: number) => 8 + Math.sqrt(count) * 1.2;
+
 	// Rebuild whenever the incoming groups change.
-	let signature = $derived(groups.map((g) => `${g.name}:${g.count}:${g.subgroups.length}`).join('|'));
+	let signature = $derived(
+		groups.map((g) => `${g.name}:${g.count}:${g.subgroups.map((s) => s.name).join(',')}`).join('|')
+	);
 	let builtFor = '';
 	$effect(() => {
 		if (signature !== builtFor) {
@@ -65,23 +73,29 @@
 
 	function build() {
 		const ns: Node[] = [];
+		const idx = new Map<string, number>();
 		const cx = W / 2;
 		const cy = H / 2;
-		const n = Math.max(1, groups.length);
+		const gN = Math.max(1, groups.length);
+		const ringR = Math.min(W, H) * 0.32;
+
 		groups.forEach((g, gi) => {
 			const hue = hueFor(g.name);
-			const ang = (gi / n) * Math.PI * 2;
-			const gx = cx + Math.cos(ang) * 210;
-			const gy = cy + Math.sin(ang) * 190;
+			const ang = (gi / gN) * Math.PI * 2 - Math.PI / 2;
+			const gx = cx + Math.cos(ang) * ringR;
+			const gy = cy + Math.sin(ang) * ringR;
 			const gid = `g:${g.name}`;
+			idx.set(gid, ns.length);
 			ns.push({
 				id: gid,
 				kind: 'group',
 				name: g.name,
 				count: g.count,
-				r: 18 + Math.sqrt(g.count) * 1.7,
+				r: groupR(g.count),
 				hue,
+				parent: null,
 				group: g,
+				sub: null,
 				x: gx,
 				y: gy,
 				vx: 0,
@@ -91,19 +105,21 @@
 			});
 			const m = Math.max(1, g.subgroups.length);
 			g.subgroups.forEach((s, si) => {
-				const sa = ang + (si - (m - 1) / 2) * 0.5;
+				const sa = ang + (si - (m - 1) / 2) * 0.7;
+				const gr = groupR(g.count);
+				idx.set(`${gid}/s:${s.name}`, ns.length);
 				ns.push({
 					id: `${gid}/s:${s.name}`,
 					kind: 'sub',
 					name: s.name,
 					count: s.count,
-					r: 8 + Math.sqrt(s.count) * 1.25,
+					r: subR(s.count),
 					hue,
 					parent: gid,
 					group: g,
 					sub: s,
-					x: gx + Math.cos(sa) * 85,
-					y: gy + Math.sin(sa) * 85,
+					x: gx + Math.cos(sa) * (gr + 34),
+					y: gy + Math.sin(sa) * (gr + 34),
 					vx: 0,
 					vy: 0,
 					fx: null,
@@ -111,12 +127,11 @@
 				});
 			});
 		});
+
 		nodes = ns;
-		const byId = new Map(ns.map((nd) => [nd.id, nd]));
 		links = ns
-			.filter((nd) => nd.parent)
-			.map((nd) => ({ a: byId.get(nd.parent!)!, b: nd }))
-			.filter((l) => l.a && l.b);
+			.map((nd, i) => (nd.parent ? { a: idx.get(nd.parent)!, b: i } : null))
+			.filter((l): l is { a: number; b: number } => !!l && l.a != null);
 		startSim();
 	}
 
@@ -125,7 +140,27 @@
 		let alpha = 1;
 		const tick = () => {
 			const arr = nodes;
-			// Repulsion + collision (O(n²), fine for a small node count).
+
+			// 1) Strong spring: each subgroup is pulled to hug its parent group.
+			for (const l of links) {
+				const a = arr[l.a];
+				const b = arr[l.b];
+				let dx = b.x - a.x;
+				let dy = b.y - a.y;
+				let d = Math.hypot(dx, dy) || 0.01;
+				const target = a.r + b.r + 14;
+				const f = ((d - target) / d) * 0.12 * alpha;
+				const fx = dx * f;
+				const fy = dy * f;
+				// Groups are heavy: nudge them little, move subgroups more.
+				a.vx += fx * 0.25;
+				a.vy += fy * 0.25;
+				b.vx -= fx * 1.0;
+				b.vy -= fy * 1.0;
+			}
+
+			// 2) Repulsion: groups spread from each other; siblings fan out. Kept
+			//    short-range and gentle so nothing is flung to the walls.
 			for (let i = 0; i < arr.length; i++) {
 				const a = arr[i];
 				for (let j = i + 1; j < arr.length; j++) {
@@ -136,67 +171,63 @@
 					let d = Math.sqrt(d2);
 					const ux = dx / d;
 					const uy = dy / d;
-					const rep = ((a.r * b.r * 0.9) / d2) * 55 * alpha;
-					a.vx += ux * rep;
-					a.vy += uy * rep;
-					b.vx -= ux * rep;
-					b.vy -= uy * rep;
-					const min = a.r + b.r + 8;
+
+					// Long-range charge only between the big group hubs.
+					if (a.kind === 'group' && b.kind === 'group') {
+						const rep = ((a.r * b.r) / d2) * 40 * alpha;
+						a.vx += ux * rep;
+						a.vy += uy * rep;
+						b.vx -= ux * rep;
+						b.vy -= uy * rep;
+					}
+
+					// Collision: never let two bubbles overlap.
+					const min = a.r + b.r + 4;
 					if (d < min) {
-						const o = (min - d) * 0.5;
-						a.x += ux * o;
-						a.y += uy * o;
-						b.x -= ux * o;
-						b.y -= uy * o;
+						const push = (min - d) * 0.5;
+						a.x += ux * push;
+						a.y += uy * push;
+						b.x -= ux * push;
+						b.y -= uy * push;
 					}
 				}
 			}
-			// Link springs pull subgroups to their parent.
-			for (const l of links) {
-				const a = l.a;
-				const b = l.b;
-				let dx = b.x - a.x;
-				let dy = b.y - a.y;
-				let d = Math.hypot(dx, dy) || 0.01;
-				const target = a.r + b.r + 26;
-				const f = (d - target) * 0.03 * alpha;
-				const ux = dx / d;
-				const uy = dy / d;
-				a.vx += ux * f;
-				a.vy += uy * f;
-				b.vx -= ux * f;
-				b.vy -= uy * f;
-			}
-			// Centering + integrate.
+
+			// 3) Gentle centering + integrate.
 			for (const nd of arr) {
-				if (nd.fx != null) {
+				if (nd.fx != null && nd.fy != null) {
 					nd.x = nd.fx;
-					nd.y = nd.fy!;
+					nd.y = nd.fy;
 					nd.vx = 0;
 					nd.vy = 0;
 					continue;
 				}
-				nd.vx += (W / 2 - nd.x) * 0.0011 * alpha;
-				nd.vy += (H / 2 - nd.y) * 0.0011 * alpha;
-				nd.vx *= 0.86;
-				nd.vy *= 0.86;
+				if (nd.kind === 'group') {
+					nd.vx += (W / 2 - nd.x) * 0.004 * alpha;
+					nd.vy += (H / 2 - nd.y) * 0.004 * alpha;
+				}
+				nd.vx *= 0.8;
+				nd.vy *= 0.8;
 				nd.x += nd.vx;
 				nd.y += nd.vy;
 				nd.x = Math.max(nd.r, Math.min(W - nd.r, nd.x));
 				nd.y = Math.max(nd.r, Math.min(H - nd.r, nd.y));
 			}
-			alpha *= 0.994;
-			if (alpha > 0.02) raf = requestAnimationFrame(tick);
+
+			alpha *= 0.99;
+			if (alpha > 0.015) raf = requestAnimationFrame(tick);
 		};
 		raf = requestAnimationFrame(tick);
 	}
 
 	onMount(() => () => cancelAnimationFrame(raf));
 
-	// Drag.
-	let dragging: Node | null = null;
-	let svgEl: SVGSVGElement;
-	function toSvg(e: PointerEvent) {
+	// --- drag ---
+	let dragId: string | null = null;
+	let svgEl: SVGSVGElement | null = null;
+
+	function toSvg(e: PointerEvent): { x: number; y: number } {
+		if (!svgEl) return { x: 0, y: 0 };
 		const rect = svgEl.getBoundingClientRect();
 		return {
 			x: ((e.clientX - rect.left) / rect.width) * W,
@@ -204,84 +235,94 @@
 		};
 	}
 	function onDown(nd: Node, e: PointerEvent) {
-		dragging = nd;
+		dragId = nd.id;
 		const p = toSvg(e);
 		nd.fx = p.x;
 		nd.fy = p.y;
-		svgEl.setPointerCapture(e.pointerId);
+		(e.target as Element).setPointerCapture?.(e.pointerId);
 		startSim();
 	}
 	function onMove(e: PointerEvent) {
-		if (!dragging) return;
+		if (!dragId) return;
+		const nd = nodes.find((n) => n.id === dragId);
+		if (!nd) return;
 		const p = toSvg(e);
-		dragging.fx = p.x;
-		dragging.fy = p.y;
-		dragging.x = p.x;
-		dragging.y = p.y;
+		nd.fx = p.x;
+		nd.fy = p.y;
+		nd.x = p.x;
+		nd.y = p.y;
 	}
 	function onUp() {
-		if (dragging) {
-			dragging.fx = null;
-			dragging.fy = null;
-			dragging = null;
+		if (!dragId) return;
+		const nd = nodes.find((n) => n.id === dragId);
+		if (nd) {
+			nd.fx = null;
+			nd.fy = null;
 		}
+		dragId = null;
 	}
 
 	function pick(nd: Node) {
-		if (nd.kind === 'sub' && nd.sub) onSelect?.({ group: nd.group, sub: nd.sub, id: nd.id });
+		if (nd.kind === 'sub' && nd.sub) onSelect?.(nd.group, nd.sub);
 	}
 </script>
 
-<svg
-	bind:this={svgEl}
-	viewBox="0 0 {W} {H}"
-	class="w-full touch-none select-none rounded-lg border bg-card"
-	style="aspect-ratio: {W}/{H};"
-	onpointermove={onMove}
-	onpointerup={onUp}
-	onpointerleave={onUp}
-	role="presentation"
->
-	{#each links as l}
-		<line
-			x1={l.a.x}
-			y1={l.a.y}
-			x2={l.b.x}
-			y2={l.b.y}
-			stroke="hsl({l.a.hue} 45% 55% / 0.35)"
-			stroke-width="1.5"
-		/>
-	{/each}
-	{#each nodes as nd (nd.id)}
-		<g
-			class="cursor-pointer"
-			onpointerdown={(e) => onDown(nd, e)}
-			onclick={() => pick(nd)}
-			onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && pick(nd)}
-			role="button"
-			tabindex="-1"
-		>
-			<circle
-				cx={nd.x}
-				cy={nd.y}
-				r={nd.r}
-				fill="hsl({nd.hue} {nd.kind === 'group' ? 60 : 55}% {nd.kind === 'group' ? 48 : 62}% / {nd.kind ===
-				'group'
-					? 0.9
-					: 0.8})"
-				stroke={selectedId === nd.id ? 'hsl(var(--foreground))' : 'white'}
-				stroke-width={selectedId === nd.id ? 3 : nd.kind === 'group' ? 2 : 1}
+{#if nodes.length === 0}
+	<div
+		class="flex h-64 items-center justify-center rounded-lg border bg-card text-sm text-muted-foreground"
+	>
+		Aucun groupe à afficher.
+	</div>
+{:else}
+	<svg
+		bind:this={svgEl}
+		viewBox="0 0 {W} {H}"
+		class="w-full touch-none select-none rounded-lg border bg-card"
+		onpointermove={onMove}
+		onpointerup={onUp}
+		onpointerleave={onUp}
+		role="presentation"
+	>
+		{#each links as l (l.a + '-' + l.b)}
+			<line
+				x1={nodes[l.a].x}
+				y1={nodes[l.a].y}
+				x2={nodes[l.b].x}
+				y2={nodes[l.b].y}
+				stroke="hsl({nodes[l.a].hue} 45% 55% / 0.4)"
+				stroke-width="1.5"
 			/>
-			<text
-				x={nd.x}
-				y={nd.y - nd.r - 3}
-				text-anchor="middle"
-				class="pointer-events-none fill-foreground font-medium"
-				style="font-size: {nd.kind === 'group' ? 13 : 10}px;"
+		{/each}
+		{#each nodes as nd (nd.id)}
+			<g
+				class="cursor-pointer"
+				onpointerdown={(e) => onDown(nd, e)}
+				onclick={() => pick(nd)}
+				onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && pick(nd)}
+				role="button"
+				tabindex="-1"
 			>
-				{nd.name}
-				<tspan class="fill-muted-foreground">· {nd.count}</tspan>
-			</text>
-		</g>
-	{/each}
-</svg>
+				<circle
+					cx={nd.x}
+					cy={nd.y}
+					r={nd.r}
+					fill="hsl({nd.hue} {nd.kind === 'group' ? 60 : 52}% {nd.kind === 'group'
+						? 52
+						: 62}% / {nd.kind === 'group' ? 0.9 : 0.85})"
+					stroke={selectedId === nd.id ? 'white' : `hsl(${nd.hue} 55% 40%)`}
+					stroke-width={selectedId === nd.id ? 3 : nd.kind === 'group' ? 2 : 1}
+				/>
+				<text
+					x={nd.x}
+					y={nd.kind === 'group' ? nd.y - nd.r - 4 : nd.y + nd.r + 10}
+					text-anchor="middle"
+					class="pointer-events-none fill-foreground font-medium"
+					font-size={nd.kind === 'group' ? 13 : 10}
+				>
+					{nd.name}
+					<tspan class="fill-muted-foreground">· {nd.count}</tspan>
+				</text>
+			</g>
+		{/each}
+	</svg>
+{/if}


### PR DESCRIPTION
The PR group graph was dysfunctional: the force sim flung **subgroups to the canvas edges** and connectors did not follow (`links` held raw pre-proxy node refs, not the reactive `$state` nodes). Verified visually with agent-browser.

Retuned physics: strong parent-spring so each subgroup hugs its group, group-only repulsion to spread the hubs, a collision pass, and links bound to the reactive nodes. Re-verified in a real browser: subgroups cluster around their parent and clicking one fires onSelect (→ PR list).

Both webs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)