### PR TITLE
fix(triage): issue-number link goes to the specific issue, not the list

### DIFF
--- a/web/src/routes/triage/+page.svelte
+++ b/web/src/routes/triage/+page.svelte
@@ -151,7 +151,7 @@
 				</Table.Row>
 				{#each sorted as result}
 					<Table.Row>
-						<Table.Cell class="px-2 py-1.5 mono"><a href="/issues">#{result.issue_number}</a></Table.Cell>
+						<Table.Cell class="px-2 py-1.5 mono"><a href="/issues/{result.issue_number}" class="text-primary hover:underline">#{result.issue_number}</a></Table.Cell>
 						<Table.Cell class="px-2 py-1.5">
 							<Badge variant={categoryBadge(result.category).variant} class={categoryBadge(result.category).class}>{result.category}</Badge>
 						</Table.Cell>


### PR DESCRIPTION
Reported: clicking an issue number on /triage always lands on the generic /issues list, not the issue it was actually about — the href never interpolated `result.issue_number` at all (`<a href="/issues">`). Wired in the existing `/issues/{number}` dedicated single-issue page (already used elsewhere by the Issues page's detail-modal 'Open full page' link).