### PR TITLE
feat(dashboard): color-code the activity sparkline by repo

### DIFF
--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -1073,22 +1073,37 @@ fn count_created_since<T>(items: &[T], created_at: impl Fn(&T) -> &str, cutoff: 
 struct DailyCount {
     /// "YYYY-MM-DD"
     date: String,
+    repo: String,
     issues: usize,
     prs: usize,
 }
 
-/// Build the last `days` daily buckets (oldest first, today last) and bump
-/// `issues`/`prs` for every item whose `created_at` falls on that date.
-/// Only counts currently-open items — same "backlog created recently"
-/// semantic as `count_created_since`, not a full creation history (a
-/// same-day-closed item would be missed, which is fine for a trend
+/// Build the last `days` daily buckets (oldest first, today last) for one
+/// repo and bump `issues`/`prs` for every item whose `created_at` falls on
+/// that date. Only counts currently-open items — same "backlog created
+/// recently" semantic as `count_created_since`, not a full creation history
+/// (a same-day-closed item would be missed, which is fine for a trend
 /// sparkline over the open backlog).
 fn bucket_daily_activity(
-    buckets: &mut [DailyCount],
-    date_index: &std::collections::HashMap<String, usize>,
+    dates: &[String],
+    repo: &str,
     issues: &[crate::db::issues::Issue],
     prs: &[crate::db::pulls::PullRequest],
-) {
+) -> Vec<DailyCount> {
+    let date_index: std::collections::HashMap<&str, usize> = dates
+        .iter()
+        .enumerate()
+        .map(|(i, d)| (d.as_str(), i))
+        .collect();
+    let mut buckets: Vec<DailyCount> = dates
+        .iter()
+        .map(|d| DailyCount {
+            date: d.clone(),
+            repo: repo.to_string(),
+            issues: 0,
+            prs: 0,
+        })
+        .collect();
     for issue in issues {
         if let Some(&idx) = issue.created_at.get(..10).and_then(|d| date_index.get(d)) {
             buckets[idx].issues += 1;
@@ -1099,6 +1114,7 @@ fn bucket_daily_activity(
             buckets[idx].prs += 1;
         }
     }
+    buckets
 }
 
 #[derive(Serialize)]
@@ -1138,23 +1154,15 @@ async fn api_status(
 
     const DAILY_WINDOW: i64 = 14;
     let today = chrono::Utc::now().date_naive();
-    let mut daily_activity: Vec<DailyCount> = (0..DAILY_WINDOW)
+    let dates: Vec<String> = (0..DAILY_WINDOW)
         .rev()
-        .map(|offset| DailyCount {
-            date: (today - chrono::Duration::days(offset))
+        .map(|offset| {
+            (today - chrono::Duration::days(offset))
                 .format("%Y-%m-%d")
-                .to_string(),
-            issues: 0,
-            prs: 0,
+                .to_string()
         })
         .collect();
-    // Owned keys (not &str borrows into daily_activity) so the map can
-    // outlive the mutable borrows taken while bucketing each repo below.
-    let date_index: std::collections::HashMap<String, usize> = daily_activity
-        .iter()
-        .enumerate()
-        .map(|(i, d)| (d.date.clone(), i))
-        .collect();
+    let mut daily_activity: Vec<DailyCount> = Vec::new();
 
     // Snapshot the repo map and drop the read guard before the per-repo
     // blocking DB work, so the RwLock is not held across the whole scan
@@ -1182,7 +1190,7 @@ async fn api_status(
 
         let issues_new_7d = count_created_since(&open_issues, |i| i.created_at.as_str(), &week_ago);
         let prs_new_7d = count_created_since(&open_prs, |p| p.created_at.as_str(), &week_ago);
-        bucket_daily_activity(&mut daily_activity, &date_index, &open_issues, &open_prs);
+        daily_activity.extend(bucket_daily_activity(&dates, slug, &open_issues, &open_prs));
 
         let last_sync = ds
             .db

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -49,6 +49,7 @@ export interface RepoInfo {
 
 export interface DailyCount {
 	date: string;
+	repo: string;
 	issues: number;
 	prs: number;
 }

--- a/web/src/lib/components/ActivitySparkline.svelte
+++ b/web/src/lib/components/ActivitySparkline.svelte
@@ -3,7 +3,34 @@
 
 	let { data }: { data: DailyCount[] } = $props();
 
-	let max = $derived(Math.max(1, ...data.flatMap((d) => [d.issues, d.prs])));
+	// Fixed palette, assigned per-repo in a stable order (first-seen in the
+	// data, which the backend emits in a consistent repo iteration order) so
+	// a repo keeps the same color across reloads rather than shuffling with
+	// whichever repo happens to have the most activity that day.
+	const PALETTE = [
+		'bg-primary/70',
+		'bg-green-500/70',
+		'bg-amber-500/70',
+		'bg-pink-500/70',
+		'bg-cyan-500/70',
+		'bg-purple-500/70'
+	];
+
+	let repos = $derived([...new Set(data.map((d) => d.repo))]);
+	let repoColor = $derived(new Map(repos.map((r, i) => [r, PALETTE[i % PALETTE.length]])));
+
+	let dates = $derived([...new Set(data.map((d) => d.date))].sort());
+	let byDate = $derived(
+		dates.map((date) => ({
+			date,
+			entries: data
+				.filter((d) => d.date === date)
+				.map((d) => ({ ...d, total: d.issues + d.prs }))
+				.filter((d) => d.total > 0)
+		}))
+	);
+	let dayTotal = $derived((entries: { total: number }[]) => entries.reduce((sum, e) => sum + e.total, 0));
+	let max = $derived(Math.max(1, ...byDate.map((d) => dayTotal(d.entries))));
 
 	function shortDate(iso: string): string {
 		const d = new Date(`${iso}T00:00:00`);
@@ -12,27 +39,31 @@
 </script>
 
 <div class="flex items-end gap-1 h-16">
-	{#each data as day (day.date)}
+	{#each byDate as day (day.date)}
+		{@const total = dayTotal(day.entries)}
 		<div
-			class="flex-1 flex items-end justify-center gap-0.5 h-full"
-			title="{shortDate(day.date)}: {day.issues} new issue{day.issues === 1 ? '' : 's'}, {day.prs} new PR{day.prs === 1 ? '' : 's'}"
+			class="flex-1 flex flex-col-reverse h-full min-w-[6px] rounded-t-sm overflow-hidden"
+			title="{shortDate(day.date)}: {day.entries.map((e) => `${e.repo} (${e.issues} issues, ${e.prs} PRs)`).join(', ') || 'no activity'}"
 		>
-			<div
-				class="flex-1 min-w-[3px] rounded-t-sm bg-primary/60"
-				style="height: {Math.max(2, (day.issues / max) * 100)}%"
-			></div>
-			<div
-				class="flex-1 min-w-[3px] rounded-t-sm bg-green-500/60"
-				style="height: {Math.max(2, (day.prs / max) * 100)}%"
-			></div>
+			{#each day.entries as e (e.repo)}
+				<div
+					class="{repoColor.get(e.repo)} w-full"
+					style="height: {(e.total / max) * 100}%"
+				></div>
+			{/each}
+			{#if total === 0}
+				<div class="w-full bg-muted-foreground/10" style="height: 2px"></div>
+			{/if}
 		</div>
 	{/each}
 </div>
 <div class="flex items-center justify-between mt-1.5 text-[0.65rem] text-muted-foreground">
-	<span>{data.length > 0 ? shortDate(data[0].date) : ''}</span>
-	<div class="flex items-center gap-3">
-		<span class="flex items-center gap-1"><span class="inline-block w-2 h-2 rounded-sm bg-primary/60"></span>Issues</span>
-		<span class="flex items-center gap-1"><span class="inline-block w-2 h-2 rounded-sm bg-green-500/60"></span>PRs</span>
+	<span>{dates.length > 0 ? shortDate(dates[0]) : ''}</span>
+	<div class="flex flex-wrap items-center gap-x-3 gap-y-1 justify-end">
+		{#each repos as repo}
+			<span class="flex items-center gap-1">
+				<span class="inline-block w-2 h-2 rounded-sm {repoColor.get(repo)}"></span>{repo}
+			</span>
+		{/each}
 	</div>
-	<span>{data.length > 0 ? shortDate(data[data.length - 1].date) : ''}</span>
 </div>


### PR DESCRIPTION
Follow-up to #192: the sparkline aggregated all repos into one issues/PRs count per day — no way to tell which repo the activity came from.

- Backend: `daily_activity` entries now carry a `repo` field; one bucket set per (date, repo) pair instead of a single merged per-date total.
- Frontend: stacked bars, one colored segment per repo (issues+PRs combined — the useful distinction here is repo, not issue-vs-PR), fixed 6-color palette assigned in first-seen order so a repo keeps the same color across reloads. Legend shows a colored square per repo slug.

## Verification
`cargo build`/`npm run check`/`npm run build` all clean. Will screenshot-verify against live prod data once deployed.