### PR TITLE
fix(triage): close duplicate issues as "not planned", not "completed"

### DIFF
--- a/src/github/issues.rs
+++ b/src/github/issues.rs
@@ -345,6 +345,22 @@ impl Client {
             .with_context(|| format!("Failed to close issue #{number}"))?;
         Ok(())
     }
+
+    /// Close an issue as "not planned" rather than the API's default
+    /// "completed" — used for duplicates, since the original issue (not
+    /// this one) tracks the actual work. GitHub only accepts `completed` or
+    /// `not_planned` as a close `state_reason`.
+    pub async fn close_issue_not_planned(&self, number: u64) -> Result<()> {
+        self.octocrab
+            .issues(&self.owner, &self.repo)
+            .update(number)
+            .state(octocrab::models::IssueState::Closed)
+            .state_reason(octocrab::models::issues::IssueStateReason::NotPlanned)
+            .send()
+            .await
+            .with_context(|| format!("Failed to close issue #{number} as not planned"))?;
+        Ok(())
+    }
 }
 
 /// Ensure the comment body contains a hidden marker for idempotent updates.

--- a/src/pipelines/triage.rs
+++ b/src/pipelines/triage.rs
@@ -541,7 +541,7 @@ async fn triage_issue(
                         "Closing as duplicate of #{original}. See the original issue for updates."
                     );
                     gh.comment_issue(issue.number, &close_msg).await?;
-                    gh.close_issue(issue.number).await?;
+                    gh.close_issue_not_planned(issue.number).await?;
                 }
             }
             "wontfix" => {


### PR DESCRIPTION
User report on rtk-ai/rtk: "wshm is closing duplicates as completed rather than not planned. Seems strange, except if the original issue is already completed."

Root cause: `Client::close_issue()` calls GitHub's update API with only `state: closed`, no `state_reason` — which the API defaults to `completed`. For a duplicate, the more accurate reason is `not_planned` (this issue itself isn't being worked; the original is).

Fix: added `close_issue_not_planned()` (sets `state_reason: not_planned` explicitly — the only other value GitHub's REST API accepts for closing), wired the duplicate-handling branch in `triage.rs` to call it instead of the generic `close_issue`.

`close_issue` itself is untouched — it's also reused by `git_provider::github`'s trait impl (just delegates to the same `Client`), and only the duplicate path needed the reason change.

## Verification
`cargo build` + `cargo test --lib` (83 passed) clean.