### PR TITLE
feat(sync): fetch and store real CI status for open PRs

### DIFF
--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -125,6 +125,19 @@ pub trait DatabaseBackend: Send + Sync {
         Ok(0)
     }
 
+    /// Apply freshly-synced CI statuses (PR number → state) to open PRs;
+    /// PRs absent from the map get their status cleared. Backs the CI
+    /// column on the PRs and Merge Queue views. Default no-op returning 0
+    /// so backends without the column keep compiling — real backends
+    /// override it.
+    fn set_ci_statuses(
+        &self,
+        statuses: &std::collections::HashMap<u64, Option<String>>,
+    ) -> Result<u64> {
+        let _ = statuses;
+        Ok(0)
+    }
+
     /// Read a runtime K/V setting (DB-backed so it survives on stateless pods
     /// and is shared across replicas). Default: unset. Real backends override.
     fn get_app_setting(&self, key: &str) -> Result<Option<String>> {
@@ -402,6 +415,13 @@ impl DatabaseBackend for super::Database {
 
     fn set_pull_reactions(&self, reactions: &std::collections::HashMap<u64, u32>) -> Result<u64> {
         self.set_pull_reactions(reactions)
+    }
+
+    fn set_ci_statuses(
+        &self,
+        statuses: &std::collections::HashMap<u64, Option<String>>,
+    ) -> Result<u64> {
+        self.set_ci_statuses(statuses)
     }
 
     fn get_app_setting(&self, key: &str) -> Result<Option<String>> {

--- a/src/db/pulls.rs
+++ b/src/db/pulls.rs
@@ -178,6 +178,39 @@ impl Database {
         self.with_conn(|conn| get_pull(conn, number))
     }
 
+    /// Apply freshly-synced CI statuses to open PRs; PRs absent from the map
+    /// (no commit status/check run reported) get their status cleared, same
+    /// "absence clears it" contract as `set_review_decisions`. Backs the CI
+    /// column on the PRs and Merge Queue views. Returns the number of PRs
+    /// whose status changed.
+    pub fn set_ci_statuses(
+        &self,
+        statuses: &std::collections::HashMap<u64, Option<String>>,
+    ) -> Result<u64> {
+        self.with_conn(|conn| {
+            let tx = conn.unchecked_transaction()?;
+            let mut changed = 0u64;
+            {
+                let mut current =
+                    tx.prepare("SELECT number, ci_status FROM pull_requests WHERE state = 'open'")?;
+                let rows: Vec<(u64, Option<String>)> = current
+                    .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?
+                    .collect::<Result<_, _>>()?;
+                let mut update =
+                    tx.prepare("UPDATE pull_requests SET ci_status = ?1 WHERE number = ?2")?;
+                for (number, old) in rows {
+                    let new = statuses.get(&number).cloned().unwrap_or(None);
+                    if new != old {
+                        update.execute(params![new, number])?;
+                        changed += 1;
+                    }
+                }
+            }
+            tx.commit()?;
+            Ok(changed)
+        })
+    }
+
     /// Apply freshly-synced 👍 (+1) reaction counts to open PRs. Mirrors
     /// `set_review_decisions`: maintained by a dedicated sync pass, NOT the
     /// upsert (GitHub's `/pulls` list carries no reactions). `reactions` maps

--- a/src/github/pulls.rs
+++ b/src/github/pulls.rs
@@ -224,6 +224,64 @@ impl Client {
         Ok(map)
     }
 
+    /// Fetch combined CI status for every open PR, number → state.
+    ///
+    /// GitHub's `/pulls` list carries no CI info, and there's no per-PR
+    /// combined-status endpoint worth calling N times over — mirrors
+    /// `fetch_review_decisions`: three `status:*` Search API qualifiers,
+    /// same endpoint/retry/1000-result cap, no extra request budget spent
+    /// per PR. A PR matching none of the three (no commit statuses/check
+    /// runs reported yet) is simply absent from the map.
+    pub async fn fetch_ci_statuses(
+        &self,
+    ) -> Result<std::collections::HashMap<u64, Option<String>>> {
+        let mut map = std::collections::HashMap::new();
+        for (qualifier, state) in [
+            ("status:success", "success"),
+            ("status:failure", "failure"),
+            ("status:pending", "pending"),
+        ] {
+            let query = format!(
+                "repo:{}/{} is:pr is:open {qualifier}",
+                self.owner, self.repo
+            );
+            let mut page = 1u32;
+            loop {
+                let url = format!(
+                    "https://api.github.com/search/issues?q={}&per_page=100&page={page}",
+                    urlencoding::encode(&query)
+                );
+                let body = crate::retry::with_retry("github: search ci statuses", || async {
+                    let resp = self
+                        .octocrab
+                        ._get(&url)
+                        .await
+                        .context("Failed to search CI statuses")?;
+                    self.octocrab
+                        .body_to_string(resp)
+                        .await
+                        .context("Failed to read search response body")
+                })
+                .await?;
+                let json: serde_json::Value = serde_json::from_str(&body)
+                    .context("Failed to parse ci-status search response")?;
+                let items = json["items"].as_array().cloned().unwrap_or_default();
+                let n = items.len();
+                for item in &items {
+                    if let Some(number) = item["number"].as_u64() {
+                        map.insert(number, Some(state.to_string()));
+                    }
+                }
+                // The Search API caps results at 1000 (10 pages of 100).
+                if n < 100 || page >= 10 {
+                    break;
+                }
+                page += 1;
+            }
+        }
+        Ok(map)
+    }
+
     /// Fetch pull requests filtered by state ("open", "closed", or "all").
     /// Used by incremental sync to fetch only open PRs (saves bandwidth).
     pub async fn fetch_pulls_by_state(&self, state: &str) -> Result<Vec<PullRequest>> {

--- a/src/github/sync.rs
+++ b/src/github/sync.rs
@@ -208,6 +208,19 @@ async fn sync_pulls_finalize(
         Err(e) => tracing::warn!("Failed to fetch PR reactions: {e}"),
     }
 
+    // CI status backs the CI column on the PRs and Merge Queue views — never
+    // populated by the /pulls list itself. Same best-effort contract as
+    // review decisions/reactions: a Search API failure leaves prior statuses
+    // untouched.
+    match gh.fetch_ci_statuses().await {
+        Ok(statuses) => match db.set_ci_statuses(&statuses) {
+            Ok(0) => {}
+            Ok(n) => info!("CI statuses updated for {n} PR(s)"),
+            Err(e) => tracing::warn!("Failed to store CI statuses: {e}"),
+        },
+        Err(e) => tracing::warn!("Failed to fetch CI statuses: {e}"),
+    }
+
     let now = Utc::now().to_rfc3339();
     db.update_sync_entry("pulls", &now, None)?;
 


### PR DESCRIPTION
Found while investigating why the Merge Queue page's SCORE column was flat `10` for every single PR and CI/RISK columns were always empty.

RISK is empty by design (`analyze_prs` is off for these repos — that's a Pro feature toggle, not a bug). But CI status is a different story: `pull_requests.ci_status` has existed in the schema forever and is rendered on both the PRs and Merge Queue pages, but `github/pulls.rs::parse_pull()` hardcodes `ci_status: None` on every single PR — nothing anywhere ever populates it. Confirmed live against prod: every open PR across both tracked repos shows CI as `-`.

This flattens the Merge Queue's score too, since it only awards +10 for `ci_status == Some("success")` — with that always None, every PR's score reduces to whatever the staleness bonus alone produces (capped at 10), which is exactly the flat `10` observed.

Fix mirrors the existing `review_decision`/`reactions` pattern: a dedicated best-effort sync pass using three Search API `status:*` qualifiers (same endpoint/retry/1000-result-cap as `fetch_review_decisions`), stored via a new `set_ci_statuses` on `DatabaseBackend` (default no-op so other backends keep compiling).

## Verification
- `cargo build` + `cargo test --lib` (83 passed) + `cargo clippy --lib` all clean.
- wshm-pro's Postgres backend override builds clean against this trait signature (companion PR incoming).
