### PR TITLE
feat(github): authenticate as a GitHub App instead of a personal token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6512,6 +6512,7 @@ dependencies = [
  "hmac 0.12.1",
  "hostname",
  "is-terminal",
+ "jsonwebtoken",
  "mime_guess",
  "mongodb",
  "mysql_async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,10 @@ vault-all = ["vault-hashicorp", "vault-aws", "vault-gcp"]
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
 octocrab = "0.44"
+# Pinned to the exact version octocrab 0.44 depends on — its `.app()`
+# builder takes a `jsonwebtoken::EncodingKey` by value, so a mismatched
+# major/minor version would fail to type-check even though both compile.
+jsonwebtoken = "9.3"
 rusqlite = { version = "0.32", features = ["bundled"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,15 @@ use std::path::{Path, PathBuf};
 
 use crate::cli::Cli;
 
+/// Resolved GitHub App credentials — never part of `config.toml` (secrets
+/// only live in the encrypted store / env, per [`Config::github_app_auth_optional`]).
+#[derive(Debug, Clone)]
+pub struct GithubAppAuth {
+    pub app_id: u64,
+    pub installation_id: u64,
+    pub private_key_pem: String,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
     #[serde(default)]
@@ -1871,6 +1880,14 @@ impl Config {
 
         let template = r#"[github]
 # Token from env var GITHUB_TOKEN or WSHM_TOKEN, or `gh auth token` (never stored in config)
+#
+# Alternative: authenticate as a GitHub App instead of a personal token.
+# A self-refreshing installation token beats a PAT for an unattended bot —
+# no manual rotation, and it's scoped to only the repos the App is
+# installed on. Set all three (env or Settings -> Secrets), never in this
+# file: WSHM_GITHUB_APP_ID, WSHM_GITHUB_APP_INSTALLATION_ID,
+# WSHM_GITHUB_APP_PRIVATE_KEY (PEM; literal "\n" line breaks are accepted).
+# When present, App auth takes priority over GITHUB_TOKEN/WSHM_TOKEN.
 
 [ai]
 provider = "anthropic"
@@ -2141,6 +2158,53 @@ full_sync_interval_hours = 24
             .context("No GitHub token found. Set GITHUB_TOKEN, WSHM_TOKEN, authenticate with `gh auth login`, or add a github_token in Settings → Secrets")
     }
 
+    /// Resolve GitHub App credentials for self-refreshing bot auth, without
+    /// bailing when absent (App auth is opt-in; most installs still use a
+    /// PAT). All three fields must be present and non-empty — a partially
+    /// configured App is treated as "not configured" so callers fall back
+    /// to [`Self::github_token_optional`] instead of failing outright.
+    ///
+    /// Same resolution order as `github_token_optional`: encrypted secret
+    /// store (per-repo override → global) → env var.
+    pub fn github_app_auth_optional(&self) -> Option<GithubAppAuth> {
+        let store = crate::secrets::global();
+        let slug = self.repo_slug();
+        let resolve = |key: &str, env_name: &str| {
+            crate::secrets::resolve(store.as_ref(), Some(&slug), key, env_name)
+                .filter(|v| !v.trim().is_empty())
+        };
+
+        let app_id = resolve("github_app_id", "WSHM_GITHUB_APP_ID")?;
+        let installation_id = resolve(
+            "github_app_installation_id",
+            "WSHM_GITHUB_APP_INSTALLATION_ID",
+        )?;
+        let private_key_pem = resolve("github_app_private_key", "WSHM_GITHUB_APP_PRIVATE_KEY")?;
+
+        let app_id = app_id.trim().parse().ok().or_else(|| {
+            tracing::warn!("github_app_id is not a valid integer — ignoring GitHub App auth");
+            None
+        })?;
+        let installation_id = installation_id.trim().parse().ok().or_else(|| {
+            tracing::warn!(
+                "github_app_installation_id is not a valid integer — ignoring GitHub App auth"
+            );
+            None
+        })?;
+
+        // A PEM pasted into a single-line secret input can't carry real
+        // newlines, so accept the literal two-character sequence `\n` as an
+        // escape and unescape it here — same convention as Firebase/Vercel
+        // service-account env vars.
+        let private_key_pem = private_key_pem.replace("\\n", "\n");
+
+        Some(GithubAppAuth {
+            app_id,
+            installation_id,
+            private_key_pem,
+        })
+    }
+
     /// Resolve a GitHub token without bailing when absent. Returns `None` so
     /// the daemon can run in anonymous read-only mode against public repos
     /// (rate-limited to 60 req/h). Mutating endpoints (post labels/comments,
@@ -2286,5 +2350,60 @@ mod tests {
         let (owner, repo) = parse_github_url("https://github.com/user/project").unwrap();
         assert_eq!(owner, "user");
         assert_eq!(repo, "project");
+    }
+
+    /// Self-contained: sets/clears its own env vars sequentially so it's
+    /// safe alongside other tests running in the same process (no other
+    /// test touches these var names). `secrets::global()` is never
+    /// installed in a unit-test process, so `github_app_auth_optional`
+    /// resolves purely from env — matching production's env-var fallback
+    /// path for a standalone (non-daemon) install.
+    #[test]
+    fn test_github_app_auth_optional_requires_all_three_fields() {
+        const VARS: [&str; 3] = [
+            "WSHM_GITHUB_APP_ID",
+            "WSHM_GITHUB_APP_INSTALLATION_ID",
+            "WSHM_GITHUB_APP_PRIVATE_KEY",
+        ];
+        for v in VARS {
+            std::env::remove_var(v);
+        }
+
+        let config = Config {
+            repo_owner: "acme".to_string(),
+            repo_name: "widgets".to_string(),
+            ..Config::default()
+        };
+
+        assert!(
+            config.github_app_auth_optional().is_none(),
+            "no App fields set — must not report configured"
+        );
+
+        std::env::set_var("WSHM_GITHUB_APP_ID", "123456");
+        assert!(
+            config.github_app_auth_optional().is_none(),
+            "only app_id set — partial config must still be None"
+        );
+
+        std::env::set_var("WSHM_GITHUB_APP_INSTALLATION_ID", "789");
+        std::env::set_var(
+            "WSHM_GITHUB_APP_PRIVATE_KEY",
+            "-----BEGIN RSA PRIVATE KEY-----\\nabc\\n-----END RSA PRIVATE KEY-----",
+        );
+        let auth = config
+            .github_app_auth_optional()
+            .expect("all three fields set — must resolve");
+        assert_eq!(auth.app_id, 123456);
+        assert_eq!(auth.installation_id, 789);
+        assert_eq!(
+            auth.private_key_pem,
+            "-----BEGIN RSA PRIVATE KEY-----\nabc\n-----END RSA PRIVATE KEY-----",
+            "literal \\n must be unescaped to real newlines"
+        );
+
+        for v in VARS {
+            std::env::remove_var(v);
+        }
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -551,13 +551,11 @@ pub struct DaemonExtensions {
 /// Produces the storage backend for one repo. Pro shares a single Postgres
 /// pool across repos, scoping each instance by slug; OSS opens a per-repo
 /// SQLite `Database`.
-pub type DbFactory =
-    Arc<dyn Fn(&Config) -> anyhow::Result<Arc<dyn DatabaseBackend>> + Send + Sync>;
+pub type DbFactory = Arc<dyn Fn(&Config) -> anyhow::Result<Arc<dyn DatabaseBackend>> + Send + Sync>;
 
 /// Persists the whole tracked-repo registry (list + per-repo settings). Pro
 /// writes the JSON blob to Postgres; OSS falls back to `global.toml`.
-pub type RepoPersist =
-    Arc<dyn Fn(&[crate::config::RepoEntry]) -> anyhow::Result<()> + Send + Sync>;
+pub type RepoPersist = Arc<dyn Fn(&[crate::config::RepoEntry]) -> anyhow::Result<()> + Send + Sync>;
 
 /// Run daemon in multi-repo mode from a global config file.
 pub async fn run_multi(global: GlobalConfig, args: DaemonArgs) -> Result<()> {

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -2084,7 +2084,7 @@ async fn api_license_activate(
             StatusCode::BAD_REQUEST,
             Json(json!({
                 "status": "error",
-                "message": format!("{e}"),
+                "message": e.to_string(),
             })),
         )
             .into_response(),

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -2995,7 +2995,15 @@ async fn api_auth_status(State(state): State<Arc<WebState>>) -> impl IntoRespons
         false
     };
 
-    let github = secrets_has("github_token").await
+    let github_app = secrets_has("github_app_id").await
+        && secrets_has("github_app_installation_id").await
+        && secrets_has("github_app_private_key").await
+        || (std::env::var("WSHM_GITHUB_APP_ID").is_ok()
+            && std::env::var("WSHM_GITHUB_APP_INSTALLATION_ID").is_ok()
+            && std::env::var("WSHM_GITHUB_APP_PRIVATE_KEY").is_ok());
+
+    let github = github_app
+        || secrets_has("github_token").await
         || creds.contains_key("GITHUB_TOKEN")
         || std::env::var("GITHUB_TOKEN").is_ok()
         || std::env::var("WSHM_TOKEN").is_ok();
@@ -3015,8 +3023,17 @@ async fn api_auth_status(State(state): State<Arc<WebState>>) -> impl IntoRespons
         None
     };
 
+    let github_kind = if github_app {
+        Some("app")
+    } else if github {
+        Some("token")
+    } else {
+        None
+    };
+
     Json(json!({
         "github": github,
+        "github_kind": github_kind,
         "anthropic": anthropic_kind,
     }))
 }
@@ -3511,19 +3528,26 @@ async fn api_secrets_put(
                 "api_secrets_put: store.put OK — row id={id}"
             );
             // Hot-reload affected daemon clients so the new token / API key
-            // takes effect without a restart. Only github_token reloads the
-            // GhClient today; other keys are read on-demand by the relevant
-            // pipeline so no reload is needed.
-            if key.trim() == "github_token" {
+            // takes effect without a restart. GitHub-auth keys (PAT or the
+            // three GitHub App fields) reload the GhClient; other keys are
+            // read on-demand by the relevant pipeline so no reload is needed.
+            const GITHUB_AUTH_KEYS: [&str; 4] = [
+                "github_token",
+                "github_app_id",
+                "github_app_installation_id",
+                "github_app_private_key",
+            ];
+            if GITHUB_AUTH_KEYS.contains(&key.trim()) {
                 tracing::debug!(
                     target: "wshm_core::secrets_trace",
-                    "api_secrets_put: key is github_token — triggering reload"
+                    "api_secrets_put: key={:?} is a GitHub auth key — triggering reload",
+                    key.trim()
                 );
                 reload_github_clients(&state, scope, effective_slug).await;
             } else {
                 tracing::debug!(
                     target: "wshm_core::secrets_trace",
-                    "api_secrets_put: key={:?} ≠ github_token — no reload",
+                    "api_secrets_put: key={:?} is not a GitHub auth key — no reload",
                     key.trim()
                 );
             }

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use octocrab::models::{AppId, InstallationId};
 use octocrab::Octocrab;
 use tracing::debug;
 
@@ -20,21 +21,55 @@ pub struct Client {
     pub authenticated: bool,
 }
 
+/// Build the `Octocrab` auth layer: GitHub App (self-refreshing installation
+/// token, preferred for an unattended bot) if fully configured, else a
+/// static personal/legacy token, else anonymous. Returns whether the
+/// resulting client is authenticated.
+fn build_octocrab(config: &Config) -> Result<(Octocrab, bool)> {
+    if let Some(app_auth) = config.github_app_auth_optional() {
+        let key = jsonwebtoken::EncodingKey::from_rsa_pem(app_auth.private_key_pem.as_bytes())
+            .context(
+                "Invalid GitHub App private key (expected a PEM-encoded RSA key, \
+                 e.g. the .pem file GitHub gives you when you generate a private key \
+                 for the App)",
+            )?;
+        let app_client = Octocrab::builder()
+            .app(AppId(app_auth.app_id), key)
+            .build()
+            .context("Failed to create GitHub App client")?;
+        let installation_client = app_client
+            .installation(InstallationId(app_auth.installation_id))
+            .context("Failed to scope GitHub App client to its installation")?;
+        tracing::info!(
+            target: "wshm_core::github",
+            app_id = app_auth.app_id,
+            installation_id = app_auth.installation_id,
+            "GitHub client authenticated as App installation (self-refreshing token)"
+        );
+        return Ok((installation_client, true));
+    }
+
+    let token = config.github_token_optional();
+    let authenticated = token.is_some();
+    let mut builder = Octocrab::builder();
+    if let Some(t) = token {
+        builder = builder.personal_token(t);
+    } else {
+        tracing::warn!(
+            target: "wshm_core::github",
+            "GitHub client built without a token — anonymous mode (60 req/h, public repos read-only). \
+             Add a token in Settings → Secrets for full functionality."
+        );
+    }
+    Ok((
+        builder.build().context("Failed to create GitHub client")?,
+        authenticated,
+    ))
+}
+
 impl Client {
     pub fn new(config: &Config) -> Result<Self> {
-        let token = config.github_token_optional();
-        let authenticated = token.is_some();
-        let mut builder = Octocrab::builder();
-        if let Some(t) = token {
-            builder = builder.personal_token(t);
-        } else {
-            tracing::warn!(
-                target: "wshm_core::github",
-                "GitHub client built without a token — anonymous mode (60 req/h, public repos read-only). \
-                 Add a token in Settings → Secrets for full functionality."
-            );
-        }
-        let octocrab = builder.build().context("Failed to create GitHub client")?;
+        let (octocrab, authenticated) = build_octocrab(config)?;
 
         let http = reqwest::Client::builder()
             .user_agent("wshm")
@@ -90,8 +125,8 @@ impl Client {
     pub fn require_auth(&self, action: &str) -> Result<()> {
         if !self.authenticated {
             anyhow::bail!(
-                "{action}: GitHub auth required. Add a github_token in \
-                 Settings → Secrets, or set GITHUB_TOKEN."
+                "{action}: GitHub auth required. Add a github_token (or GitHub App \
+                 credentials) in Settings → Secrets, or set GITHUB_TOKEN."
             );
         }
         Ok(())

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -203,6 +203,8 @@
 	"settings.secrets.repoSlug": "Repository slug",
 	"settings.secrets.key": "Key",
 	"settings.secrets.commonKeys": "Common keys:",
+	"settings.secrets.githubAppHint": "For a self-refreshing bot instead of a personal token, set all three:",
+	"settings.secrets.githubAppHintSuffix": "(private key: paste the PEM as-is, or with \\n in place of line breaks).",
 	"settings.secrets.value": "Value",
 	"settings.secrets.save": "Save secret",
 

--- a/web/src/lib/i18n/fr.json
+++ b/web/src/lib/i18n/fr.json
@@ -203,6 +203,8 @@
 	"settings.secrets.repoSlug": "Slug du dépôt",
 	"settings.secrets.key": "Clé",
 	"settings.secrets.commonKeys": "Clés courantes :",
+	"settings.secrets.githubAppHint": "Pour un bot à jeton auto-renouvelé plutôt qu'un token personnel, renseignez les trois :",
+	"settings.secrets.githubAppHintSuffix": "(clé privée : collez le PEM tel quel, ou avec \\n à la place des retours à la ligne).",
 	"settings.secrets.value": "Valeur",
 	"settings.secrets.save": "Enregistrer le secret",
 

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -1374,6 +1374,11 @@
 								{$t('settings.secrets.commonKeys')} <code>github_token</code>, <code>anthropic_oauth_token</code>,
 								<code>anthropic_api_key</code>.
 							</p>
+							<p class="text-xs text-muted-foreground mt-1">
+								{$t('settings.secrets.githubAppHint')} <code>github_app_id</code>,
+								<code>github_app_installation_id</code>, <code>github_app_private_key</code>
+								{$t('settings.secrets.githubAppHintSuffix')}
+							</p>
 						</div>
 						<div>
 							<Label for="sec-value" class="text-xs mb-1">{$t('settings.secrets.value')}</Label>


### PR DESCRIPTION
## Contexte

Le poller GitHub de `wshm-pro` en prod (ns `wshm-pro`) échouait en boucle : `GITHUB_TOKEN` était vide (0 octet) dans le secret K8s, remonté jusqu'à la source Google Secret Manager `wshm-pro-env` qui n'avait jamais eu de valeur pour cette clé depuis sa création.

Plutôt que de simplement régénérer un PAT (même classe de panne possible plus tard : expiration/révocation silencieuse d'un secret statique porté par un compte humain), ce PR ajoute le support d'une authentification **GitHub App** — token d'installation généré à la demande et auto-rafraîchi par `octocrab` à chaque requête, donc rien à renouveler manuellement.

## Changements

- `Config::github_app_auth_optional()` — résout `app_id`/`installation_id`/`private_key` depuis le secret store chiffré (override par repo → global) ou les env vars `WSHM_GITHUB_APP_ID` / `WSHM_GITHUB_APP_INSTALLATION_ID` / `WSHM_GITHUB_APP_PRIVATE_KEY`. Les 3 doivent être présents, sinon traité comme "non configuré" (fallback PAT).
- `github::client::build_octocrab()` — App auth en priorité, sinon PAT existant, sinon anonyme.
- Hot-reload du `GhClient` sans redémarrage quand ces clés sont sauvegardées via l'API secrets existante (déjà utilisée par `github_token`).
- Settings UI : mention des 3 clés dans le formulaire générique existant (pas de nouveau composant), i18n EN/FR. Clé privée : accepte `\n` littéral (unescape) puisqu'un `<input>` mono-ligne ne peut pas porter un vrai saut de ligne PEM.
- 1 test unitaire (précédence de résolution + unescape).

## Non couvert (documenté dans le code)

Le conteneur sandbox de la feature `auto_pr` (génération de PR de fix auto) ne forward encore qu'un `GITHUB_TOKEN` statique — pas de flux d'auth App pour ce conteneur. Sans impact aujourd'hui : aucun repo pollé n'a `auto_pr` activé.

## Tests

- `cargo build` ✓
- `cargo test` ✓ (4/4, dont le nouveau test)
- `cargo clippy` ✓ (aucun nouveau warning)
- `npm run check` (svelte-check) ✓ (aucune nouvelle erreur — 12 pré-existantes confirmées identiques sur `main`)

## Suivi requis pour activer en prod

1. Créer la GitHub App côté org `wshm-dev` (permissions lecture seule : Issues, Pull requests, Metadata, Contents) et l'installer sur les repos suivis.
2. Renseigner les 3 secrets (Settings → Secrets, ou GSM `wshm-pro-env`).
3. Déployer et vérifier que les logs `Polling error` disparaissent.

Voir le PDF de revue joint à la session pour le détail complet (chronologie, comparatif PAT vs App, checklist).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>