### PR TITLE
feat(daemon): repo registry persistence hook + runtime remove_repo

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1416,7 +1416,7 @@ fn default_poll_interval() -> u64 {
     30
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RepoEntry {
     /// Repository slug: "owner/repo"
     pub slug: String,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -45,6 +45,13 @@ pub struct DaemonState {
     /// Pipelines must check the relevant flag before performing mutating
     /// actions (triage, analyze, auto-fix, merge).
     features: std::sync::RwLock<crate::config::RepoFeatures>,
+    /// Set when the repo is removed at runtime; the scheduler and poller
+    /// check [`DaemonState::is_cancelled`] each cycle and exit so a removed
+    /// repo stops writing to the DB without a daemon restart.
+    cancelled: std::sync::atomic::AtomicBool,
+    /// Wakes the scheduler/poller immediately on cancellation instead of
+    /// waiting out the current sleep interval.
+    cancel_notify: tokio::sync::Notify,
 }
 
 impl DaemonState {
@@ -74,7 +81,35 @@ impl DaemonState {
             config,
             apply: std::sync::atomic::AtomicBool::new(apply),
             features: std::sync::RwLock::new(features),
+            cancelled: std::sync::atomic::AtomicBool::new(false),
+            cancel_notify: tokio::sync::Notify::new(),
         }
+    }
+
+    /// True once the repo has been removed at runtime. Long-running loops
+    /// (scheduler, poller) must check this each cycle and exit.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Signal the scheduler/poller to stop and wake them immediately.
+    pub fn cancel(&self) {
+        self.cancelled
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        self.cancel_notify.notify_waiters();
+    }
+
+    /// Sleep for `dur`, returning early if the repo is cancelled. Returns
+    /// `true` if cancelled (caller should break its loop).
+    pub async fn sleep_or_cancel(&self, dur: std::time::Duration) -> bool {
+        if self.is_cancelled() {
+            return true;
+        }
+        tokio::select! {
+            _ = tokio::time::sleep(dur) => {}
+            _ = self.cancel_notify.notified() => {}
+        }
+        self.is_cancelled()
     }
 
     /// Live apply-mode flag. `true` → mutating actions hit GitHub;
@@ -146,6 +181,31 @@ pub struct DynamicRuntime {
     pub poll_interval: u64,
     pub global_apply: bool,
     pub global_config_path: PathBuf,
+    /// Canonical repo registry (list + per-repo settings). Source of truth for
+    /// persistence; seeded from `GlobalConfig.repos` at boot and mutated by
+    /// add/remove/feature edits.
+    pub repos: Arc<RwLock<Vec<crate::config::RepoEntry>>>,
+    /// Persist the registry (Pro → Postgres). When `None`, `persist()` writes
+    /// `global.toml` at `global_config_path`.
+    pub persist_repos: Option<RepoPersist>,
+    /// Build a repo's storage backend (Pro → shared Postgres pool). When
+    /// `None`, a runtime-added repo opens a per-repo SQLite `Database`.
+    pub db_factory: Option<DbFactory>,
+}
+
+impl DynamicRuntime {
+    /// Persist the current registry: via the Pro hook when set, else by
+    /// rewriting `global.toml`. Best-effort; errors are returned to the caller.
+    pub async fn persist(&self) -> Result<()> {
+        let repos = self.repos.read().await.clone();
+        if let Some(hook) = &self.persist_repos {
+            hook(&repos)
+        } else {
+            let mut global = GlobalConfig::load(&self.global_config_path).unwrap_or_default();
+            global.repos = repos;
+            global.save(&self.global_config_path)
+        }
+    }
 }
 
 /// Multi-repo state: maps "owner/repo" slug to its DaemonState.
@@ -225,7 +285,14 @@ impl MultiDaemonState {
         std::fs::create_dir_all(&config.wshm_dir)?;
         config.web.resolve_password(&config.wshm_dir);
 
-        let db = Arc::new(Database::open(&config)?) as Arc<dyn DatabaseBackend>;
+        // Build the storage backend via the Pro-provided factory (shared
+        // Postgres pool) when present; otherwise open a per-repo SQLite DB.
+        // Using the factory is what makes a runtime-added repo land in
+        // Postgres in prod instead of a stray, empty SQLite file.
+        let db = match &runtime.db_factory {
+            Some(factory) => factory(&config)?,
+            None => Arc::new(Database::open(&config)?) as Arc<dyn DatabaseBackend>,
+        };
         let gh = Arc::new(GhClient::new(&config)?);
         let state = Arc::new(DaemonState::new(
             db,
@@ -235,9 +302,23 @@ impl MultiDaemonState {
         ));
 
         // Persist before mutating runtime state so a crash can't lose the
-        // user's intent silently.
-        crate::config::append_repo_to_global(&runtime.global_config_path, slug, &path, None)
-            .with_context(|| format!("failed to persist {slug} to global config"))?;
+        // user's intent silently. Append to the canonical registry, then flush
+        // via the persistence hook (Pro → Postgres) or the TOML fallback.
+        {
+            let mut canonical = runtime.repos.write().await;
+            canonical.push(crate::config::RepoEntry {
+                slug: slug.to_string(),
+                path: path.clone(),
+                apply: None,
+                enabled: true,
+                secret: None,
+                features: crate::config::RepoFeatures::default(),
+            });
+        }
+        runtime
+            .persist()
+            .await
+            .with_context(|| format!("failed to persist {slug} to repo registry"))?;
 
         {
             let mut repos = self.repos.write().await;
@@ -269,6 +350,38 @@ impl MultiDaemonState {
         );
 
         Ok(state)
+    }
+
+    /// Remove a repo at runtime: stop its scheduler/poller, drop it from the
+    /// live map and the canonical registry, and persist (Pro → Postgres, else
+    /// TOML) so the removal survives a restart. Idempotent-ish: errors if the
+    /// slug isn't registered.
+    pub async fn remove_repo(&self, slug: &str) -> Result<()> {
+        let runtime = self
+            .runtime
+            .as_ref()
+            .context("Dynamic remove_repo not available (daemon not running in multi-repo mode)")?;
+
+        // Drop from the live map and signal its background tasks to exit.
+        let removed = {
+            let mut repos = self.repos.write().await;
+            repos.remove(slug)
+        };
+        let state = removed.with_context(|| format!("repo {slug} not registered"))?;
+        state.cancel();
+
+        // Remove from the canonical registry, then persist the new list.
+        {
+            let mut canonical = runtime.repos.write().await;
+            canonical.retain(|e| e.slug != slug);
+        }
+        runtime
+            .persist()
+            .await
+            .with_context(|| format!("failed to persist removal of {slug}"))?;
+
+        info!("Repo removed at runtime: {slug}");
+        Ok(())
     }
 }
 
@@ -428,15 +541,23 @@ pub struct DaemonExtensions {
     /// pool across all repos while scoping each backend instance by repo
     /// slug. When `None`, falls back to `Database::open(config)` (the
     /// historical OSS-only behaviour).
-    #[allow(clippy::type_complexity)]
-    pub db_factory: Option<
-        Arc<
-            dyn Fn(&crate::Config) -> anyhow::Result<Arc<dyn crate::db::backend::DatabaseBackend>>
-                + Send
-                + Sync,
-        >,
-    >,
+    pub db_factory: Option<DbFactory>,
+    /// Optional hook to persist the full repo registry (Pro writes it to
+    /// Postgres). When `Some`, runtime add/remove/feature edits call this
+    /// instead of rewriting `global.toml`; when `None`, the TOML file is used.
+    pub persist_repos: Option<RepoPersist>,
 }
+
+/// Produces the storage backend for one repo. Pro shares a single Postgres
+/// pool across repos, scoping each instance by slug; OSS opens a per-repo
+/// SQLite `Database`.
+pub type DbFactory =
+    Arc<dyn Fn(&Config) -> anyhow::Result<Arc<dyn DatabaseBackend>> + Send + Sync>;
+
+/// Persists the whole tracked-repo registry (list + per-repo settings). Pro
+/// writes the JSON blob to Postgres; OSS falls back to `global.toml`.
+pub type RepoPersist =
+    Arc<dyn Fn(&[crate::config::RepoEntry]) -> anyhow::Result<()> + Send + Sync>;
 
 /// Run daemon in multi-repo mode from a global config file.
 pub async fn run_multi(global: GlobalConfig, args: DaemonArgs) -> Result<()> {
@@ -644,6 +765,9 @@ pub async fn run_multi_with_extensions(
         poll_interval,
         global_apply,
         global_config_path,
+        repos: Arc::new(RwLock::new(global.repos.clone())),
+        persist_repos: extensions.persist_repos.clone(),
+        db_factory: extensions.db_factory.clone(),
     };
 
     let multi = Arc::new(MultiDaemonState::with_runtime(repos, runtime));

--- a/src/daemon/poller.rs
+++ b/src/daemon/poller.rs
@@ -54,7 +54,10 @@ pub async fn run_multi(
     );
 
     loop {
-        tokio::time::sleep(interval).await;
+        if state.sleep_or_cancel(interval).await {
+            info!("[{slug}] repo removed — stopping poller");
+            break;
+        }
 
         match poll_events(&state, &mut last_event_id).await {
             Ok(events) => {

--- a/src/daemon/scheduler.rs
+++ b/src/daemon/scheduler.rs
@@ -76,7 +76,13 @@ pub async fn run(state: Arc<DaemonState>) {
     }
 
     loop {
-        tokio::time::sleep(interval).await;
+        if state.sleep_or_cancel(interval).await {
+            info!(
+                "[{}] repo removed — stopping scheduler",
+                state.config.repo_slug()
+            );
+            break;
+        }
 
         let features = state.features();
         if !features.collect_issues && !features.collect_prs {

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -14,7 +14,7 @@ use axum::{
     http::{header, HeaderMap, HeaderValue, Request, StatusCode},
     middleware::{self, Next},
     response::{Html, IntoResponse, Response},
-    routing::{get, post},
+    routing::{delete, get, post},
     Json, Router,
 };
 use base64::Engine;
@@ -2286,13 +2286,14 @@ async fn api_repo_features_patch(
         ds.set_apply(new_apply);
     }
 
-    // Persist to global.toml so the change survives restart. Errors are
-    // logged but not propagated — the in-memory state is already updated,
-    // worst case the user has to re-toggle after a restart.
-    let global_path = crate::config::GlobalConfig::default_path();
-    if global_path.exists() {
-        if let Ok(mut global) = crate::config::GlobalConfig::load(&global_path) {
-            for entry in &mut global.repos {
+    // Persist so the change survives restart: mutate the canonical registry
+    // and flush via the persistence hook (Pro → Postgres) or the TOML
+    // fallback (OSS). Errors are logged but not propagated — the in-memory
+    // state is already updated, worst case the user re-toggles after restart.
+    if let Some(runtime) = state.multi.runtime.as_ref() {
+        {
+            let mut canonical = runtime.repos.write().await;
+            for entry in canonical.iter_mut() {
                 if entry.slug == slug {
                     entry.features = features.clone();
                     if let Some(new_apply) = apply_change {
@@ -2300,9 +2301,9 @@ async fn api_repo_features_patch(
                     }
                 }
             }
-            if let Err(e) = global.save(&global_path) {
-                tracing::warn!("Failed to persist features to global.toml: {e}");
-            }
+        }
+        if let Err(e) = runtime.persist().await {
+            tracing::warn!("Failed to persist repo features: {e}");
         }
     }
 
@@ -2782,6 +2783,41 @@ async fn api_add_repo(
             let msg = format!("{e}");
             let code = if msg.contains("already") {
                 StatusCode::CONFLICT
+            } else if msg.contains("not available") {
+                StatusCode::METHOD_NOT_ALLOWED
+            } else {
+                StatusCode::BAD_REQUEST
+            };
+            (code, Json(json!({"status": "error", "message": msg}))).into_response()
+        }
+    }
+}
+
+/// DELETE /api/v1/repos/{slug} -- remove a repo at runtime (multi-repo mode
+/// only). Stops its scheduler/poller and persists the removal so it survives a
+/// restart. Requires `admin` role.
+async fn api_remove_repo(
+    State(state): State<Arc<WebState>>,
+    user: axum::Extension<Option<crate::auth::User>>,
+    axum::extract::Path(slug): axum::extract::Path<String>,
+) -> Response {
+    if state.users.is_some() {
+        if let Err(e) = require_admin(&user) {
+            return e;
+        }
+    }
+
+    match state.multi.remove_repo(&slug).await {
+        Ok(()) => Json(json!({
+            "status": "ok",
+            "slug": slug,
+            "message": "Repo removed — scheduler/poller stopped",
+        }))
+        .into_response(),
+        Err(e) => {
+            let msg = format!("{e}");
+            let code = if msg.contains("not registered") {
+                StatusCode::NOT_FOUND
             } else if msg.contains("not available") {
                 StatusCode::METHOD_NOT_ALLOWED
             } else {
@@ -3683,6 +3719,7 @@ pub fn oss_api_routes() -> Router<Arc<WebState>> {
         .route("/api/v1/license", get(api_license))
         .route("/api/v1/license/activate", post(api_license_activate))
         .route("/api/v1/repos", get(api_list_repos).post(api_add_repo))
+        .route("/api/v1/repos/{slug}", delete(api_remove_repo))
         .route(
             "/api/v1/config/retry",
             get(api_retry_get).patch(api_retry_patch),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -441,6 +441,15 @@ export function addRepo(slug: string, path?: string): Promise<{ status: string; 
 	return apiPost('/repos', path ? { slug, path } : { slug });
 }
 
+export async function removeRepo(slug: string): Promise<{ status: string; slug: string; message: string }> {
+	const res = await apiMutate(`/repos/${encodeURIComponent(slug)}`, { method: 'DELETE' });
+	const json = await res.json();
+	if (!res.ok) {
+		throw new Error((json && (json.error || json.message)) || `HTTP ${res.status}`);
+	}
+	return json;
+}
+
 export interface AuthStatus {
 	github: boolean;
 	anthropic: 'oauth' | 'api_key' | null;

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -82,6 +82,8 @@
 	"settings.repos.configured": "Configured",
 	"settings.repos.none": "None configured.",
 	"settings.repos.editFeatures": "Edit features",
+	"settings.repos.remove": "Remove repository",
+	"settings.repos.removeConfirm": "Remove this repository from tracking? Its collected data stays in the database, but the daemon stops syncing it.",
 	"settings.repos.badge.apply": "apply",
 	"settings.repos.badge.dryrun": "dry-run",
 	"settings.repos.slug": "Slug",

--- a/web/src/lib/i18n/fr.json
+++ b/web/src/lib/i18n/fr.json
@@ -82,6 +82,8 @@
 	"settings.repos.configured": "Configurés",
 	"settings.repos.none": "Aucun dépôt configuré.",
 	"settings.repos.editFeatures": "Modifier les options",
+	"settings.repos.remove": "Retirer le dépôt",
+	"settings.repos.removeConfirm": "Retirer ce dépôt du suivi ? Ses données collectées restent en base, mais le démon cesse de le synchroniser.",
 	"settings.repos.badge.apply": "apply",
 	"settings.repos.badge.dryrun": "dry-run",
 	"settings.repos.slug": "Slug",

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -23,6 +23,7 @@
 		activateLicense,
 		fetchRepos,
 		addRepo,
+		removeRepo,
 		fetchAuthStatus,
 		setGithubToken,
 		setAnthropicToken,
@@ -449,6 +450,22 @@
 		addingRepo = false;
 	}
 
+	let removingRepo: string | null = $state(null);
+	async function handleRemoveRepo(slug: string) {
+		if (!confirm(`${slug}\n\n${$t('settings.repos.removeConfirm')}`)) return;
+		removingRepo = slug;
+		addRepoMessage = null; addRepoError = false;
+		try {
+			const r = await removeRepo(slug);
+			addRepoMessage = r.message;
+			await refreshRepos();
+		} catch (e) {
+			addRepoMessage = e instanceof Error ? e.message : 'Remove failed';
+			addRepoError = true;
+		}
+		removingRepo = null;
+	}
+
 	async function handleSetGithub() {
 		if (!ghToken.trim()) return;
 		savingGh = true; ghMessage = null; ghError = false;
@@ -637,6 +654,14 @@
 												<Button variant="outline" size="xs" onclick={() => openFeaturesModal(r.slug)}>
 													{$t('settings.repos.editFeatures')}
 												</Button>
+												<Button
+													variant="ghost"
+													size="xs"
+													class="text-destructive hover:bg-destructive/10"
+													disabled={removingRepo === r.slug}
+													title={$t('settings.repos.remove')}
+													onclick={() => handleRemoveRepo(r.slug)}
+												>✕</Button>
 											</div>
 										</li>
 									{/each}


### PR DESCRIPTION
Makes the tracked-repo registry persist through an injectable hook so Pro can store it in Postgres (source of truth on stateless pods), and adds runtime repo removal.

## wshm-core
- `DaemonExtensions.persist_repos` hook + `DbFactory`/`RepoPersist` aliases.
- `DynamicRuntime` holds the canonical `repos` + persist/db_factory handles; single `persist()` (hook, else `global.toml` fallback — OSS unchanged).
- **Bug fix** in `add_repo`: build backend via `db_factory` (shared PG pool in Pro) instead of hardcoded per-repo SQLite.
- New `remove_repo`: cancels scheduler/poller (new cancellation token on `DaemonState`, honoured by both loops) + persists.
- `PATCH /repos/{slug}/features` persists via hook; new `DELETE /api/v1/repos/{slug}` (admin).
- Settings → Repos: remove (✕) button + `removeRepo()` + i18n.
- `RepoEntry: Clone`.

## Verification
- `cargo build` (lib + OSS bin), `cargo clippy`, daemon tests, `svelte-check` (touched files) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)