### PR TITLE
feat(review): auto code review with configurable Skills + web-only posting toggle

### DIFF
--- a/src/ai/schemas.rs
+++ b/src/ai/schemas.rs
@@ -80,7 +80,7 @@ pub struct DomainDiscovery {
     pub domains: Vec<DiscoveredDomain>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct InlineReviewResult {
     #[serde(default)]
     pub comments: Vec<InlineComment>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -695,8 +695,8 @@ pub struct SkillDef {
     /// The actual instructions appended to the prompt verbatim.
     pub content: String,
 
-    /// Which pipelines this skill applies to: any of "triage", "pr_review".
-    /// Empty means both.
+    /// Which pipelines this skill applies to: any of "triage", "pr_review",
+    /// "review" (inline code review). Empty means all of them.
     #[serde(default)]
     pub pipelines: Vec<String>,
 
@@ -724,6 +724,44 @@ pub fn skills_prompt(skills: &[SkillDef], pipeline: &str) -> String {
         out.push_str(&format!("\n### {}\n{}\n", skill.name, skill.content.trim()));
     }
     out
+}
+
+/// Load this repo's configured Skills, falling back to [`default_skills`]
+/// when the repo has never saved its own list (`SKILLS_KEY` unset). Once a
+/// repo saves ANY list via Settings — including an empty one — that becomes
+/// its persisted choice and the default is no longer consulted for it.
+pub fn load_skills(db: &dyn crate::db::backend::DatabaseBackend) -> Vec<SkillDef> {
+    match db
+        .get_app_setting(crate::db::settings::SKILLS_KEY)
+        .ok()
+        .flatten()
+    {
+        Some(raw) => serde_json::from_str(&raw).unwrap_or_default(),
+        None => default_skills(),
+    }
+}
+
+/// The single Skill pre-seeded for a repo that has never configured its own
+/// skills list (i.e. the `SKILLS_KEY` app_setting has never been written).
+/// Applies to every pipeline by default; repos disable or edit it like any
+/// other skill via Settings — once a repo saves ANY skills list (even an
+/// empty one), that repo's own choice is persisted and this default is no
+/// longer consulted for it.
+pub fn default_skills() -> Vec<SkillDef> {
+    vec![SkillDef {
+        name: "core-review-checklist".to_string(),
+        description: Some(
+            "Baseline checks applied to every AI review pass by default.".to_string(),
+        ),
+        content: "Flag concrete defects only: real bugs, security issues (injection, auth \
+bypass, leaked secrets, unsafe deserialization), correctness errors, and obvious data \
+races/resource leaks. Do not nitpick style, formatting, or naming that a linter already \
+enforces. Do not suggest speculative refactors or hypothetical future-proofing. If a change \
+looks correct and reasonably simple, say so briefly instead of inventing issues."
+            .to_string(),
+        pipelines: vec![],
+        enabled: true,
+    }]
 }
 
 /// A "grand domain" — a broad area of the codebase/product (e.g. codex, bun,
@@ -1523,6 +1561,14 @@ pub struct RepoFeatures {
     /// Pro-only inline code review.
     #[serde(default)]
     pub review_prs: bool,
+    /// Whether a computed review is also posted to GitHub as inline PR
+    /// comments. Independent of `apply` (the repo's general "write to
+    /// GitHub" mode) so a repo can run review computation silently — shown
+    /// on the dashboard only — even while `apply` is on for other features.
+    /// Defaults true so enabling `review_prs` elsewhere keeps today's
+    /// behavior (compute-and-post) unless explicitly turned off.
+    #[serde(default = "default_true")]
+    pub review_post_comments: bool,
 
     // Mutating actions on the repo
     #[serde(default)]
@@ -1543,6 +1589,7 @@ impl Default for RepoFeatures {
             triage_issues: false,
             analyze_prs: false,
             review_prs: false,
+            review_post_comments: true,
             auto_pr: false,
             auto_merge: false,
             filters: RepoFilters::default(),

--- a/src/daemon/processor.rs
+++ b/src/daemon/processor.rs
@@ -12,6 +12,7 @@ use super::{DaemonState, MultiDaemonState};
 use crate::cli::{PrArgs, TriageArgs};
 use crate::github::sync as gh_sync;
 use crate::pipelines;
+use crate::pro_hooks;
 
 /// Tracks which issue/PR numbers are currently being processed to prevent concurrent duplicates.
 /// Key is (repo_slug, number) for multi-repo isolation, or ("", number) for single-repo.
@@ -386,6 +387,29 @@ async fn handle_pull_request(state: &DaemonState, event: &WebhookEvent) -> anyho
                     return Ok(());
                 }
                 Err(e) => warn!("Direct fetch of PR #{n} failed: {e:#}"),
+            }
+        }
+    }
+
+    // Inline code review (Pro) — independent of analyze_prs below, so it
+    // still runs even for a repo that only wants review, not the coarse
+    // risk/type classification. `should_post` combines the repo's general
+    // apply mode with the review-specific post-to-GitHub toggle: both must
+    // be on for inline comments to actually land on the PR; the review
+    // itself is always computed and stored either way.
+    if features.review_prs {
+        if let Some(n) = number {
+            let should_post = state.apply() && features.review_post_comments;
+            if let Err(e) = pro_hooks::run_review(
+                &state.config,
+                state.db.as_ref(),
+                &state.gh(),
+                n,
+                should_post,
+            )
+            .await
+            {
+                warn!("Review failed for PR #{n}: {e:#}");
             }
         }
     }

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -2355,6 +2355,7 @@ async fn api_repo_features_patch(
     patch_bool!(triage_issues);
     patch_bool!(analyze_prs);
     patch_bool!(review_prs);
+    patch_bool!(review_post_comments);
     patch_bool!(auto_pr);
     patch_bool!(auto_merge);
 
@@ -2576,13 +2577,7 @@ async fn api_repo_skills_get(
     let repos = state.multi.repos.read().await;
     match repos.get(&slug) {
         Some(ds) => {
-            let skills: Vec<crate::config::SkillDef> = ds
-                .db
-                .get_app_setting(crate::db::settings::SKILLS_KEY)
-                .ok()
-                .flatten()
-                .and_then(|s| serde_json::from_str(&s).ok())
-                .unwrap_or_default();
+            let skills = crate::config::load_skills(ds.db.as_ref());
             Json(json!({ "skills": skills })).into_response()
         }
         None => (

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -6,6 +6,7 @@ use crate::ai::schemas::IssueClassification;
 use crate::db::events::WebhookEventRow;
 use crate::db::issues::Issue;
 use crate::db::pulls::{PrAnalysisRow, PullRequest};
+use crate::db::reviews::PrReviewRow;
 use crate::db::search::SearchHit;
 use crate::db::sync::SyncEntry;
 use crate::db::triage::TriageResultRow;
@@ -103,6 +104,20 @@ pub trait DatabaseBackend: Send + Sync {
     /// `with_conn(|conn| INSERT ... ON CONFLICT ...)` so callers can run
     /// against any backend that implements this trait.
     fn upsert_pr_analysis(&self, row: &PrAnalysisRow) -> Result<()>;
+
+    // ── PR inline review (Pro) ──────────────────────────────────
+    //
+    // Distinct from PR analysis above: `pr_reviews` stores the actual
+    // line-anchored inline-comment findings from `pipelines::review`
+    // (a real code review), not the coarse risk/type/summary classification
+    // `pr_analyses` holds. Written whenever a review is computed, regardless
+    // of whether it was also posted to GitHub — `posted_to_github` records
+    // that separately so the web UI can show "reviewed, not posted".
+
+    fn get_pr_review(&self, pr_number: u64) -> Result<Option<PrReviewRow>>;
+    /// Batch loader mirroring `get_all_pr_analyses`.
+    fn get_all_pr_reviews(&self) -> Result<std::collections::HashMap<u64, PrReviewRow>>;
+    fn upsert_pr_review(&self, row: &PrReviewRow) -> Result<()>;
 
     /// Apply freshly-synced GitHub review decisions (PR number → decision)
     /// to open PRs; PRs absent from the map get their decision cleared.
@@ -294,6 +309,18 @@ impl DatabaseBackend for super::Database {
 
     fn get_all_pr_analyses(&self) -> Result<std::collections::HashMap<u64, PrAnalysisRow>> {
         self.get_all_pr_analyses()
+    }
+
+    fn get_pr_review(&self, pr_number: u64) -> Result<Option<PrReviewRow>> {
+        self.get_pr_review(pr_number)
+    }
+
+    fn get_all_pr_reviews(&self) -> Result<std::collections::HashMap<u64, PrReviewRow>> {
+        self.get_all_pr_reviews()
+    }
+
+    fn upsert_pr_review(&self, row: &PrReviewRow) -> Result<()> {
+        self.upsert_pr_review(row)
     }
 
     fn get_closed_pulls(&self, limit: usize) -> Result<Vec<PullRequest>> {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -3,6 +3,7 @@ pub mod events;
 pub mod issues;
 pub mod licenses;
 pub mod pulls;
+pub mod reviews;
 pub mod schema;
 pub mod search;
 pub mod settings;

--- a/src/db/reviews.rs
+++ b/src/db/reviews.rs
@@ -1,0 +1,92 @@
+use anyhow::Result;
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+
+use crate::ai::schemas::InlineReviewResult;
+use crate::db::Database;
+
+/// One stored inline-code-review pass over a PR. `result` is the AI's
+/// findings (comments + summary + stats); `posted_to_github` records
+/// whether this pass actually wrote inline comments to the PR (gated
+/// separately from computing the review at all — see `review_post_comments`
+/// in `RepoFeatures`), so the dashboard can show "computed, not posted".
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrReviewRow {
+    pub pr_number: u64,
+    pub result: InlineReviewResult,
+    pub posted_to_github: bool,
+    #[serde(default)]
+    pub content_hash: Option<String>,
+    pub reviewed_at: String,
+}
+
+fn row_to_pr_review(row: &rusqlite::Row) -> rusqlite::Result<PrReviewRow> {
+    let result_json: String = row.get(1)?;
+    let result: InlineReviewResult =
+        serde_json::from_str(&result_json).unwrap_or(InlineReviewResult {
+            comments: Vec::new(),
+            summary: String::new(),
+            stats: Default::default(),
+        });
+    Ok(PrReviewRow {
+        pr_number: row.get(0)?,
+        result,
+        posted_to_github: row.get::<_, i64>(2)? != 0,
+        content_hash: row.get(3)?,
+        reviewed_at: row.get(4)?,
+    })
+}
+
+const SELECT_COLUMNS: &str = "pr_number, result_json, posted_to_github, content_hash, reviewed_at";
+
+impl Database {
+    pub fn get_pr_review(&self, pr_number: u64) -> Result<Option<PrReviewRow>> {
+        self.with_conn(|conn| {
+            let mut stmt = conn.prepare(&format!(
+                "SELECT {SELECT_COLUMNS} FROM pr_reviews WHERE pr_number = ?1"
+            ))?;
+            let result = stmt.query_row(params![pr_number], row_to_pr_review);
+            match result {
+                Ok(r) => Ok(Some(r)),
+                Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+                Err(e) => Err(e.into()),
+            }
+        })
+    }
+
+    /// Load every stored review in one query, keyed by PR number. Mirrors
+    /// `get_all_pr_analyses` — used by the /api/v1/reviews web handler to
+    /// avoid an N+1 per open PR.
+    pub fn get_all_pr_reviews(&self) -> Result<std::collections::HashMap<u64, PrReviewRow>> {
+        self.with_conn(|conn| {
+            let mut stmt = conn.prepare(&format!("SELECT {SELECT_COLUMNS} FROM pr_reviews"))?;
+            let rows = stmt
+                .query_map([], row_to_pr_review)?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            Ok(rows.into_iter().map(|r| (r.pr_number, r)).collect())
+        })
+    }
+
+    pub fn upsert_pr_review(&self, row: &PrReviewRow) -> Result<()> {
+        self.with_conn(|conn| {
+            let result_json = serde_json::to_string(&row.result).unwrap_or_default();
+            conn.execute(
+                "INSERT INTO pr_reviews (pr_number, result_json, posted_to_github, content_hash, reviewed_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)
+                 ON CONFLICT(pr_number) DO UPDATE SET
+                    result_json = excluded.result_json,
+                    posted_to_github = excluded.posted_to_github,
+                    content_hash = excluded.content_hash,
+                    reviewed_at = excluded.reviewed_at",
+                params![
+                    row.pr_number,
+                    result_json,
+                    row.posted_to_github as i64,
+                    row.content_hash,
+                    row.reviewed_at,
+                ],
+            )?;
+            Ok(())
+        })
+    }
+}

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -68,6 +68,14 @@ pub fn run_migrations(conn: &Connection) -> Result<()> {
             analyzed_at   TEXT NOT NULL
         );
 
+        CREATE TABLE IF NOT EXISTS pr_reviews (
+            pr_number        INTEGER PRIMARY KEY,
+            result_json      TEXT NOT NULL,
+            posted_to_github INTEGER NOT NULL DEFAULT 0,
+            content_hash     TEXT,
+            reviewed_at      TEXT NOT NULL
+        );
+
         CREATE TABLE IF NOT EXISTS sync_log (
             table_name     TEXT PRIMARY KEY,
             last_synced_at TEXT NOT NULL,

--- a/src/pipelines/pr_analysis.rs
+++ b/src/pipelines/pr_analysis.rs
@@ -191,12 +191,7 @@ async fn analyze_pr(
     }
 
     // Inject configured Skills that apply to PR review (see config::skills_prompt).
-    let skills: Vec<crate::config::SkillDef> = db
-        .get_app_setting(crate::db::settings::SKILLS_KEY)
-        .ok()
-        .flatten()
-        .and_then(|s| serde_json::from_str(&s).ok())
-        .unwrap_or_default();
+    let skills = crate::config::load_skills(db);
     let skills_prompt = crate::config::skills_prompt(&skills, "pr_review");
     if !skills_prompt.is_empty() {
         user_prompt.push_str(&skills_prompt);

--- a/src/pipelines/triage.rs
+++ b/src/pipelines/triage.rs
@@ -385,12 +385,7 @@ async fn triage_issue(
     }
 
     // Inject configured Skills that apply to triage (see config::skills_prompt).
-    let skills: Vec<crate::config::SkillDef> = db
-        .get_app_setting(crate::db::settings::SKILLS_KEY)
-        .ok()
-        .flatten()
-        .and_then(|s| serde_json::from_str(&s).ok())
-        .unwrap_or_default();
+    let skills = crate::config::load_skills(db);
     let skills_prompt = crate::config::skills_prompt(&skills, "triage");
     if !skills_prompt.is_empty() {
         user_prompt.push_str(&skills_prompt);

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -516,6 +516,7 @@ export interface RepoFeatures {
 	triage_issues: boolean;
 	analyze_prs: boolean;
 	review_prs: boolean;
+	review_post_comments: boolean;
 	auto_pr: boolean;
 	auto_merge: boolean;
 	filters: RepoFilters;

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -45,7 +45,10 @@
 	"settings.features.ai.analyze.tip": "Sends the PR diff + body to your AI provider and gets back a risk level (low/medium/high), PR type (feature/fix/refactor/...), summary, and a review checklist. When Apply is on, posts a summary comment on the PR. Skipped for drafts when skip_drafts is enabled.",
 	"settings.features.ai.review": "Review PRs (Pro)",
 	"settings.features.ai.review.help": "— inline code review on PR diffs (Pro feature)",
-	"settings.features.ai.review.tip": "Pro feature. Sends the PR diff to the AI for line-by-line review. When Apply is on, posts inline review comments on suspicious lines (security, perf, bugs, style). Higher token cost than Analyze PRs — use it on PRs that matter.",
+	"settings.features.ai.review.tip": "Pro feature. Sends the PR diff to the AI for line-by-line review. Results always show up on the wshm dashboard. When Apply is on AND \"Post review comments to GitHub\" is checked, also posts inline review comments on suspicious lines (security, perf, bugs, style). Higher token cost than Analyze PRs — use it on PRs that matter.",
+	"settings.features.ai.review.post": "Post review comments to GitHub",
+	"settings.features.ai.review.post.help": "— otherwise findings stay visible only on the wshm dashboard",
+	"settings.features.ai.review.post.tip": "When unchecked, the review still runs and is stored/visible on the wshm dashboard, but no comment is posted on the PR itself. Independent from Apply mode — lets you turn on auto-review without spamming the PR yet.",
 
 	"settings.features.auto.title": "Auto-actions",
 	"settings.features.auto.body": "Mutating actions on the repo. Off by default; require Mode: Apply to take effect.",

--- a/web/src/lib/i18n/fr.json
+++ b/web/src/lib/i18n/fr.json
@@ -45,7 +45,10 @@
 	"settings.features.ai.analyze.tip": "Envoie le diff + corps de la PR à ton fournisseur IA et reçoit en retour un niveau de risque (low/medium/high), un type de PR (feature/fix/refactor/...), un résumé et une checklist de revue. En mode Apply, poste un commentaire de résumé sur la PR. Ignoré pour les drafts si skip_drafts est actif.",
 	"settings.features.ai.review": "Reviewer les PRs (Pro)",
 	"settings.features.ai.review.help": "— revue de code inline sur les diffs (feature Pro)",
-	"settings.features.ai.review.tip": "Feature Pro. Envoie le diff de la PR à l'IA pour une revue ligne par ligne. En mode Apply, poste des commentaires de revue inline sur les lignes suspectes (sécurité, perf, bugs, style). Coût en tokens plus élevé qu'Analyze PRs — à réserver aux PRs qui comptent.",
+	"settings.features.ai.review.tip": "Feature Pro. Envoie le diff de la PR à l'IA pour une revue ligne par ligne. Le résultat est toujours visible sur le dashboard wshm. Si Apply est actif ET que \"Poster les commentaires de revue sur GitHub\" est coché, poste aussi des commentaires de revue inline sur les lignes suspectes (sécurité, perf, bugs, style). Coût en tokens plus élevé qu'Analyze PRs — à réserver aux PRs qui comptent.",
+	"settings.features.ai.review.post": "Poster les commentaires de revue sur GitHub",
+	"settings.features.ai.review.post.help": "— sinon les résultats restent visibles uniquement sur le dashboard wshm",
+	"settings.features.ai.review.post.tip": "Si décoché, la revue s'exécute et reste visible sur le dashboard wshm, mais aucun commentaire n'est posté sur la PR. Indépendant du mode Apply — permet d'activer la revue auto sans encore spammer la PR.",
 
 	"settings.features.auto.title": "Auto-actions",
 	"settings.features.auto.body": "Actions mutantes sur le repo. Désactivées par défaut ; nécessitent Mode : Apply pour prendre effet.",

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -1922,6 +1922,14 @@
 							</span>
 							{@render infoTip('tip-review', 'settings.features.ai.review.tip')}
 						</label>
+						<label class="flex items-center gap-2 text-sm ml-6" class:opacity-60={!featuresDraft.review_prs}>
+							<input type="checkbox" bind:checked={featuresDraft.review_post_comments} disabled={!featuresDraft.review_prs} class="rounded" />
+							<span>
+								{$t('settings.features.ai.review.post')}
+								<span class="text-xs text-muted-foreground">{$t('settings.features.ai.review.post.help')}</span>
+							</span>
+							{@render infoTip('tip-review-post', 'settings.features.ai.review.post.tip')}
+						</label>
 					</div>
 				</div>
 


### PR DESCRIPTION
## Summary
- Wires `review_prs` into the daemon's PR event handler (Pro hook), so inline code review actually runs automatically on new/updated PRs instead of only via the `wshm review` CLI.
- Adds a `pr_reviews` table + `DatabaseBackend` methods (`get_pr_review`, `get_all_pr_reviews`, `upsert_pr_review`) so review results (comments + summary + stats) are always persisted and visible on the dashboard, regardless of whether they were posted to GitHub.
- New `review_post_comments` repo-feature flag (default `true`), independent of the existing `apply`/dry-run toggle — lets auto-review run "web only" for a repo without posting PR comments yet. Settable globally (default) and per repo via Settings.
- Skills (standing review instructions) are now injected into `pipelines/review.rs`'s prompt the same way triage/PR-analysis already do, via a new shared `config::load_skills` helper.
- One default Skill (`core-review-checklist`) is auto-seeded for any repo that hasn't configured its own Skills list yet — visible/editable in Settings → Skills like any other skill.

## Test plan
- [x] `cargo build` + `cargo test --lib` (83 passed)
- [x] `npm run check` + `npm run build` (web) — no new type errors
- [ ] CI green