### PR TITLE
fix(web): UX review pass — label tooltips, queue scoring, sparkline range, Skills tab

### DIFF
--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -1495,36 +1495,11 @@ async fn api_queue(
         if let Ok(prs) = ds.db.get_open_pulls() {
             let analyses = ds.db.get_all_pr_analyses().unwrap_or_default();
             for pr in prs {
-                // Basic scoring (mirrors pipelines::merge_queue logic)
-                let mut score: i64 = 0;
-
-                // CI passing
-                if pr.ci_status.as_deref() == Some("success") {
-                    score += 10;
-                }
-
-                // Conflicts
-                if pr.mergeable == Some(false) {
-                    score -= 10;
-                }
-
-                // Staleness bonus: +1 per day since creation, max 10
-                if let Ok(created) = chrono::DateTime::parse_from_rfc3339(&pr.created_at) {
-                    let age_days = (chrono::Utc::now() - created.with_timezone(&chrono::Utc))
-                        .num_days()
-                        .min(10);
-                    score += age_days;
-                }
-
-                // Analysis data (if available)
+                // Same scoring engine used by `wshm health` / merge_queue, so
+                // the web queue and the CLI never disagree on a PR's rank.
+                let (score, _breakdown) =
+                    crate::pipelines::pr_health::score_pr_with(&pr, &ds.config.scoring.pr);
                 let analysis = analyses.get(&pr.number);
-                if let Some(a) = analysis {
-                    match a.risk_level.as_str() {
-                        "low" => score += 5,
-                        "high" => score -= 5,
-                        _ => {}
-                    }
-                }
 
                 queue.push(json!({
                     "repo": slug,

--- a/web/src/lib/components/ActivitySparkline.svelte
+++ b/web/src/lib/components/ActivitySparkline.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { DailyCount } from '$lib/api';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 
 	let { data }: { data: DailyCount[] } = $props();
 
@@ -39,26 +40,46 @@
 </script>
 
 <div class="flex items-end gap-1 h-16">
-	{#each byDate as day (day.date)}
-		{@const total = dayTotal(day.entries)}
-		<div
-			class="flex-1 flex flex-col-reverse h-full min-w-[6px] rounded-t-sm overflow-hidden"
-			title="{shortDate(day.date)}: {day.entries.map((e) => `${e.repo} (${e.issues} issues, ${e.prs} PRs)`).join(', ') || 'no activity'}"
-		>
-			{#each day.entries as e (e.repo)}
-				<div
-					class="{repoColor.get(e.repo)} w-full"
-					style="height: {(e.total / max) * 100}%"
-				></div>
-			{/each}
-			{#if total === 0}
-				<div class="w-full bg-muted-foreground/10" style="height: 2px"></div>
-			{/if}
-		</div>
-	{/each}
+	<Tooltip.Provider>
+		{#each byDate as day (day.date)}
+			{@const total = dayTotal(day.entries)}
+			<Tooltip.Root>
+				<Tooltip.Trigger>
+					{#snippet child({ props })}
+						<div
+							{...props}
+							class="flex-1 flex flex-col-reverse h-full min-w-[6px] rounded-t-sm overflow-hidden"
+						>
+							{#each day.entries as e (e.repo)}
+								<div
+									class="{repoColor.get(e.repo)} w-full"
+									style="height: {(e.total / max) * 100}%"
+								></div>
+							{/each}
+							{#if total === 0}
+								<div class="w-full bg-muted-foreground/10" style="height: 2px"></div>
+							{/if}
+						</div>
+					{/snippet}
+				</Tooltip.Trigger>
+				<Tooltip.Content class="text-xs leading-snug">
+					<div class="font-medium">{shortDate(day.date)}</div>
+					{#if day.entries.length > 0}
+						{#each day.entries as e (e.repo)}
+							<div>{e.repo}: {e.issues} issues, {e.prs} PRs</div>
+						{/each}
+					{:else}
+						<div>no activity</div>
+					{/if}
+				</Tooltip.Content>
+			</Tooltip.Root>
+		{/each}
+	</Tooltip.Provider>
 </div>
 <div class="flex items-center justify-between mt-1.5 text-[0.65rem] text-muted-foreground">
-	<span>{dates.length > 0 ? shortDate(dates[0]) : ''}</span>
+	<span>
+		{dates.length > 0 ? shortDate(dates[0]) : ''}{dates.length > 1 ? ` – ${shortDate(dates[dates.length - 1])}` : ''}
+	</span>
 	<div class="flex flex-wrap items-center gap-x-3 gap-y-1 justify-end">
 		{#each repos as repo}
 			<span class="flex items-center gap-1">

--- a/web/src/routes/issues/+page.svelte
+++ b/web/src/routes/issues/+page.svelte
@@ -197,12 +197,25 @@
 						<Table.Cell class="px-2 py-1.5 text-foreground text-xs">
 							{issue.pr_status === 'pr_ready' ? 'PR ready' : issue.pr_status === 'has_pr' ? 'PR open' : 'No PR'}
 						</Table.Cell>
-						<Table.Cell class="px-2 py-1.5 overflow-hidden whitespace-nowrap">
-							{#each issue.labels.slice(0, 2) as label}
-								<Badge variant="outline" class="bg-primary/15 text-primary mr-1">{label}</Badge>
-							{/each}
-							{#if issue.labels.length > 2}
-								<Badge variant="outline" class="text-muted-foreground">+{issue.labels.length - 2}</Badge>
+						<Table.Cell class="px-2 py-1.5 overflow-hidden">
+							{#if issue.labels.length > 0}
+								<Tooltip.Provider>
+									<Tooltip.Root>
+										<Tooltip.Trigger>
+											{#snippet child({ props })}
+												<span {...props} class="flex items-center gap-1 truncate">
+													{#each issue.labels.slice(0, 2) as label}
+														<Badge variant="outline" class="bg-primary/15 text-primary shrink-0">{label}</Badge>
+													{/each}
+													{#if issue.labels.length > 2}
+														<Badge variant="outline" class="text-muted-foreground shrink-0">+{issue.labels.length - 2}</Badge>
+													{/if}
+												</span>
+											{/snippet}
+										</Tooltip.Trigger>
+										<Tooltip.Content class="max-w-sm text-xs leading-snug">{issue.labels.join(', ')}</Tooltip.Content>
+									</Tooltip.Root>
+								</Tooltip.Provider>
 							{/if}
 						</Table.Cell>
 						<Table.Cell class="px-2 py-1.5 text-foreground">{issue.priority ?? '-'}</Table.Cell>

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -1463,49 +1463,13 @@
 		<div class="w-full space-y-4">
 			<Card.Root>
 				<Card.Header>
-					<Card.Title>How Skills fit into the review pipeline</Card.Title>
-					<Card.Description class="text-xs">
-						A Skill is a standing instruction block the AI loads when it applies — the same idea as an
-						Anthropic Agent Skill, scoped here to wshm's own triage and PR-review calls. It's appended to
-						the prompt alongside labels and grand domains, right before the AI provider call.
-					</Card.Description>
-				</Card.Header>
-				<Card.Content>
-					<div class="flex flex-col items-stretch gap-0 max-w-md mx-auto text-xs">
-						{#snippet flowStep(label: string, fn: string, highlight: boolean)}
-							<div
-								class="rounded-md border px-3 py-2 text-center {highlight
-									? 'border-primary bg-primary/10 text-primary font-semibold'
-									: 'bg-muted/30 text-foreground/90'}"
-							>
-								<div>{label}</div>
-								<div class="mono text-[0.65rem] {highlight ? 'text-primary/80' : 'text-muted-foreground'}">{fn}</div>
-							</div>
-							<div class="text-center text-muted-foreground leading-none py-0.5">↓</div>
-						{/snippet}
-						{@render flowStep('GitHub event — issue opened / PR updated', 'daemon::processor', false)}
-						{@render flowStep('Build base prompt', 'issue_classify / pr_analyze :: build_user_prompt()', false)}
-						{@render flowStep('+ Labels', 'Config::labels_prompt()', false)}
-						{@render flowStep('+ Grand domains', 'config::domains_prompt()', false)}
-						{@render flowStep('+ Skills (this tab)', 'config::skills_prompt()', true)}
-						<div
-							class="rounded-md border bg-muted/30 px-3 py-2 text-center text-foreground/90"
-						>
-							<div>AI provider call</div>
-							<div class="mono text-[0.65rem] text-muted-foreground">AiClient::complete()</div>
-						</div>
-					</div>
-					<p class="text-[0.7rem] text-muted-foreground mt-3">
-						Each Skill below can target <code>triage</code>, <code>pr_review</code>, or both. Disabled
-						skills stay saved but are skipped. Changes take effect on the next triage/PR-review pass —
-						no restart needed.
-					</p>
-				</Card.Content>
-			</Card.Root>
-
-			<Card.Root>
-				<Card.Header>
 					<Card.Title>Configured skills</Card.Title>
+					<Card.Description class="text-xs">
+						A Skill is a standing instruction the AI follows whenever it applies — appended to the prompt
+						alongside labels and grand domains before triage, PR analysis, or code review runs. Each
+						Skill below can target triage, PR analysis, review, or all three. Disabled skills stay saved
+						but are skipped. Changes take effect on the next pass — no restart needed.
+					</Card.Description>
 				</Card.Header>
 				<Card.Content class="space-y-3">
 					<div>
@@ -1580,9 +1544,18 @@
 												checked={s.pipelines.includes('pr_review')}
 												onchange={() => togglePipeline(i, 'pr_review')}
 											/>
-											PR review
+											PR analysis
 										</label>
-										<span class="italic">(both, if none checked)</span>
+										<label class="flex items-center gap-1">
+											<input
+												type="checkbox"
+												class="h-3.5 w-3.5"
+												checked={s.pipelines.includes('review')}
+												onchange={() => togglePipeline(i, 'review')}
+											/>
+											Code review (Pro)
+										</label>
+										<span class="italic">(all, if none checked)</span>
 									</div>
 									<textarea
 										class="w-full rounded-md border bg-background px-2 py-1 text-xs min-h-[72px] mono"
@@ -1922,10 +1895,10 @@
 							</span>
 							{@render infoTip('tip-review', 'settings.features.ai.review.tip')}
 						</label>
-						<label class="flex items-center gap-2 text-sm ml-6" class:opacity-60={!featuresDraft.review_prs}>
+						<label class="flex items-center gap-2 text-sm ml-6 pl-3 border-l-2 border-muted" class:opacity-60={!featuresDraft.review_prs}>
 							<input type="checkbox" bind:checked={featuresDraft.review_post_comments} disabled={!featuresDraft.review_prs} class="rounded" />
 							<span>
-								{$t('settings.features.ai.review.post')}
+								<strong>{$t('settings.features.ai.review.post')}</strong>
 								<span class="text-xs text-muted-foreground">{$t('settings.features.ai.review.post.help')}</span>
 							</span>
 							{@render infoTip('tip-review-post', 'settings.features.ai.review.post.tip')}


### PR DESCRIPTION
## Summary
Fixes from a UX/UI audit of the live site (screenshots + DOM inspection):
- Issues table LABELS cell had no tooltip on truncated badges — label data was genuinely unrecoverable in the UI. Now shows the full list on hover.
- `/api/v1/queue` had its own ad-hoc scoring formula duplicated from `pipelines::pr_health`, which saturates to the same score for most PRs (CI success +10 capped, age +10 capped, nothing else usually differs) — replaced with the real scoring engine so scores discriminate PRs again and match `wshm health`.
- Dashboard activity sparkline only labeled the first date on its axis and used a native unstyled browser tooltip — now labels both ends of the range and uses the app's styled tooltip.
- Settings → Skills tab showed an internal architecture diagram with raw Rust symbol names (`daemon::processor`, `Config::labels_prompt()`, ...) — replaced with a plain description matching every other tab. Also added the missing "Code review" pipeline checkbox (Skills could only target triage/PR-analysis, not the newer review pipeline).
- The nested "Post review comments to GitHub" checkbox under "Review PRs (Pro)" now reads clearly as a child of its parent (bold label + connecting rule).

## Test plan
- [x] `cargo build` + `cargo test --lib` (83 passed)
- [x] `npm run check` + `npm run build` — no new type errors vs baseline
- [ ] CI green