### PR TITLE
fix(i18n): default locale to English, not browser/OS language

### DIFF
--- a/web/src/lib/i18n/index.ts
+++ b/web/src/lib/i18n/index.ts
@@ -45,10 +45,13 @@ function detectInitial(): Locale {
 		const saved = localStorage.getItem('wshm-locale') as Locale | null;
 		if (saved && KNOWN.includes(saved)) return saved;
 	} catch { /* ignore */ }
-	if (typeof navigator !== 'undefined' && navigator.language) {
-		const tag = navigator.language.toLowerCase().split('-')[0] as Locale;
-		if (KNOWN.includes(tag)) return tag;
-	}
+	// No language picker exists in the UI yet, and only a handful of routes
+	// (Settings, Login, and — via the wshm-pro overlay — PR/Issue Insights)
+	// are wired to `t()` while the rest of the app is hardcoded English —
+	// so auto-switching those few pages off a browser/OS locale produced a
+	// jarring mixed-language UI with no way to opt back out. Default to
+	// English until a real language switcher lands; an explicit choice
+	// (saved above) still always wins.
 	return 'en';
 }
 


### PR DESCRIPTION
Found while surveying wshm-pro pages: PR Insights and Issue Insights rendered entirely in French (screenshots in the wshm-pro PR that first 'fixed' this). Traced it back here — those two pages get their `i18n` module copied verbatim from this repo by wshm-pro's Docker build overlay, so the actual bug lives in this file, not wshm-pro's copy. Settings and Login in this OSS app are affected the same way.

Root cause: only Settings/Login use `t()` — everything else is hardcoded English. `detectInitial()` fell back to `navigator.language` when no locale was saved, so those pages alone followed the browser/OS language with no way to opt back out (no picker exists in the UI).

Fix: default to English unless a locale was explicitly saved (still respected).