### PR TITLE
fix(login): don't report GitHub as authenticated on an empty token

### DIFF
--- a/src/login.rs
+++ b/src/login.rs
@@ -496,9 +496,13 @@ fn show_status() -> Result<()> {
     println!("── Authentication Status ──\n");
 
     // GitHub
+    // `.ok()` alone treats an env var that's *set but empty* (e.g. a K8s
+    // Deployment declaring `GITHUB_TOKEN=""` just to make the var visible)
+    // as present, which used to report "authenticated" for a blank token.
     let gh_token = std::env::var("GITHUB_TOKEN")
         .or_else(|_| std::env::var("WSHM_TOKEN"))
-        .ok();
+        .ok()
+        .filter(|s| !s.trim().is_empty());
 
     let gh_cli = std::process::Command::new("gh")
         .args(["auth", "token"])


### PR DESCRIPTION
## Summary
- `show_status()` used `std::env::var("GITHUB_TOKEN").ok()`, which treats a variable that's *set but empty* as present.
- On K8s, a Deployment manifest often declares `GITHUB_TOKEN=""` just to make the variable visible to the container without a real value — this made `wshm login --status` print `authenticated (env var)` for a blank token, while the actual GitHub client silently ran in anonymous mode (60 req/h).
- Filters out blank values, matching the "empty-is-absent" rule `inject_credentials()` already uses.

Found while diagnosing why `wshm-pro`'s CLI subcommands couldn't see a `github_token` that was correctly configured in Settings → Secrets (Postgres) — see wshm-dev/wshm-pro#100 for the companion fix on the Pro side.

## Test plan
- [x] `cargo check` clean
- [x] `cargo clippy` clean, no warnings