### PR TITLE
fix(ui): table overflow hiding filters on Issues/PRs/Triage

### DIFF
--- a/web/src/routes/issues/+page.svelte
+++ b/web/src/routes/issues/+page.svelte
@@ -9,6 +9,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import * as Table from '$lib/components/ui/table';
 	import * as Dialog from '$lib/components/ui/dialog';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { colorConfig, prStatusBorder, priorityColor, categoryColor, type ColorConfig } from '$lib/colors';
 	import IssueDetail from '$lib/components/IssueDetail.svelte';
 	import TablePagination from '$lib/components/TablePagination.svelte';
@@ -140,7 +141,7 @@
 	</Card.Root>
 {:else}
 	<div class="rounded-lg border">
-		<Table.Root class="w-full">
+		<Table.Root class="w-full table-fixed">
 			<Table.Header class="text-xs uppercase text-muted-foreground">
 				<Table.Row>
 					<Table.Head class="cursor-pointer select-none px-2 py-1.5 w-[60px]" onclick={(e: MouseEvent) => handleSort('number', e)}>
@@ -181,14 +182,28 @@
 						onclick={() => openIssue(issue)}
 					>
 						<Table.Cell class="px-2 py-1.5 mono text-foreground">{issue.number}</Table.Cell>
-						<Table.Cell class="px-2 py-1.5 truncate text-foreground">{issue.title}</Table.Cell>
+						<Table.Cell class="px-2 py-1.5 text-foreground">
+							<Tooltip.Provider>
+								<Tooltip.Root>
+									<Tooltip.Trigger>
+										{#snippet child({ props })}
+											<span {...props} class="block truncate">{issue.title}</span>
+										{/snippet}
+									</Tooltip.Trigger>
+									<Tooltip.Content class="max-w-sm text-xs leading-snug">{issue.title}</Tooltip.Content>
+								</Tooltip.Root>
+							</Tooltip.Provider>
+						</Table.Cell>
 						<Table.Cell class="px-2 py-1.5 text-foreground text-xs">
 							{issue.pr_status === 'pr_ready' ? 'PR ready' : issue.pr_status === 'has_pr' ? 'PR open' : 'No PR'}
 						</Table.Cell>
-						<Table.Cell class="px-2 py-1.5">
-							{#each issue.labels as label}
+						<Table.Cell class="px-2 py-1.5 overflow-hidden whitespace-nowrap">
+							{#each issue.labels.slice(0, 2) as label}
 								<Badge variant="outline" class="bg-primary/15 text-primary mr-1">{label}</Badge>
 							{/each}
+							{#if issue.labels.length > 2}
+								<Badge variant="outline" class="text-muted-foreground">+{issue.labels.length - 2}</Badge>
+							{/if}
 						</Table.Cell>
 						<Table.Cell class="px-2 py-1.5 text-foreground">{issue.priority ?? '-'}</Table.Cell>
 						<Table.Cell class="px-2 py-1.5 text-foreground">{issue.category ?? '-'}</Table.Cell>

--- a/web/src/routes/prs/+page.svelte
+++ b/web/src/routes/prs/+page.svelte
@@ -8,6 +8,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import * as Table from '$lib/components/ui/table';
 	import * as Dialog from '$lib/components/ui/dialog';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 	import PrDetail from '$lib/components/PrDetail.svelte';
 	import TablePagination from '$lib/components/TablePagination.svelte';
 	import FilterSelect from '$lib/components/FilterSelect.svelte';
@@ -149,7 +150,7 @@
 	</div>
 {:else}
 	<div class="rounded-lg border">
-		<Table.Root class="w-full">
+		<Table.Root class="w-full table-fixed">
 			<Table.Header class="text-xs uppercase text-muted-foreground">
 				<Table.Row>
 					<Table.Head class="cursor-pointer select-none px-2 py-1.5 w-[60px]" onclick={(e: MouseEvent) => handleSort('number', e)}>
@@ -192,7 +193,18 @@
 				{#each sorted as pr}
 					<Table.Row class="cursor-pointer" onclick={() => openPr(pr)}>
 						<Table.Cell class="px-2 py-1.5 mono">{pr.number}</Table.Cell>
-						<Table.Cell class="px-2 py-1.5 truncate">{pr.title}</Table.Cell>
+						<Table.Cell class="px-2 py-1.5">
+							<Tooltip.Provider>
+								<Tooltip.Root>
+									<Tooltip.Trigger>
+										{#snippet child({ props })}
+											<span {...props} class="block truncate">{pr.title}</span>
+										{/snippet}
+									</Tooltip.Trigger>
+									<Tooltip.Content class="max-w-sm text-xs leading-snug">{pr.title}</Tooltip.Content>
+								</Tooltip.Root>
+							</Tooltip.Provider>
+						</Table.Cell>
 						<Table.Cell class="px-2 py-1.5">
 							<Badge variant="outline" class={pr.state === 'open' ? GREEN_BADGE : RED_BADGE}>{pr.state}</Badge>
 						</Table.Cell>

--- a/web/src/routes/triage/+page.svelte
+++ b/web/src/routes/triage/+page.svelte
@@ -8,6 +8,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { Input } from '$lib/components/ui/input';
 	import * as Table from '$lib/components/ui/table';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 	import TablePagination from '$lib/components/TablePagination.svelte';
 	import FilterSelect from '$lib/components/FilterSelect.svelte';
 
@@ -118,7 +119,7 @@
 	</div>
 {:else}
 	<div class="rounded-lg border">
-		<Table.Root class="w-full">
+		<Table.Root class="w-full table-fixed">
 			<Table.Header class="text-xs uppercase text-muted-foreground">
 				<Table.Row>
 					<Table.Head class="cursor-pointer select-none px-2 py-1.5 w-[70px]" onclick={(e: MouseEvent) => handleSort('issue_number', e)}>
@@ -133,7 +134,8 @@
 					<Table.Head class="cursor-pointer select-none px-2 py-1.5 w-[90px]" onclick={(e: MouseEvent) => handleSort('priority', e)}>
 						Priority <span class={sortArrowClass(sortColumns, 'priority')}>{sortArrow(sortColumns, 'priority')}</span>{#if sortIndex(sortColumns, 'priority') > 0}<span class="text-[0.625rem] text-primary ml-0.5">{sortIndex(sortColumns, 'priority')}</span>{/if}
 					</Table.Head>
-					<Table.Head class="cursor-pointer select-none px-2 py-1.5" onclick={(e: MouseEvent) => handleSort('acted_at', e)}>
+					<Table.Head class="px-2 py-1.5">Summary</Table.Head>
+					<Table.Head class="cursor-pointer select-none px-2 py-1.5 w-[110px]" onclick={(e: MouseEvent) => handleSort('acted_at', e)}>
 						Acted At <span class={sortArrowClass(sortColumns, 'acted_at')}>{sortArrow(sortColumns, 'acted_at')}</span>{#if sortIndex(sortColumns, 'acted_at') > 0}<span class="text-[0.625rem] text-primary ml-0.5">{sortIndex(sortColumns, 'acted_at')}</span>{/if}
 					</Table.Head>
 				</Table.Row>
@@ -144,6 +146,7 @@
 					<Table.Cell class="px-2 py-1"><FilterSelect bind:value={filters.category} options={categoryOptions} /></Table.Cell>
 					<Table.Cell class="px-2 py-1"><Input type="text" bind:value={filters.confidence} placeholder=">85" class="h-7 px-1 text-xs" /></Table.Cell>
 					<Table.Cell class="px-2 py-1"><FilterSelect bind:value={filters.priority} options={priorityOptions} /></Table.Cell>
+					<Table.Cell class="px-2 py-1"></Table.Cell>
 					<Table.Cell class="px-2 py-1"><Input type="text" bind:value={filters.acted_at} placeholder="filter..." class="h-7 px-1 text-xs" /></Table.Cell>
 				</Table.Row>
 				{#each sorted as result}
@@ -156,13 +159,29 @@
 							<span class="mono font-semibold {confidenceColor(result.confidence)}">{(result.confidence * 100).toFixed(0)}%</span>
 						</Table.Cell>
 						<Table.Cell class="px-2 py-1.5">{result.priority}</Table.Cell>
+						<Table.Cell class="px-2 py-1.5 text-muted-foreground">
+							{#if result.summary}
+								<Tooltip.Provider>
+									<Tooltip.Root>
+										<Tooltip.Trigger>
+											{#snippet child({ props })}
+												<span {...props} class="block truncate">{result.summary}</span>
+											{/snippet}
+										</Tooltip.Trigger>
+										<Tooltip.Content class="max-w-sm text-xs leading-snug">{result.summary}</Tooltip.Content>
+									</Tooltip.Root>
+								</Tooltip.Provider>
+							{:else}
+								-
+							{/if}
+						</Table.Cell>
 						<Table.Cell class="px-2 py-1.5 text-muted-foreground" title={result.acted_at ? exactTime(result.acted_at) : undefined}>
 							{result.acted_at ? timeAgo(result.acted_at) : 'Not acted'}
 						</Table.Cell>
 					</Table.Row>
 				{:else}
 					<Table.Row>
-						<Table.Cell colspan={5} class="text-center text-muted-foreground py-8">
+						<Table.Cell colspan={6} class="text-center text-muted-foreground py-8">
 							{#if loading}
 								Loading…
 							{:else}


### PR DESCRIPTION
## Summary
- Issues, Pull Requests and Triage tables used `table-layout: auto`, so the unbounded Title column (and Labels' inline badge list) stretched way past the viewport on live data — measured 2287px wide on a 1440px viewport — pushing Priority/Category/Age and their filter inputs off-screen with no visual indication of horizontal scroll.
- Switched all three `<Table.Root>` to `table-fixed` so declared `w-[Npx]` column widths are actually enforced.
- Issues: capped the Labels cell to the first 2 badges + a `+N` badge instead of rendering every label inline (that alone was ~860px wide on some rows).
- Issues/PRs: added a hover tooltip (same pattern as the Summary page fix) on the now-truncated Title cell so the full text is still one hover away.
- Triage: surfaced the `summary` field (the AI's actual classification reasoning) in a new column — it was already returned by the API but never rendered anywhere, which was the real "manque d'informations" gap on that page. Gave `Acted At` a fixed width so Summary gets the flexible remaining space.

## Verification
Screenshot-verified against live production data (via `kubectl port-forward` + vite dev proxy with the real trusted-proxy headers) at 1440x900:
- Issues: all 7 columns + filter row visible, `getComputedStyle(table).tableLayout === "fixed"`, table width 1206px (was 2287px auto).
- Pull Requests: all 8 columns + filters visible without scroll.
- Triage: new Summary column renders, tooltip works on hover, table still fits.
- `npm run check` clean on the 3 edited files (4 pre-existing unrelated errors in vite.config.ts / actions page untouched).
- `npm run build` succeeds.

## Test plan
- [ ] Deploy and re-check the 3 pages live at full viewport widths (1440 and narrower) to confirm no regression on smaller screens.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01HdSXAhjyuojtV5WcXZ3Un8