### PR TITLE
fix(graphs): link graph items to GitHub (fix "PR #99 not found")

### DIFF
--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -2557,7 +2557,7 @@ async fn api_pr_groups_get(
             .collect()
     };
 
-    let mut prs: Vec<(u64, String)> = Vec::new();
+    let mut prs: Vec<(u64, String, String)> = Vec::new();
     let mut name_stop: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut default_limit: Option<usize> = None;
     for (slug, ds) in &snapshot {
@@ -2573,10 +2573,10 @@ async fn api_pr_groups_get(
             ));
         }
         for p in ds.db.get_open_pulls().unwrap_or_default() {
-            prs.push((p.number, p.title));
+            prs.push((p.number, p.title, slug.clone()));
         }
         for p in ds.db.get_closed_pulls(100_000).unwrap_or_default() {
-            prs.push((p.number, p.title));
+            prs.push((p.number, p.title, slug.clone()));
         }
     }
 
@@ -2619,7 +2619,7 @@ async fn api_issue_groups_get(
             .collect()
     };
 
-    let mut issues: Vec<(u64, String)> = Vec::new();
+    let mut issues: Vec<(u64, String, String)> = Vec::new();
     let mut name_stop: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut default_limit: Option<usize> = None;
     for (slug, ds) in &snapshot {
@@ -2635,7 +2635,7 @@ async fn api_issue_groups_get(
             ));
         }
         for i in ds.db.get_open_issues().unwrap_or_default() {
-            issues.push((i.number, i.title));
+            issues.push((i.number, i.title, slug.clone()));
         }
     }
 

--- a/src/pipelines/pr_groups.rs
+++ b/src/pipelines/pr_groups.rs
@@ -16,11 +16,14 @@ use crate::pipelines::discover_domains::{title_words, top_terms};
 /// very large groups; the `count` is always the true total.
 const PR_CAP_PER_SUBGROUP: usize = 200;
 
-/// A pull request referenced by a subgroup.
+/// A pull request (or issue) referenced by a group/subgroup. Carries its repo
+/// so the UI can link correctly across repos and for closed items (which the
+/// in-app PR view doesn't load).
 #[derive(Serialize)]
 pub struct PrRef {
     pub number: u64,
     pub title: String,
+    pub repo: String,
 }
 
 /// A secondary subject inside a grand groupe.
@@ -43,34 +46,34 @@ pub struct Group {
 
 /// Build the group → subgroup → PRs hierarchy from a PR set.
 ///
-/// `prs` is (number, title) for every PR to consider; `name_stop` holds the
+/// `prs` is (number, title, repo) for every PR to consider; `name_stop` holds the
 /// repo owner/name tokens to exclude as self-referential noise. `group_limit` =
 /// number of grand groupes, `sub_limit` = subgroups per group.
 pub fn build_from(
-    prs: &[(u64, String)],
+    prs: &[(u64, String, String)],
     name_stop: &HashSet<String>,
     group_limit: usize,
     sub_limit: usize,
 ) -> Vec<Group> {
-    // (number, title, singularised word-set) per PR.
-    let items: Vec<(u64, String, HashSet<String>)> = prs
+    // (number, title, repo, singularised word-set) per PR.
+    let items: Vec<(u64, String, String, HashSet<String>)> = prs
         .iter()
-        .map(|(n, t)| (*n, t.clone(), title_words(t)))
+        .map(|(n, t, r)| (*n, t.clone(), r.clone(), title_words(t)))
         .collect();
-    let all_titles: Vec<String> = items.iter().map(|(_, t, _)| t.clone()).collect();
+    let all_titles: Vec<String> = items.iter().map(|(_, t, _, _)| t.clone()).collect();
 
     // Grand groupes: the top subjects across all PR titles.
     let group_terms = top_terms(&all_titles, &[], name_stop, group_limit);
 
     let mut groups = Vec::with_capacity(group_terms.len());
     for (g, _) in group_terms {
-        let members: Vec<&(u64, String, HashSet<String>)> =
-            items.iter().filter(|(_, _, w)| w.contains(&g)).collect();
+        let members: Vec<&(u64, String, String, HashSet<String>)> =
+            items.iter().filter(|(_, _, _, w)| w.contains(&g)).collect();
         let g_count = members.len();
 
         // Sous-groupes: frequent secondary terms among this group's PRs,
         // excluding the group term itself and the repo name.
-        let member_titles: Vec<String> = members.iter().map(|(_, t, _)| t.clone()).collect();
+        let member_titles: Vec<String> = members.iter().map(|(_, t, _, _)| t.clone()).collect();
         let mut sub_stop = name_stop.clone();
         sub_stop.insert(g.clone());
         let sub_terms = top_terms(&member_titles, &[], &sub_stop, sub_limit);
@@ -79,13 +82,14 @@ pub fn build_from(
         for (s, _) in sub_terms {
             let mut count = 0usize;
             let mut list: Vec<PrRef> = Vec::new();
-            for (num, title, w) in members.iter().copied() {
+            for (num, title, repo, w) in members.iter().copied() {
                 if w.contains(&s) {
                     count += 1;
                     if list.len() < PR_CAP_PER_SUBGROUP {
                         list.push(PrRef {
                             number: *num,
                             title: title.clone(),
+                            repo: repo.clone(),
                         });
                     }
                 }
@@ -101,9 +105,10 @@ pub fn build_from(
         let group_prs: Vec<PrRef> = members
             .iter()
             .take(PR_CAP_PER_SUBGROUP)
-            .map(|(num, title, _)| PrRef {
+            .map(|(num, title, repo, _)| PrRef {
                 number: *num,
                 title: title.clone(),
+                repo: repo.clone(),
             })
             .collect();
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -590,6 +590,7 @@ export async function discoverRepoDomains(slug: string, limit?: number): Promise
 export interface PrGroupPr {
 	number: number;
 	title: string;
+	repo: string;
 }
 /** A secondary subject inside a grand groupe. */
 export interface PrSubGroup {

--- a/web/src/lib/components/GroupGraphTab.svelte
+++ b/web/src/lib/components/GroupGraphTab.svelte
@@ -25,8 +25,14 @@
 	} = $props();
 
 	let noun = $derived(kind === 'pr' ? 'PR' : 'issue');
-	let linkBase = $derived(kind === 'pr' ? '/prs/' : '/issues/');
 	let fetcher = $derived(kind === 'pr' ? fetchPrGroups : fetchIssueGroups);
+
+	// Link to GitHub rather than the in-app page: the graph groups ALL PRs incl.
+	// closed ones (and can span repos), which the in-app PR view can't load.
+	function itemUrl(pr: PrGroupPr): string {
+		const seg = kind === 'pr' ? 'pull' : 'issues';
+		return `https://github.com/${pr.repo}/${seg}/${pr.number}`;
+	}
 
 	let groups = $state<PrGroup[]>([]);
 	let loading = $state(true);
@@ -133,7 +139,12 @@
 				</div>
 				<div class="max-h-[70vh] space-y-0.5 overflow-y-auto">
 					{#each selected.prs as pr}
-						<a href="{linkBase}{pr.number}" class="block rounded px-2 py-1 text-xs hover:bg-muted">
+						<a
+							href={itemUrl(pr)}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="block rounded px-2 py-1 text-xs hover:bg-muted"
+						>
 							<span class="mono text-muted-foreground">#{pr.number}</span>
 							{pr.title}
 						</a>


### PR DESCRIPTION
Clicking a PR in the graph panel could 404 with **"PR #99 not found"**. Root cause verified in prod: the graph groups **all** PRs (open + closed, and across both repos), but `/prs/{n}` only loads the 500 **open** pulls — so old/closed PRs (#99, #5, #14…) are unknown to it.

Fix: `PrRef` now carries its `repo`; the side-panel list links to the **GitHub** PR/issue URL (new tab), which works for open **and** closed items, in either repo. Threaded `repo` through `build_from` + both handlers; `PrGroupPr` gains `repo`.

Backend clippy `-D warnings` + fmt clean; both webs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)