### PR TITLE
fix(web): rename /review nav label 'To Validate' -> 'Code Review'

### DIFF
--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -78,7 +78,7 @@
 		{ href: '/search', label: 'Search', icon: 'search', section: 'Work', feature: 'search' },
 		{ href: '/issues', label: 'Issues', icon: 'issues', section: 'Work' },
 		{ href: '/prs', label: 'Pull Requests', icon: 'prs', section: 'Work' },
-		{ href: '/review', label: 'To Validate', icon: 'review', section: 'Work' },
+		{ href: '/review', label: 'Code Review', icon: 'review', section: 'Work' },
 		{ href: '/triage', label: 'Triage', icon: 'triage', section: 'Work' },
 		{ href: '/queue', label: 'Merge Queue', icon: 'queue', section: 'Work' },
 		{ href: '/actions', label: 'Actions', icon: 'actions', section: 'Work' },


### PR DESCRIPTION
Follow-up to #196: that PR's nav-label fix landed only in wshm-pro's own `+layout.svelte` copy, which the Docker build unconditionally overwrites from this file at build time — so it never actually shipped. Fixing it at the actual source of truth this time.