### PR TITLE
feat(dashboard): clickable stat cards + weekly trend, conflicts pre-filter

### DIFF
--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -1060,7 +1060,10 @@ struct StatusResponse {
 /// String comparison works because RFC3339 timestamps sort lexicographically
 /// by time — no parsing needed for a "since N days ago" cutoff.
 fn count_created_since<T>(items: &[T], created_at: impl Fn(&T) -> &str, cutoff: &str) -> usize {
-    items.iter().filter(|item| created_at(item) >= cutoff).count()
+    items
+        .iter()
+        .filter(|item| created_at(item) >= cutoff)
+        .count()
 }
 
 #[derive(Serialize)]

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -1037,6 +1037,8 @@ struct RepoStatus {
     open_prs: usize,
     unanalyzed: usize,
     conflicts: usize,
+    issues_new_7d: usize,
+    prs_new_7d: usize,
     last_sync: Option<String>,
     apply: bool,
 }
@@ -1048,8 +1050,17 @@ struct StatusResponse {
     open_prs: usize,
     unanalyzed: usize,
     conflicts: usize,
+    issues_new_7d: usize,
+    prs_new_7d: usize,
     last_sync: Option<String>,
     repos: Vec<RepoStatus>,
+}
+
+/// Count items whose `created_at` (RFC3339) falls within the last 7 days.
+/// String comparison works because RFC3339 timestamps sort lexicographically
+/// by time — no parsing needed for a "since N days ago" cutoff.
+fn count_created_since<T>(items: &[T], created_at: impl Fn(&T) -> &str, cutoff: &str) -> usize {
+    items.iter().filter(|item| created_at(item) >= cutoff).count()
 }
 
 #[derive(Serialize)]
@@ -1079,9 +1090,12 @@ async fn api_status(
         open_prs: 0,
         unanalyzed: 0,
         conflicts: 0,
+        issues_new_7d: 0,
+        prs_new_7d: 0,
         last_sync: None,
         repos: Vec::new(),
     };
+    let week_ago = (chrono::Utc::now() - chrono::Duration::days(7)).to_rfc3339();
 
     // Snapshot the repo map and drop the read guard before the per-repo
     // blocking DB work, so the RwLock is not held across the whole scan
@@ -1107,6 +1121,9 @@ async fn api_status(
             .filter(|pr| pr.mergeable == Some(false))
             .count();
 
+        let issues_new_7d = count_created_since(&open_issues, |i| i.created_at.as_str(), &week_ago);
+        let prs_new_7d = count_created_since(&open_prs, |p| p.created_at.as_str(), &week_ago);
+
         let last_sync = ds
             .db
             .get_sync_entry("issues")
@@ -1121,6 +1138,8 @@ async fn api_status(
             open_prs: open_prs.len(),
             unanalyzed: unanalyzed.len(),
             conflicts,
+            issues_new_7d,
+            prs_new_7d,
             last_sync: last_sync.clone(),
             apply: ds.apply(),
         };
@@ -1130,6 +1149,8 @@ async fn api_status(
         resp.open_prs += repo_status.open_prs;
         resp.unanalyzed += repo_status.unanalyzed;
         resp.conflicts += repo_status.conflicts;
+        resp.issues_new_7d += repo_status.issues_new_7d;
+        resp.prs_new_7d += repo_status.prs_new_7d;
 
         // Use the most recent sync time across repos
         if let Some(ref ls) = last_sync {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -53,6 +53,8 @@ export interface Status {
 	open_prs: number;
 	unanalyzed: number;
 	conflicts: number;
+	issues_new_7d: number;
+	prs_new_7d: number;
 	last_sync: string | null;
 	repos: RepoInfo[];
 }

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -44,32 +44,46 @@
 	</Card.Root>
 {:else}
 	<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-		<Card.Root class="text-center">
-			<Card.Content>
-				<div class="text-xs uppercase tracking-wider text-muted-foreground mb-2">Open Issues</div>
-				<div class="text-3xl font-bold text-foreground mono">{status?.open_issues ?? '--'}</div>
-			</Card.Content>
-		</Card.Root>
-		<Card.Root class="text-center">
-			<Card.Content>
-				<div class="text-xs uppercase tracking-wider text-muted-foreground mb-2">Open PRs</div>
-				<div class="text-3xl font-bold text-foreground mono">{status?.open_prs ?? '--'}</div>
-			</Card.Content>
-		</Card.Root>
-		<Card.Root class="text-center">
-			<Card.Content>
-				<div class="text-xs uppercase tracking-wider text-muted-foreground mb-2">Untriaged</div>
-				<div class="text-3xl font-bold text-foreground mono">{status?.untriaged ?? '--'}</div>
-			</Card.Content>
-		</Card.Root>
-		<Card.Root class="text-center">
-			<Card.Content>
-				<div class="text-xs uppercase tracking-wider text-muted-foreground mb-2">Conflicts</div>
-				<div
-					class="text-3xl font-bold mono {status?.conflicts ? 'text-red-600 dark:text-red-400' : 'text-foreground'}"
-				>{status?.conflicts ?? '--'}</div>
-			</Card.Content>
-		</Card.Root>
+		<a href="/issues" class="block">
+			<Card.Root class="text-center transition-colors hover:border-primary/50 hover:bg-accent/30">
+				<Card.Content>
+					<div class="text-xs uppercase tracking-wider text-muted-foreground mb-2">Open Issues</div>
+					<div class="text-3xl font-bold text-foreground mono">{status?.open_issues ?? '--'}</div>
+					{#if status && status.issues_new_7d > 0}
+						<div class="text-xs text-green-600 dark:text-green-400 mt-1">+{status.issues_new_7d} this week</div>
+					{/if}
+				</Card.Content>
+			</Card.Root>
+		</a>
+		<a href="/prs" class="block">
+			<Card.Root class="text-center transition-colors hover:border-primary/50 hover:bg-accent/30">
+				<Card.Content>
+					<div class="text-xs uppercase tracking-wider text-muted-foreground mb-2">Open PRs</div>
+					<div class="text-3xl font-bold text-foreground mono">{status?.open_prs ?? '--'}</div>
+					{#if status && status.prs_new_7d > 0}
+						<div class="text-xs text-green-600 dark:text-green-400 mt-1">+{status.prs_new_7d} this week</div>
+					{/if}
+				</Card.Content>
+			</Card.Root>
+		</a>
+		<a href="/issues" class="block">
+			<Card.Root class="text-center transition-colors hover:border-primary/50 hover:bg-accent/30">
+				<Card.Content>
+					<div class="text-xs uppercase tracking-wider text-muted-foreground mb-2">Untriaged</div>
+					<div class="text-3xl font-bold text-foreground mono">{status?.untriaged ?? '--'}</div>
+				</Card.Content>
+			</Card.Root>
+		</a>
+		<a href="/prs?conflicts=yes" class="block">
+			<Card.Root class="text-center transition-colors hover:border-primary/50 hover:bg-accent/30">
+				<Card.Content>
+					<div class="text-xs uppercase tracking-wider text-muted-foreground mb-2">Conflicts</div>
+					<div
+						class="text-3xl font-bold mono {status?.conflicts ? 'text-red-600 dark:text-red-400' : 'text-foreground'}"
+					>{status?.conflicts ?? '--'}</div>
+				</Card.Content>
+			</Card.Root>
+		</a>
 	</div>
 
 	<Card.Root class="mt-6">

--- a/web/src/routes/prs/+page.svelte
+++ b/web/src/routes/prs/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
 	import { selectedRepo } from '$lib/stores';
 	import { fetchPulls, type PullRequest } from '$lib/api';
 	import { multiSort, toggleSort as toggle, sortArrow, sortIndex, sortArrowClass, type SortColumn } from '$lib/sort';
@@ -31,7 +32,8 @@
 	let loading = $state(true);
 	let sortColumns: SortColumn[] = $state([{ key: 'risk_level', asc: true }, { key: 'age', asc: false }]);
 	let filters: Record<string, string> = $state({
-		number: '', title: '', state: '', base_ref: '', risk: '', ci_status: '', conflicts: '', age: ''
+		number: '', title: '', state: '', base_ref: '', risk: '', ci_status: '',
+		conflicts: $page.url.searchParams.get('conflicts') ?? '', age: ''
 	});
 
 	function timeAgo(dateStr: string): string {


### PR DESCRIPTION
Requested: improve the Dashboard with trends and clickable numbers linking to the right pages.

- Each stat card is now a link: Open Issues/PRs go to their list page, Untriaged goes to Issues, Conflicts goes to PRs pre-filtered (`?conflicts=yes`).
- Open Issues/PRs cards show a "+N this week" trend (issues/PRs created in the last 7 days), computed server-side from data the handler already fetches — no new DB queries.
- PRs page now reads an initial `conflicts` query param so the Conflicts card actually lands on the filtered view.

## Verification
Screenshot-verified live against real prod data: clicking Open Issues navigates to /issues; clicking Conflicts (532) navigates to `/prs?conflicts=yes` with the Conflicts filter pre-selected to "yes" and only conflicting PRs shown.