### PR TITLE
fix(github): fetch PR diffs via the authenticated api.github.com endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6511,6 +6511,8 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "hostname",
+ "http 1.4.0",
+ "http-body-util",
  "is-terminal",
  "jsonwebtoken",
  "mime_guess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,13 @@ vault-all = ["vault-hashicorp", "vault-aws", "vault-gcp"]
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
 octocrab = "0.44"
+# Used with octocrab's low-level `_get_with_headers` to fetch a PR diff
+# through the authenticated api.github.com endpoint instead of the public
+# github.com/*.diff URL — see fetch_pr_diff_raw. Versions match what
+# octocrab 0.44 itself resolves to (Cargo.lock already carries both
+# transitively; these just make them directly nameable in our code).
+http = "1"
+http-body-util = "0.1"
 # Pinned to the exact version octocrab 0.44 depends on — its `.app()`
 # builder takes a `jsonwebtoken::EncodingKey` by value, so a mismatched
 # major/minor version would fail to type-check even though both compile.

--- a/src/github/pulls.rs
+++ b/src/github/pulls.rs
@@ -416,27 +416,41 @@ impl Client {
         self.fetch_pr_diff_raw(number).await
     }
 
-    /// Fetch the raw unified diff for a PR
+    /// Fetch the raw unified diff for a PR.
+    ///
+    /// Goes through the authenticated `api.github.com` REST endpoint (content
+    /// negotiation via the diff media type), not the public
+    /// `github.com/.../pull/N.diff` URL — that URL lives on GitHub's main web
+    /// domain rather than its API, which some network paths (this app's own
+    /// production cluster included) reach far less reliably than
+    /// `api.github.com`, and it also bypasses whatever auth/rate-limit
+    /// headroom the GitHub App installation token gives us.
     pub async fn fetch_pr_diff_raw(&self, number: u64) -> Result<String> {
-        // Use the .diff URL which returns raw unified diff
-        let url = format!(
-            "https://github.com/{}/{}/pull/{number}.diff",
-            self.owner, self.repo
+        use http_body_util::BodyExt;
+
+        let route = format!("/repos/{}/{}/pulls/{number}", self.owner, self.repo);
+        let mut headers = http::header::HeaderMap::new();
+        headers.insert(
+            http::header::ACCEPT,
+            http::header::HeaderValue::from_static("application/vnd.github.v3.diff"),
         );
 
         crate::retry::with_retry("github: fetch PR diff", || async {
             let response = self
-                .http
-                .get(&url)
-                .send()
+                .octocrab
+                ._get_with_headers(route.as_str(), Some(headers.clone()))
                 .await
-                .with_context(|| format!("Failed to fetch raw diff for PR #{number}"))?;
+                .with_context(|| format!("Failed to fetch diff for PR #{number}"))?;
 
             let status = response.status();
-            let text = response
-                .text()
+            let body = response
+                .into_body()
+                .collect()
                 .await
-                .with_context(|| format!("Failed to read raw diff for PR #{number}"))?;
+                .with_context(|| format!("Failed to read diff body for PR #{number}"))?
+                .to_bytes();
+            let text = String::from_utf8(body.to_vec())
+                .with_context(|| format!("Diff for PR #{number} was not valid UTF-8"))?;
 
             if !status.is_success() {
                 anyhow::bail!("Failed to fetch diff for PR #{number}: HTTP {status}");


### PR DESCRIPTION
## Summary
`fetch_pr_diff_raw` called `https://github.com/{owner}/{repo}/pull/N.diff` — GitHub's main web domain, not its API — with a bare unauthenticated `reqwest` client. In production this endpoint consistently times out from inside the cluster (confirmed via a live `wshm review --repo rtk-ai/icm --pr 470` run — two attempts, both timing out after 30s each, while `api.github.com` auth succeeded fine moments earlier in the same process).

This silently broke every pipeline that needs a PR diff: `pr_analysis` (`analyze_prs`) and the just-shipped inline code review pipeline both go through this one function.

Switched to octocrab's low-level `_get_with_headers`, requesting `GET /repos/{owner}/{repo}/pulls/{number}` with an `application/vnd.github.v3.diff` Accept header — same authenticated client already used for every other GitHub call in this codebase, same `api.github.com` host, same token/rate-limit headroom.

## Test plan
- [x] `cargo build` + `cargo test --lib` (83 passed)
- [ ] CI green
- [ ] Re-run `wshm review --repo rtk-ai/icm --pr 470` against prod after deploy to confirm the diff actually fetches now