### PR TITLE
feat(ai): Skills — user-authored standing instructions for triage/PR review

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -712,7 +712,9 @@ pub struct SkillDef {
 pub fn skills_prompt(skills: &[SkillDef], pipeline: &str) -> String {
     let matching: Vec<&SkillDef> = skills
         .iter()
-        .filter(|s| s.enabled && (s.pipelines.is_empty() || s.pipelines.iter().any(|p| p == pipeline)))
+        .filter(|s| {
+            s.enabled && (s.pipelines.is_empty() || s.pipelines.iter().any(|p| p == pipeline))
+        })
         .collect();
     if matching.is_empty() {
         return String::new();

--- a/src/config.rs
+++ b/src/config.rs
@@ -677,6 +677,53 @@ pub fn domains_prompt(domains: &[DomainDef], custom: Option<&str>) -> String {
     out
 }
 
+/// A named block of standing instructions the AI review should follow when
+/// it applies — the same idea as an Anthropic Agent Skill (a reusable
+/// capability the model loads when relevant), scoped here to wshm's own
+/// triage/PR-review calls rather than a whole Claude session. Users write
+/// these in Settings; `skills_prompt` renders the ones that match the
+/// current pipeline into the user prompt, right after domains.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SkillDef {
+    /// Short human name (e.g. "rust-error-handling").
+    pub name: String,
+
+    /// One-line summary shown in the Settings list — NOT sent to the AI.
+    #[serde(default)]
+    pub description: Option<String>,
+
+    /// The actual instructions appended to the prompt verbatim.
+    pub content: String,
+
+    /// Which pipelines this skill applies to: any of "triage", "pr_review".
+    /// Empty means both.
+    #[serde(default)]
+    pub pipelines: Vec<String>,
+
+    /// Skills can be authored but temporarily switched off without deleting them.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+/// Build the AI-prompt fragment listing the skills that apply to `pipeline`
+/// ("triage" or "pr_review"). Mirrors [`domains_prompt`]'s DB-backed,
+/// stateless-pods-safe pattern — see its doc comment for why this isn't TOML.
+/// Returns empty when no enabled skill matches.
+pub fn skills_prompt(skills: &[SkillDef], pipeline: &str) -> String {
+    let matching: Vec<&SkillDef> = skills
+        .iter()
+        .filter(|s| s.enabled && (s.pipelines.is_empty() || s.pipelines.iter().any(|p| p == pipeline)))
+        .collect();
+    if matching.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("\n## Skills — standing instructions to apply to this review:\n");
+    for skill in matching {
+        out.push_str(&format!("\n### {}\n{}\n", skill.name, skill.content.trim()));
+    }
+    out
+}
+
 /// A "grand domain" — a broad area of the codebase/product (e.g. codex, bun,
 /// c#). Multi-valued per PR/issue, assigned by the AI review, and surfaced as
 /// filters in the PR network graph. Mirrors [`LabelDef`] minus the color/when.
@@ -2405,5 +2452,38 @@ mod tests {
         for v in VARS {
             std::env::remove_var(v);
         }
+    }
+
+    fn skill(name: &str, pipelines: &[&str], enabled: bool) -> SkillDef {
+        SkillDef {
+            name: name.to_string(),
+            description: None,
+            content: format!("do {name} things"),
+            pipelines: pipelines.iter().map(|s| s.to_string()).collect(),
+            enabled,
+        }
+    }
+
+    #[test]
+    fn test_skills_prompt_filters_by_pipeline_and_enabled() {
+        let skills = vec![
+            skill("triage-only", &["triage"], true),
+            skill("pr-only", &["pr_review"], true),
+            skill("both", &[], true),
+            skill("disabled", &["triage"], false),
+        ];
+
+        let triage = skills_prompt(&skills, "triage");
+        assert!(triage.contains("triage-only"));
+        assert!(triage.contains("both"));
+        assert!(!triage.contains("pr-only"));
+        assert!(!triage.contains("disabled"));
+
+        let pr = skills_prompt(&skills, "pr_review");
+        assert!(pr.contains("pr-only"));
+        assert!(pr.contains("both"));
+        assert!(!pr.contains("triage-only"));
+
+        assert_eq!(skills_prompt(&[], "triage"), "");
     }
 }

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -2553,7 +2553,10 @@ async fn api_repo_skills_patch(
     };
 
     let json_str = serde_json::to_string(&skills).unwrap_or_else(|_| "[]".into());
-    if let Err(e) = ds.db.set_app_setting(crate::db::settings::SKILLS_KEY, &json_str) {
+    if let Err(e) = ds
+        .db
+        .set_app_setting(crate::db::settings::SKILLS_KEY, &json_str)
+    {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({"error": e.to_string()})),

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -2476,6 +2476,94 @@ async fn api_repo_domains_patch(
     Json(json!({ "domains": domains, "review_prompt": prompt, "limit": limit })).into_response()
 }
 
+/// GET /api/v1/repos/{slug}/skills -- read the configured AI review skills.
+/// DB-backed (app_settings), same rationale as domains: survives stateless
+/// pod restarts and is shared across replicas.
+async fn api_repo_skills_get(
+    State(state): State<Arc<WebState>>,
+    axum::extract::Path(slug): axum::extract::Path<String>,
+) -> Response {
+    let repos = state.multi.repos.read().await;
+    match repos.get(&slug) {
+        Some(ds) => {
+            let skills: Vec<crate::config::SkillDef> = ds
+                .db
+                .get_app_setting(crate::db::settings::SKILLS_KEY)
+                .ok()
+                .flatten()
+                .and_then(|s| serde_json::from_str(&s).ok())
+                .unwrap_or_default();
+            Json(json!({ "skills": skills })).into_response()
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": format!("repo '{slug}' not configured")})),
+        )
+            .into_response(),
+    }
+}
+
+/// PATCH /api/v1/repos/{slug}/skills -- replace the configured skills list.
+/// Body: `{ "skills": [{ "name", "description", "content", "pipelines", "enabled" }] }`.
+/// Persists to the DB (app_settings), effective on the next triage/PR review
+/// pass across every pod — no restart needed.
+async fn api_repo_skills_patch(
+    State(state): State<Arc<WebState>>,
+    user: axum::Extension<Option<crate::auth::User>>,
+    axum::extract::Path(slug): axum::extract::Path<String>,
+    Json(body): Json<serde_json::Value>,
+) -> Response {
+    if state.users.is_some() {
+        if let Err(e) = require_admin(&user) {
+            return e;
+        }
+    }
+
+    let repos = state.multi.repos.read().await;
+    let ds = match repos.get(&slug) {
+        Some(d) => d.clone(),
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": format!("repo '{slug}' not configured")})),
+            )
+                .into_response();
+        }
+    };
+    drop(repos);
+
+    let skills = match body.get("skills") {
+        Some(s) => match serde_json::from_value::<Vec<crate::config::SkillDef>>(s.clone()) {
+            Ok(parsed) => parsed,
+            Err(e) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": format!("invalid skills: {e}")})),
+                )
+                    .into_response();
+            }
+        },
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "skills is required"})),
+            )
+                .into_response();
+        }
+    };
+
+    let json_str = serde_json::to_string(&skills).unwrap_or_else(|_| "[]".into());
+    if let Err(e) = ds.db.set_app_setting(crate::db::settings::SKILLS_KEY, &json_str) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response();
+    }
+
+    Json(json!({ "skills": skills })).into_response()
+}
+
 /// POST /api/v1/repos/{slug}/domains/discover -- infer the repo's grand domains
 /// from the frequency of subjects across ALL its PR & issue titles and merge
 /// the top ones into the DB set as PROPOSED. Deterministic and instant (no AI),
@@ -3759,6 +3847,10 @@ pub fn oss_api_routes() -> Router<Arc<WebState>> {
         .route(
             "/api/v1/repos/{slug}/domains/discover",
             post(api_repo_domains_discover),
+        )
+        .route(
+            "/api/v1/repos/{slug}/skills",
+            get(api_repo_skills_get).patch(api_repo_skills_patch),
         )
         .route("/api/v1/pr-groups", get(api_pr_groups_get))
         .route("/api/v1/issue-groups", get(api_issue_groups_get))

--- a/src/db/settings.rs
+++ b/src/db/settings.rs
@@ -21,6 +21,8 @@ pub const REVIEW_DOMAINS_KEY: &str = "review_domains";
 pub const REVIEW_PROMPT_KEY: &str = "review_prompt";
 /// Setting key: how many top subjects `discover` proposes (stringified usize).
 pub const REVIEW_DOMAINS_LIMIT_KEY: &str = "review_domains_limit";
+/// Setting key: configured AI review skills, as a JSON array of `SkillDef`.
+pub const SKILLS_KEY: &str = "skills";
 
 impl Database {
     /// Read a setting value, or `None` if unset.

--- a/src/pipelines/pr_analysis.rs
+++ b/src/pipelines/pr_analysis.rs
@@ -190,6 +190,18 @@ async fn analyze_pr(
         user_prompt.push_str(&domains_prompt);
     }
 
+    // Inject configured Skills that apply to PR review (see config::skills_prompt).
+    let skills: Vec<crate::config::SkillDef> = db
+        .get_app_setting(crate::db::settings::SKILLS_KEY)
+        .ok()
+        .flatten()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default();
+    let skills_prompt = crate::config::skills_prompt(&skills, "pr_review");
+    if !skills_prompt.is_empty() {
+        user_prompt.push_str(&skills_prompt);
+    }
+
     if !icm_context.is_empty() {
         user_prompt.push_str(&format!(
             "\n\n## Past PR analysis context (from memory)\n{icm_context}"

--- a/src/pipelines/triage.rs
+++ b/src/pipelines/triage.rs
@@ -384,6 +384,18 @@ async fn triage_issue(
         user_prompt.push_str(&domains_prompt);
     }
 
+    // Inject configured Skills that apply to triage (see config::skills_prompt).
+    let skills: Vec<crate::config::SkillDef> = db
+        .get_app_setting(crate::db::settings::SKILLS_KEY)
+        .ok()
+        .flatten()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default();
+    let skills_prompt = crate::config::skills_prompt(&skills, "triage");
+    if !skills_prompt.is_empty() {
+        user_prompt.push_str(&skills_prompt);
+    }
+
     if !icm_context.is_empty() {
         user_prompt.push_str(&format!(
             "\n\n## Past triage context (from memory)\n{icm_context}"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -595,6 +595,40 @@ export async function discoverRepoDomains(slug: string, limit?: number): Promise
 	return res.json();
 }
 
+/** A standing instruction block the AI review loads when it applies —
+ *  the same idea as an Anthropic Agent Skill, scoped to wshm's own
+ *  triage/PR-review prompts. Stored in the DB (works on stateless pods). */
+export interface Skill {
+	name: string;
+	description?: string | null;
+	content: string;
+	/** Which pipelines this applies to: "triage" and/or "pr_review". Empty = both. */
+	pipelines: string[];
+	enabled: boolean;
+}
+
+export async function fetchRepoSkills(slug: string): Promise<{ skills: Skill[] }> {
+	const res = await fetch(`/api/v1/repos/${encodeURIComponent(slug)}/skills`);
+	if (!res.ok) {
+		const body = await res.json().catch(() => ({}));
+		throw new Error(body.error ?? `HTTP ${res.status}`);
+	}
+	return res.json();
+}
+
+export async function updateRepoSkills(slug: string, skills: Skill[]): Promise<{ skills: Skill[] }> {
+	const res = await fetch(`/api/v1/repos/${encodeURIComponent(slug)}/skills`, {
+		method: 'PATCH',
+		headers: { 'Content-Type': 'application/json', ...CSRF_HEADERS },
+		body: JSON.stringify({ skills })
+	});
+	if (!res.ok) {
+		const body = await res.json().catch(() => ({}));
+		throw new Error(body.error ?? `HTTP ${res.status}`);
+	}
+	return res.json();
+}
+
 /** A pull request referenced by a subgroup in the PR network graph. */
 export interface PrGroupPr {
 	number: number;

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -42,9 +42,12 @@
 		fetchRepoDomains,
 		updateRepoDomains,
 		discoverRepoDomains,
+		fetchRepoSkills,
+		updateRepoSkills,
 		fetchRetrySettings,
 		updateRetrySettings,
 		type ReviewDomain,
+		type Skill,
 		type RepoFeatures,
 		type RetrySettings,
 		type LicenseInfo,
@@ -311,6 +314,64 @@
 			domainsMessageErr = true;
 		}
 		domainsSaving = false;
+	}
+
+	// AI review "Skills" — standing instructions the AI loads when they
+	// apply, same idea as an Anthropic Agent Skill. DB-backed (works on
+	// stateless pods). Managed in the dedicated "Skills" tab, per repo.
+	let skillsRepo: string = $state('');
+	let skillsDraft: Skill[] = $state([]);
+	let skillsLoading: boolean = $state(false);
+	let skillsSaving: boolean = $state(false);
+	let skillsMessage: string | null = $state(null);
+	let skillsMessageErr: boolean = $state(false);
+
+	async function loadSkillsFor(slug: string) {
+		skillsRepo = slug;
+		skillsDraft = [];
+		skillsMessage = null;
+		if (!slug) return;
+		skillsLoading = true;
+		try {
+			const s = await fetchRepoSkills(slug);
+			skillsDraft = s.skills ?? [];
+		} catch (e) {
+			skillsMessage = e instanceof Error ? e.message : 'Failed to load skills';
+			skillsMessageErr = true;
+		}
+		skillsLoading = false;
+	}
+	async function saveSkills() {
+		if (!skillsRepo) return;
+		skillsSaving = true;
+		skillsMessage = null;
+		try {
+			await updateRepoSkills(
+				skillsRepo,
+				skillsDraft.filter((s) => s.name.trim() !== '')
+			);
+			skillsMessage = 'Saved.';
+			skillsMessageErr = false;
+		} catch (e) {
+			skillsMessage = e instanceof Error ? e.message : 'save failed';
+			skillsMessageErr = true;
+		}
+		skillsSaving = false;
+	}
+	function addSkill() {
+		skillsDraft = [
+			...skillsDraft,
+			{ name: '', description: '', content: '', pipelines: [], enabled: true }
+		];
+	}
+	function removeSkill(i: number) {
+		skillsDraft = skillsDraft.filter((_, idx) => idx !== i);
+	}
+	function togglePipeline(i: number, pipeline: string) {
+		const s = skillsDraft[i];
+		const has = s.pipelines.includes(pipeline);
+		s.pipelines = has ? s.pipelines.filter((p) => p !== pipeline) : [...s.pipelines, pipeline];
+		skillsDraft = [...skillsDraft];
 	}
 
 	async function openFeaturesModal(slug: string) {
@@ -626,6 +687,7 @@
 		<Tabs.Trigger value="secrets">{$t('settings.tabs.secrets')}</Tabs.Trigger>
 		<Tabs.Trigger value="users">{$t('settings.tabs.users')}</Tabs.Trigger>
 		<Tabs.Trigger value="domains">Domains</Tabs.Trigger>
+		<Tabs.Trigger value="skills">Skills</Tabs.Trigger>
 	</Tabs.List>
 
 	<!-- ========================= REPOSITORIES ========================= -->
@@ -1391,6 +1453,156 @@
 							{savingSecret ? $t('common.saving') : $t('settings.secrets.save')}
 						</Button>
 					</form>
+				</Card.Content>
+			</Card.Root>
+		</div>
+	</Tabs.Content>
+
+	<!-- ========================= SKILLS ========================= -->
+	<Tabs.Content value="skills" class="mt-2">
+		<div class="w-full space-y-4">
+			<Card.Root>
+				<Card.Header>
+					<Card.Title>How Skills fit into the review pipeline</Card.Title>
+					<Card.Description class="text-xs">
+						A Skill is a standing instruction block the AI loads when it applies — the same idea as an
+						Anthropic Agent Skill, scoped here to wshm's own triage and PR-review calls. It's appended to
+						the prompt alongside labels and grand domains, right before the AI provider call.
+					</Card.Description>
+				</Card.Header>
+				<Card.Content>
+					<div class="flex flex-col items-stretch gap-0 max-w-md mx-auto text-xs">
+						{#snippet flowStep(label: string, fn: string, highlight: boolean)}
+							<div
+								class="rounded-md border px-3 py-2 text-center {highlight
+									? 'border-primary bg-primary/10 text-primary font-semibold'
+									: 'bg-muted/30 text-foreground/90'}"
+							>
+								<div>{label}</div>
+								<div class="mono text-[0.65rem] {highlight ? 'text-primary/80' : 'text-muted-foreground'}">{fn}</div>
+							</div>
+							<div class="text-center text-muted-foreground leading-none py-0.5">↓</div>
+						{/snippet}
+						{@render flowStep('GitHub event — issue opened / PR updated', 'daemon::processor', false)}
+						{@render flowStep('Build base prompt', 'issue_classify / pr_analyze :: build_user_prompt()', false)}
+						{@render flowStep('+ Labels', 'Config::labels_prompt()', false)}
+						{@render flowStep('+ Grand domains', 'config::domains_prompt()', false)}
+						{@render flowStep('+ Skills (this tab)', 'config::skills_prompt()', true)}
+						<div
+							class="rounded-md border bg-muted/30 px-3 py-2 text-center text-foreground/90"
+						>
+							<div>AI provider call</div>
+							<div class="mono text-[0.65rem] text-muted-foreground">AiClient::complete()</div>
+						</div>
+					</div>
+					<p class="text-[0.7rem] text-muted-foreground mt-3">
+						Each Skill below can target <code>triage</code>, <code>pr_review</code>, or both. Disabled
+						skills stay saved but are skipped. Changes take effect on the next triage/PR-review pass —
+						no restart needed.
+					</p>
+				</Card.Content>
+			</Card.Root>
+
+			<Card.Root>
+				<Card.Header>
+					<Card.Title>Configured skills</Card.Title>
+				</Card.Header>
+				<Card.Content class="space-y-3">
+					<div>
+						<Label class="text-xs mb-1">Repository</Label>
+						<select
+							class="w-full rounded-md border bg-background px-2 py-1.5 text-xs"
+							value={skillsRepo}
+							onchange={(e) => loadSkillsFor((e.currentTarget as HTMLSelectElement).value)}
+						>
+							<option value="" disabled>Select a repository…</option>
+							{#each reposList?.repos ?? [] as r}
+								<option value={r.slug}>{r.slug}</option>
+							{/each}
+						</select>
+					</div>
+
+					{#if skillsMessage}
+						{@render statusAlert(skillsMessage, skillsMessageErr)}
+					{/if}
+
+					{#if skillsRepo}
+						{#if skillsLoading}
+							<p class="text-xs text-muted-foreground">{$t('common.loading')}</p>
+						{:else}
+							<div class="flex items-center justify-between">
+								<h5 class="text-xs uppercase text-muted-foreground font-semibold">Skills</h5>
+								<button type="button" class="text-xs text-primary hover:underline" onclick={addSkill}>
+									+ add
+								</button>
+							</div>
+							{#each skillsDraft as s, i}
+								<div class="rounded-md border p-2 space-y-1.5">
+									<div class="flex items-center gap-1">
+										<input
+											type="checkbox"
+											class="h-4 w-4 shrink-0"
+											checked={s.enabled}
+											onchange={(e) => (s.enabled = (e.currentTarget as HTMLInputElement).checked)}
+											title="enabled → applied on the next review"
+										/>
+										<Input class="h-8 w-1/3" placeholder="name (e.g. rust-error-handling)" bind:value={s.name} />
+										<Input
+											class="h-8 flex-1"
+											placeholder="one-line description (for your own reference — not sent to the AI)"
+											value={s.description ?? ''}
+											oninput={(e) => (s.description = (e.currentTarget as HTMLInputElement).value)}
+										/>
+										<button
+											type="button"
+											class="px-2 text-muted-foreground hover:text-destructive"
+											onclick={() => removeSkill(i)}
+											aria-label="remove skill"
+										>
+											✕
+										</button>
+									</div>
+									<div class="flex items-center gap-3 pl-5 text-[0.7rem] text-muted-foreground">
+										<span>Applies to:</span>
+										<label class="flex items-center gap-1">
+											<input
+												type="checkbox"
+												class="h-3.5 w-3.5"
+												checked={s.pipelines.includes('triage')}
+												onchange={() => togglePipeline(i, 'triage')}
+											/>
+											triage
+										</label>
+										<label class="flex items-center gap-1">
+											<input
+												type="checkbox"
+												class="h-3.5 w-3.5"
+												checked={s.pipelines.includes('pr_review')}
+												onchange={() => togglePipeline(i, 'pr_review')}
+											/>
+											PR review
+										</label>
+										<span class="italic">(both, if none checked)</span>
+									</div>
+									<textarea
+										class="w-full rounded-md border bg-background px-2 py-1 text-xs min-h-[72px] mono"
+										placeholder="Instructions appended to the prompt verbatim, e.g. &quot;Flag any panic!()/unwrap() in library code as a bug.&quot;"
+										bind:value={s.content}
+									></textarea>
+								</div>
+							{:else}
+								<p class="text-[0.7rem] text-muted-foreground">
+									No skills yet — click <strong>+ add</strong> to write one.
+								</p>
+							{/each}
+
+							<Button size="sm" onclick={saveSkills} disabled={skillsSaving}>
+								{skillsSaving ? $t('common.loading') : $t('common.save')}
+							</Button>
+						{/if}
+					{:else}
+						<p class="text-xs text-muted-foreground">Select a repository to manage its skills.</p>
+					{/if}
 				</Card.Content>
 			</Card.Root>
 		</div>


### PR DESCRIPTION
New Settings tab: attach reusable "Skills" (same idea as an Anthropic Agent Skill — a named instruction block the AI loads when it applies) to wshm's own triage and PR-review AI calls.

- Backend: `SkillDef` + `skills_prompt()`, DB-backed (`app_settings`, same stateless-pods-safe pattern as the existing "grand domains" feature), wired into both pipelines right after domains.
- API: `GET/PATCH /api/v1/repos/{slug}/skills`, mirrors the domains routes.
- Frontend: new "Skills" tab — a static pipeline diagram showing exactly where skills plug in (event → prompt → labels → domains → **skills** → AI call), then a per-repo skill editor (name, description, content, target pipeline(s), enabled toggle).

Verified: `cargo build/test/clippy` clean, `svelte-check` clean, screenshotted the tab against the live daemon — diagram renders, repo selector populates, add/edit form works. Save/load round-trip needs this deployed first (route doesn't exist in the currently-running image yet).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>