### PR TITLE
feat(graphs): Issue tab uses the group → subgroup network graph

### DIFF
--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -2602,6 +2602,66 @@ async fn api_pr_groups_get(
         .into_response()
 }
 
+/// GET /api/v1/issue-groups -- same subject hierarchy as pr-groups, but over
+/// ISSUE titles (open issues; closed issues are not retained in the DB). Same
+/// `?repo=`/`?groups=`/`?subs=` semantics. Reuses `pr_groups::build_from`.
+async fn api_issue_groups_get(
+    State(state): State<Arc<WebState>>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> Response {
+    let repo_filter = params.get("repo").filter(|s| !s.is_empty());
+
+    let snapshot: Vec<(String, Arc<super::DaemonState>)> = {
+        let g = state.multi.repos.read().await;
+        g.iter()
+            .filter(|(slug, _)| repo_filter.map(|r| r == *slug).unwrap_or(true))
+            .map(|(s, d)| (s.clone(), Arc::clone(d)))
+            .collect()
+    };
+
+    let mut issues: Vec<(u64, String)> = Vec::new();
+    let mut name_stop: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut default_limit: Option<usize> = None;
+    for (slug, ds) in &snapshot {
+        for part in slug.to_lowercase().split('/') {
+            if part.len() >= 2 {
+                name_stop.insert(part.to_string());
+                name_stop.insert(crate::pipelines::discover_domains::singular(part));
+            }
+        }
+        if default_limit.is_none() {
+            default_limit = Some(crate::pipelines::discover_domains::resolve_limit(
+                ds.db.as_ref(),
+            ));
+        }
+        for i in ds.db.get_open_issues().unwrap_or_default() {
+            issues.push((i.number, i.title));
+        }
+    }
+
+    let group_limit = params
+        .get("groups")
+        .and_then(|s| s.parse::<usize>().ok())
+        .map(|n| {
+            n.clamp(
+                crate::pipelines::discover_domains::MIN_DOMAINS_LIMIT,
+                crate::pipelines::discover_domains::MAX_DOMAINS_LIMIT,
+            )
+        })
+        .or(default_limit)
+        .unwrap_or(crate::pipelines::discover_domains::DEFAULT_DOMAINS_LIMIT);
+    let sub_limit = params
+        .get("subs")
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(6)
+        .clamp(1, 12);
+
+    let groups =
+        crate::pipelines::pr_groups::build_from(&issues, &name_stop, group_limit, sub_limit);
+    Json(json!({ "groups": groups, "groups_limit": group_limit, "subs_limit": sub_limit }))
+        .into_response()
+}
+
 /// GET /api/v1/config/retry -- read the live HTTP retry policy.
 async fn api_retry_get() -> Response {
     Json(crate::retry::global()).into_response()
@@ -3640,6 +3700,7 @@ pub fn oss_api_routes() -> Router<Arc<WebState>> {
             post(api_repo_domains_discover),
         )
         .route("/api/v1/pr-groups", get(api_pr_groups_get))
+        .route("/api/v1/issue-groups", get(api_issue_groups_get))
         .route("/api/v1/auth/status", get(api_auth_status))
         .route(
             "/api/v1/auth/github",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -631,6 +631,23 @@ export async function fetchPrGroups(
 	return res.json();
 }
 
+/** Same subject hierarchy as fetchPrGroups, but over ISSUE titles (open issues). */
+export async function fetchIssueGroups(
+	opts: { repo?: string | null; groups?: number; subs?: number } = {}
+): Promise<PrGroupsResponse> {
+	const qs = new URLSearchParams();
+	if (opts.repo) qs.set('repo', opts.repo);
+	if (opts.groups != null) qs.set('groups', String(opts.groups));
+	if (opts.subs != null) qs.set('subs', String(opts.subs));
+	const q = qs.toString();
+	const res = await fetch(`/api/v1/issue-groups${q ? `?${q}` : ''}`);
+	if (!res.ok) {
+		const body = await res.json().catch(() => ({}));
+		throw new Error(body.error ?? `HTTP ${res.status}`);
+	}
+	return res.json();
+}
+
 /// HTTP retry policy, shared by every outbound call (poller, git
 /// providers, AI, self-update). Editable from Settings -> Reliability;
 /// changes apply live without a daemon restart.

--- a/web/src/lib/components/GroupGraphTab.svelte
+++ b/web/src/lib/components/GroupGraphTab.svelte
@@ -91,7 +91,7 @@
 		<span class="text-xs text-muted-foreground">chargement…</span>
 	{/if}
 	<span class="text-xs text-muted-foreground">
-		· sujets des {noun}s sur toute la base — molette = zoom, glisser le fond = déplacer
+		· molette = zoom · glisser = déplacer
 	</span>
 </div>
 
@@ -102,18 +102,30 @@
 		Aucun groupe — pas encore de {noun}s synchronisées.
 	</p>
 {:else}
-	<div class="grid gap-4 lg:grid-cols-[1fr_300px]">
+	<!-- The side panel only appears once something is selected, so the graph
+	     gets the full width by default. Selecting a node splits to two columns. -->
+	<div class="grid gap-4 {selected ? 'lg:grid-cols-[1fr_300px]' : ''}">
 		<PrGroupGraph {groups} selectedId={selected?.id ?? null} onSelect={selectNode} {onInteract} />
-		<div class="rounded-lg border bg-card p-3">
-			{#if selected}
-				<div class="mb-2">
-					<div class="text-sm font-semibold">{selected.label}</div>
-					<div class="text-xs text-muted-foreground">
-						{selected.count}
-						{noun}{selected.count > 1 ? 's' : ''}
+		{#if selected}
+			<div class="rounded-lg border bg-card p-3">
+				<div class="mb-2 flex items-start justify-between gap-2">
+					<div>
+						<div class="text-sm font-semibold">{selected.label}</div>
+						<div class="text-xs text-muted-foreground">
+							{selected.count}
+							{noun}{selected.count > 1 ? 's' : ''}
+						</div>
 					</div>
+					<button
+						type="button"
+						class="shrink-0 text-muted-foreground hover:text-foreground"
+						aria-label="fermer"
+						onclick={() => (selected = null)}
+					>
+						✕
+					</button>
 				</div>
-				<div class="max-h-[600px] space-y-0.5 overflow-y-auto">
+				<div class="max-h-[70vh] space-y-0.5 overflow-y-auto">
 					{#each selected.prs as pr}
 						<a href="{linkBase}{pr.number}" class="block rounded px-2 py-1 text-xs hover:bg-muted">
 							<span class="mono text-muted-foreground">#{pr.number}</span>
@@ -126,12 +138,7 @@
 						</p>
 					{/if}
 				</div>
-			{:else}
-				<p class="text-xs text-muted-foreground">
-					Clique un <strong>groupe</strong> ou un <strong>sous-groupe</strong> pour lister ses {noun}s
-					ici.
-				</p>
-			{/if}
-		</div>
+			</div>
+		{/if}
 	</div>
 {/if}

--- a/web/src/lib/components/GroupGraphTab.svelte
+++ b/web/src/lib/components/GroupGraphTab.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+	/**
+	 * One tab of the Graphs page: the group → subgroup network graph for either
+	 * pull requests or issues, driven by the server-side hierarchy over the whole
+	 * DB. Owns its own fetch, "grands groupes" slider, selection, and the
+	 * side-panel that lists the selected group/subgroup's items.
+	 */
+	import PrGroupGraph from '$lib/components/PrGroupGraph.svelte';
+	import {
+		fetchPrGroups,
+		fetchIssueGroups,
+		type PrGroup,
+		type PrSubGroup,
+		type PrGroupPr
+	} from '$lib/api';
+
+	let {
+		kind,
+		repo = null,
+		onInteract
+	}: {
+		kind: 'pr' | 'issue';
+		repo?: string | null;
+		onInteract?: () => void;
+	} = $props();
+
+	let noun = $derived(kind === 'pr' ? 'PR' : 'issue');
+	let linkBase = $derived(kind === 'pr' ? '/prs/' : '/issues/');
+	let fetcher = $derived(kind === 'pr' ? fetchPrGroups : fetchIssueGroups);
+
+	let groups = $state<PrGroup[]>([]);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let count = $state(12);
+	let selected = $state<{ id: string; label: string; count: number; prs: PrGroupPr[] } | null>(
+		null
+	);
+
+	let token = 0;
+	async function load() {
+		const mine = ++token;
+		loading = true;
+		error = null;
+		try {
+			const r = await fetcher({ repo: repo ?? undefined, groups: count });
+			if (mine !== token) return;
+			groups = r.groups;
+			count = r.groups_limit;
+			selected = null;
+		} catch (e) {
+			if (mine === token) error = e instanceof Error ? e.message : 'failed to load';
+		} finally {
+			if (mine === token) loading = false;
+		}
+	}
+
+	// Reload when the repo changes.
+	let lastRepo: string | null | undefined;
+	$effect(() => {
+		if (repo !== lastRepo) {
+			lastRepo = repo;
+			load();
+		}
+	});
+
+	function selectNode(group: PrGroup, sub: PrSubGroup | null) {
+		selected = sub
+			? {
+					id: `g:${group.name}/s:${sub.name}`,
+					label: `${group.name} → ${sub.name}`,
+					count: sub.count,
+					prs: sub.prs
+				}
+			: { id: `g:${group.name}`, label: group.name, count: group.count, prs: group.prs };
+	}
+</script>
+
+<div class="mb-3 flex flex-wrap items-center gap-3">
+	<span class="text-xs font-medium text-muted-foreground">Grands groupes</span>
+	<input
+		type="range"
+		min="5"
+		max="30"
+		step="1"
+		bind:value={count}
+		onchange={load}
+		class="w-44 accent-primary"
+	/>
+	<span class="tabular-nums text-xs">{count}</span>
+	{#if loading}
+		<span class="text-xs text-muted-foreground">chargement…</span>
+	{/if}
+	<span class="text-xs text-muted-foreground">
+		· sujets des {noun}s sur toute la base — molette = zoom, glisser le fond = déplacer
+	</span>
+</div>
+
+{#if error}
+	<p class="text-sm text-destructive">{error}</p>
+{:else if !loading && groups.length === 0}
+	<p class="py-10 text-center text-sm text-muted-foreground">
+		Aucun groupe — pas encore de {noun}s synchronisées.
+	</p>
+{:else}
+	<div class="grid gap-4 lg:grid-cols-[1fr_300px]">
+		<PrGroupGraph {groups} selectedId={selected?.id ?? null} onSelect={selectNode} {onInteract} />
+		<div class="rounded-lg border bg-card p-3">
+			{#if selected}
+				<div class="mb-2">
+					<div class="text-sm font-semibold">{selected.label}</div>
+					<div class="text-xs text-muted-foreground">
+						{selected.count}
+						{noun}{selected.count > 1 ? 's' : ''}
+					</div>
+				</div>
+				<div class="max-h-[600px] space-y-0.5 overflow-y-auto">
+					{#each selected.prs as pr}
+						<a href="{linkBase}{pr.number}" class="block rounded px-2 py-1 text-xs hover:bg-muted">
+							<span class="mono text-muted-foreground">#{pr.number}</span>
+							{pr.title}
+						</a>
+					{/each}
+					{#if selected.count > selected.prs.length}
+						<p class="px-2 pt-1 text-[0.7rem] text-muted-foreground">
+							+ {selected.count - selected.prs.length} de plus…
+						</p>
+					{/if}
+				</div>
+			{:else}
+				<p class="text-xs text-muted-foreground">
+					Clique un <strong>groupe</strong> ou un <strong>sous-groupe</strong> pour lister ses {noun}s
+					ici.
+				</p>
+			{/if}
+		</div>
+	</div>
+{/if}

--- a/web/src/lib/components/PrGroupGraph.svelte
+++ b/web/src/lib/components/PrGroupGraph.svelte
@@ -356,7 +356,7 @@
 		<svg
 			bind:this={svgEl}
 			viewBox="0 0 {W} {H}"
-			class="h-[74vh] w-full touch-none select-none rounded-lg border bg-card"
+			class="h-[82vh] w-full touch-none select-none rounded-lg border bg-card"
 			role="application"
 			aria-label="PR groups network graph"
 			onwheel={onWheel}

--- a/web/src/routes/graphs/+page.svelte
+++ b/web/src/routes/graphs/+page.svelte
@@ -1,91 +1,16 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { selectedRepo, collapseSidebarSignal } from '$lib/stores';
-	import { fetchIssues, type Issue } from '$lib/api';
 	import * as Tabs from '$lib/components/ui/tabs';
-	import * as Dialog from '$lib/components/ui/dialog';
-	import IssueDetail from '$lib/components/IssueDetail.svelte';
-	import LabelGraphPanel from '$lib/components/LabelGraphPanel.svelte';
-	import PrGroupGraph from '$lib/components/PrGroupGraph.svelte';
-	import {
-		fetchPrGroups,
-		type PrGroup,
-		type PrSubGroup,
-		type PrGroupPr
-	} from '$lib/api';
+	import GroupGraphTab from '$lib/components/GroupGraphTab.svelte';
 
-	let issues = $state<Issue[]>([]);
-	let issueLoading = $state(true);
-
-	// Server-side PR subject hierarchy (grand groupes → sous-groupes) over the
-	// WHOLE DB — powers the PR network graph. Independent of the client PR sample.
-	let prGroups = $state<PrGroup[]>([]);
-	let groupsLoading = $state(true);
-	let groupsCount = $state(12);
-	let groupsError = $state<string | null>(null);
-	// Unified selection: a grand groupe (sub null) or a sous-groupe.
-	let selected = $state<{ id: string; label: string; count: number; prs: PrGroupPr[] } | null>(
-		null
-	);
-	function selectNode(group: PrGroup, sub: PrSubGroup | null) {
-		selected = sub
-			? {
-					id: `g:${group.name}/s:${sub.name}`,
-					label: `${group.name} → ${sub.name}`,
-					count: sub.count,
-					prs: sub.prs
-				}
-			: { id: `g:${group.name}`, label: group.name, count: group.count, prs: group.prs };
-	}
-
-	let groupToken = 0;
-	async function loadGroups(slug: string | null) {
-		const mine = ++groupToken;
-		groupsLoading = true;
-		groupsError = null;
-		try {
-			// No repo selected → the endpoint aggregates across all repos, so the
-			// graph still works "de base" (same convention as the other lists).
-			const r = await fetchPrGroups({ repo: slug ?? undefined, groups: groupsCount });
-			if (mine !== groupToken) return;
-			prGroups = r.groups;
-			groupsCount = r.groups_limit;
-			selected = null;
-		} catch (e) {
-			if (mine === groupToken) groupsError = e instanceof Error ? e.message : 'failed to load groups';
-		} finally {
-			if (mine === groupToken) groupsLoading = false;
-		}
-	}
-
-	// Aggregate history — daily snapshots. The trend endpoints are a Pro
-	// feature; in OSS they 404, so we swallow errors and show "no history".
+	// Aggregate history — daily snapshots. The trend endpoints are a Pro feature;
+	// in OSS they 404, so we swallow errors and show "no history".
 	type Point = Record<string, number | string>;
 	let prTrend = $state<Point[]>([]);
 	let issueTrend = $state<Point[]>([]);
 
-	let token = 0;
-	async function loadAll() {
-		const mine = ++token;
-		issueLoading = true;
-		// Issues (the issue-graph tab still groups a client sample by label)
-		try {
-			const all: Issue[] = [];
-			let offset = 0;
-			for (;;) {
-				const page = await fetchIssues({ limit: 250, offset });
-				if (mine !== token) return;
-				all.push(...page.items);
-				if (all.length >= page.total || page.items.length === 0 || all.length >= 2000) break;
-				offset += page.items.length;
-			}
-			issues = all;
-		} catch {
-			/* ignore */
-		} finally {
-			if (mine === token) issueLoading = false;
-		}
-		// Trends (best-effort)
+	async function loadTrends() {
 		try {
 			const r = await fetch('/api/v1/pr-insights/trend');
 			if (r.ok) prTrend = (await r.json()).points ?? [];
@@ -100,16 +25,17 @@
 		}
 	}
 
+	// Current repo slug (null = all repos); passed to each graph tab.
+	let repo = $state<string | null>(null);
 	onMount(() => {
 		const unsub = selectedRepo.subscribe((slug) => {
-			loadAll();
-			loadGroups(slug);
+			repo = slug;
+			loadTrends();
 		});
 		return unsub;
 	});
 
-	let issueModal = $state(false);
-	let activeIssue = $state<Issue | null>(null);
+	const collapseNav = () => collapseSidebarSignal.update((n) => n + 1);
 
 	/** Build an SVG polyline path for `points[valueKey]` over their order. */
 	function pathFor(points: Point[], key: string, w: number, h: number): string {
@@ -133,8 +59,8 @@
 <div class="mb-4">
 	<h2 class="text-xl font-semibold text-foreground mb-1">Graphs</h2>
 	<p class="text-sm text-muted-foreground">
-		Pull requests and issues clustered by label, filterable by domain — plus how the backlog evolved
-		over time.
+		Pull requests and issues clustered by subject across the whole DB — grands groupes and their
+		sous-groupes — plus how the backlog evolved over time.
 	</p>
 </div>
 
@@ -146,81 +72,11 @@
 	</Tabs.List>
 
 	<Tabs.Content value="pr">
-		<div class="mb-3 flex flex-wrap items-center gap-3">
-			<span class="text-xs font-medium text-muted-foreground">Grands groupes</span>
-			<input
-				type="range"
-				min="5"
-				max="30"
-				step="1"
-				bind:value={groupsCount}
-				onchange={() => loadGroups($selectedRepo)}
-				class="w-44 accent-primary"
-			/>
-			<span class="tabular-nums text-xs">{groupsCount}</span>
-			{#if groupsLoading}
-				<span class="text-xs text-muted-foreground">chargement…</span>
-			{/if}
-			<span class="text-xs text-muted-foreground"
-				>· sujets des PRs sur toute la base — clique un sous-groupe pour ses PRs</span
-			>
-		</div>
-		{#if groupsError}
-			<p class="text-sm text-destructive">{groupsError}</p>
-		{:else if !groupsLoading && prGroups.length === 0}
-			<p class="py-10 text-center text-sm text-muted-foreground">
-				Aucun groupe — pas encore de pull requests synchronisées pour ce dépôt.
-			</p>
-		{:else}
-			<div class="grid gap-4 lg:grid-cols-[1fr_300px]">
-				<PrGroupGraph
-					groups={prGroups}
-					selectedId={selected?.id ?? null}
-					onSelect={selectNode}
-					onInteract={() => collapseSidebarSignal.update((n) => n + 1)}
-				/>
-				<div class="rounded-lg border bg-card p-3">
-					{#if selected}
-						<div class="mb-2">
-							<div class="text-sm font-semibold">{selected.label}</div>
-							<div class="text-xs text-muted-foreground">
-								{selected.count} PR{selected.count > 1 ? 's' : ''}
-							</div>
-						</div>
-						<div class="max-h-[600px] space-y-0.5 overflow-y-auto">
-							{#each selected.prs as pr}
-								<a href="/prs/{pr.number}" class="block rounded px-2 py-1 text-xs hover:bg-muted">
-									<span class="mono text-muted-foreground">#{pr.number}</span>
-									{pr.title}
-								</a>
-							{/each}
-							{#if selected.count > selected.prs.length}
-								<p class="px-2 pt-1 text-[0.7rem] text-muted-foreground">
-									+ {selected.count - selected.prs.length} de plus…
-								</p>
-							{/if}
-						</div>
-					{:else}
-						<p class="text-xs text-muted-foreground">
-							Clique un <strong>groupe</strong> ou un <strong>sous-groupe</strong> dans le graphe pour
-							lister ses pull requests ici. Molette = zoom, glisser le fond = déplacer.
-						</p>
-					{/if}
-				</div>
-			</div>
-		{/if}
+		<GroupGraphTab kind="pr" {repo} onInteract={collapseNav} />
 	</Tabs.Content>
 
 	<Tabs.Content value="issue">
-		<LabelGraphPanel
-			items={issues}
-			loading={issueLoading}
-			emptyLabel="issues"
-			onSelect={(i) => {
-				activeIssue = i as unknown as Issue;
-				issueModal = true;
-			}}
-		/>
+		<GroupGraphTab kind="issue" {repo} onInteract={collapseNav} />
 	</Tabs.Content>
 
 	<Tabs.Content value="history">
@@ -230,12 +86,19 @@
 					<div class="mb-2 flex items-baseline justify-between">
 						<span class="text-sm font-medium">{chart.title}</span>
 						<span class="mono text-xs text-muted-foreground">
-							{chart.points.length ? `now ${maxOf(chart.points.slice(-1), chart.key)} · peak ${maxOf(chart.points, chart.key)}` : ''}
+							{chart.points.length
+								? `now ${maxOf(chart.points.slice(-1), chart.key)} · peak ${maxOf(chart.points, chart.key)}`
+								: ''}
 						</span>
 					</div>
 					{#if chart.points.length}
 						<svg viewBox="0 0 300 90" class="w-full" preserveAspectRatio="none" height="90">
-							<path d={pathFor(chart.points, chart.key, 300, 90)} fill="none" stroke={chart.color} stroke-width="2" />
+							<path
+								d={pathFor(chart.points, chart.key, 300, 90)}
+								fill="none"
+								stroke={chart.color}
+								stroke-width="2"
+							/>
 						</svg>
 						<div class="mt-1 flex justify-between text-[0.65rem] text-muted-foreground">
 							<span>{chart.points[0]?.day ?? ''}</span>
@@ -243,8 +106,8 @@
 						</div>
 					{:else}
 						<p class="py-6 text-center text-xs text-muted-foreground">
-							No history yet — daily snapshots accrue once the daemon has run for a few days
-							(Pro insights).
+							No history yet — daily snapshots accrue once the daemon has run for a few days (Pro
+							insights).
 						</p>
 					{/if}
 				</div>
@@ -252,20 +115,3 @@
 		</div>
 	</Tabs.Content>
 </Tabs.Root>
-
-<Dialog.Root bind:open={issueModal}>
-	<Dialog.Content class="sm:max-w-[80vw] max-h-[85vh] overflow-y-auto">
-		<Dialog.Header>
-			<Dialog.Title class="flex w-full items-center gap-3 pr-2 text-base font-semibold">
-				<span class="mono text-muted-foreground text-sm font-normal">#{activeIssue?.number}</span>
-				<span class="truncate">{activeIssue?.title}</span>
-			</Dialog.Title>
-		</Dialog.Header>
-		{#if activeIssue}
-			<IssueDetail issue={activeIssue} />
-			<div class="text-right pt-2">
-				<a href="/issues/{activeIssue.number}" class="text-xs text-primary hover:underline">Open full page →</a>
-			</div>
-		{/if}
-	</Dialog.Content>
-</Dialog.Root>


### PR DESCRIPTION
Option 1 requested: the **Issue graph** now uses the same group/subgroup model as PRs — grand groupes → sous-groupes of issue subjects across the DB, **bubbles sized by issue count**, with zoom/pan/click and a side panel linking to `/issues/{n}`.

- **Backend**: `GET /api/v1/issue-groups`, reusing `pr_groups::build_from` over open issue titles (same `?repo=`/`?groups=`/`?subs=`).
- **Frontend**: new `GroupGraphTab` component parameterised by `kind` (`pr` | `issue`) — only endpoint/link-base/noun differ. The graphs page renders both tabs via it, dropping the old label-based issue panel + client issue sample.

Backend clippy `-D warnings` + fmt clean; both webs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)