### PR TITLE
fix(graphs): fetch trend history with no-store

### DIFF
--- a/web/src/routes/graphs/+page.svelte
+++ b/web/src/routes/graphs/+page.svelte
@@ -12,13 +12,15 @@
 
 	async function loadTrends() {
 		try {
-			const r = await fetch('/api/v1/pr-insights/trend');
+			// no-store: the endpoint sends no Cache-Control, so avoid the browser
+			// serving a stale (previously empty) response.
+			const r = await fetch('/api/v1/pr-insights/trend', { cache: 'no-store' });
 			if (r.ok) prTrend = (await r.json()).points ?? [];
 		} catch {
 			/* ignore */
 		}
 		try {
-			const r = await fetch('/api/v1/issue-insights/trend');
+			const r = await fetch('/api/v1/issue-insights/trend', { cache: 'no-store' });
 			if (r.ok) issueTrend = (await r.json()).points ?? [];
 		} catch {
 			/* ignore */


### PR DESCRIPTION
The History tab stayed empty even though the trend endpoints now return data — the browser served a previously-cached empty `{"points":[]}` (endpoint sends no Cache-Control). Verified with a stubbed fetch that the chart renders correctly given points; this forces `cache: "no-store"` on the two trend fetches so history appears without a manual hard-refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)