### PR TITLE
feat(dashboard): 14-day activity sparkline

### DIFF
--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -1052,6 +1052,9 @@ struct StatusResponse {
     conflicts: usize,
     issues_new_7d: usize,
     prs_new_7d: usize,
+    /// Last 14 days, oldest first, of open-issue/open-PR creation counts —
+    /// backs the Dashboard's trend sparkline.
+    daily_activity: Vec<DailyCount>,
     last_sync: Option<String>,
     repos: Vec<RepoStatus>,
 }
@@ -1064,6 +1067,38 @@ fn count_created_since<T>(items: &[T], created_at: impl Fn(&T) -> &str, cutoff: 
         .iter()
         .filter(|item| created_at(item) >= cutoff)
         .count()
+}
+
+#[derive(Serialize, Clone)]
+struct DailyCount {
+    /// "YYYY-MM-DD"
+    date: String,
+    issues: usize,
+    prs: usize,
+}
+
+/// Build the last `days` daily buckets (oldest first, today last) and bump
+/// `issues`/`prs` for every item whose `created_at` falls on that date.
+/// Only counts currently-open items — same "backlog created recently"
+/// semantic as `count_created_since`, not a full creation history (a
+/// same-day-closed item would be missed, which is fine for a trend
+/// sparkline over the open backlog).
+fn bucket_daily_activity(
+    buckets: &mut [DailyCount],
+    date_index: &std::collections::HashMap<String, usize>,
+    issues: &[crate::db::issues::Issue],
+    prs: &[crate::db::pulls::PullRequest],
+) {
+    for issue in issues {
+        if let Some(&idx) = issue.created_at.get(..10).and_then(|d| date_index.get(d)) {
+            buckets[idx].issues += 1;
+        }
+    }
+    for pr in prs {
+        if let Some(&idx) = pr.created_at.get(..10).and_then(|d| date_index.get(d)) {
+            buckets[idx].prs += 1;
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -1095,10 +1130,31 @@ async fn api_status(
         conflicts: 0,
         issues_new_7d: 0,
         prs_new_7d: 0,
+        daily_activity: Vec::new(),
         last_sync: None,
         repos: Vec::new(),
     };
     let week_ago = (chrono::Utc::now() - chrono::Duration::days(7)).to_rfc3339();
+
+    const DAILY_WINDOW: i64 = 14;
+    let today = chrono::Utc::now().date_naive();
+    let mut daily_activity: Vec<DailyCount> = (0..DAILY_WINDOW)
+        .rev()
+        .map(|offset| DailyCount {
+            date: (today - chrono::Duration::days(offset))
+                .format("%Y-%m-%d")
+                .to_string(),
+            issues: 0,
+            prs: 0,
+        })
+        .collect();
+    // Owned keys (not &str borrows into daily_activity) so the map can
+    // outlive the mutable borrows taken while bucketing each repo below.
+    let date_index: std::collections::HashMap<String, usize> = daily_activity
+        .iter()
+        .enumerate()
+        .map(|(i, d)| (d.date.clone(), i))
+        .collect();
 
     // Snapshot the repo map and drop the read guard before the per-repo
     // blocking DB work, so the RwLock is not held across the whole scan
@@ -1126,6 +1182,7 @@ async fn api_status(
 
         let issues_new_7d = count_created_since(&open_issues, |i| i.created_at.as_str(), &week_ago);
         let prs_new_7d = count_created_since(&open_prs, |p| p.created_at.as_str(), &week_ago);
+        bucket_daily_activity(&mut daily_activity, &date_index, &open_issues, &open_prs);
 
         let last_sync = ds
             .db
@@ -1165,6 +1222,7 @@ async fn api_status(
         resp.repos.push(repo_status);
     }
 
+    resp.daily_activity = daily_activity;
     Json(resp)
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -47,6 +47,12 @@ export interface RepoInfo {
 	apply: boolean;
 }
 
+export interface DailyCount {
+	date: string;
+	issues: number;
+	prs: number;
+}
+
 export interface Status {
 	open_issues: number;
 	untriaged: number;
@@ -55,6 +61,7 @@ export interface Status {
 	conflicts: number;
 	issues_new_7d: number;
 	prs_new_7d: number;
+	daily_activity: DailyCount[];
 	last_sync: string | null;
 	repos: RepoInfo[];
 }

--- a/web/src/lib/components/ActivitySparkline.svelte
+++ b/web/src/lib/components/ActivitySparkline.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import type { DailyCount } from '$lib/api';
+
+	let { data }: { data: DailyCount[] } = $props();
+
+	let max = $derived(Math.max(1, ...data.flatMap((d) => [d.issues, d.prs])));
+
+	function shortDate(iso: string): string {
+		const d = new Date(`${iso}T00:00:00`);
+		return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+	}
+</script>
+
+<div class="flex items-end gap-1 h-16">
+	{#each data as day (day.date)}
+		<div
+			class="flex-1 flex items-end justify-center gap-0.5 h-full"
+			title="{shortDate(day.date)}: {day.issues} new issue{day.issues === 1 ? '' : 's'}, {day.prs} new PR{day.prs === 1 ? '' : 's'}"
+		>
+			<div
+				class="flex-1 min-w-[3px] rounded-t-sm bg-primary/60"
+				style="height: {Math.max(2, (day.issues / max) * 100)}%"
+			></div>
+			<div
+				class="flex-1 min-w-[3px] rounded-t-sm bg-green-500/60"
+				style="height: {Math.max(2, (day.prs / max) * 100)}%"
+			></div>
+		</div>
+	{/each}
+</div>
+<div class="flex items-center justify-between mt-1.5 text-[0.65rem] text-muted-foreground">
+	<span>{data.length > 0 ? shortDate(data[0].date) : ''}</span>
+	<div class="flex items-center gap-3">
+		<span class="flex items-center gap-1"><span class="inline-block w-2 h-2 rounded-sm bg-primary/60"></span>Issues</span>
+		<span class="flex items-center gap-1"><span class="inline-block w-2 h-2 rounded-sm bg-green-500/60"></span>PRs</span>
+	</div>
+	<span>{data.length > 0 ? shortDate(data[data.length - 1].date) : ''}</span>
+</div>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -6,6 +6,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Card from '$lib/components/ui/card';
 	import * as Table from '$lib/components/ui/table';
+	import ActivitySparkline from '$lib/components/ActivitySparkline.svelte';
 
 	let status: Status | null = $state(null);
 	let error: string | null = $state(null);
@@ -85,6 +86,17 @@
 			</Card.Root>
 		</a>
 	</div>
+
+	{#if status && status.daily_activity.length > 0}
+		<Card.Root class="mt-6">
+			<Card.Header>
+				<Card.Title class="text-base">Activity — last 14 days</Card.Title>
+			</Card.Header>
+			<Card.Content>
+				<ActivitySparkline data={status.daily_activity} />
+			</Card.Content>
+		</Card.Root>
+	{/if}
 
 	<Card.Root class="mt-6">
 		<Card.Header>


### PR DESCRIPTION
Requested: a small trend graph (7 or 15 days) on the Dashboard.

- Backend: `api_status` returns `daily_activity`, 14 daily buckets (oldest first) of open-issue/open-PR creation counts. Computed from data the handler already fetches (`open_issues`/`open_prs`) — no new DB queries. Same semantic as the existing `issues_new_7d`/`prs_new_7d`: currently-open items bucketed by creation date, not a full historical count (a same-day-created-and-closed item wouldn't show — acceptable for a backlog-growth sparkline).
- Frontend: new `ActivitySparkline` component — plain CSS/flexbox bars, no charting library (OSS `web/` has none; wshm-pro's chart.js isn't available in this shared file). Dual-series (issues/PRs) mini bar chart with a legend and first/last date labels, shown as a new card between the stat cards and the Repositories table.

## Verification
`cargo build`/`npm run check`/`npm run build` all clean. Will screenshot-verify against live prod data once deployed (release cycle in progress).