### PR TITLE
fix(web): round 2 UX fixes — sort arrows, label truncation, search table, conflict weight

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -409,7 +409,11 @@ fn pr_default_mergeable() -> i32 {
     2
 }
 fn pr_default_conflict() -> i32 {
-    -25
+    // Must outweigh every other positive signal a PR can rack up (ci_green
+    // 25 + age_bonus_max 10 = 35) so an old, green-CI PR with a real GitHub
+    // merge conflict can never coast above a clean PR on age alone — a
+    // conflict means it needs a rebase before it's "ready", full stop.
+    -35
 }
 fn pr_default_linked_issue() -> i32 {
     5

--- a/web/src/lib/sort.ts
+++ b/web/src/lib/sort.ts
@@ -58,7 +58,7 @@ export function toggleSort(columns: SortColumn[], key: string, shiftKey: boolean
 export function sortArrow(columns: SortColumn[], key: string): string {
 	const col = columns.find((c) => c.key === key);
 	if (!col) return '';
-	return col.asc ? 'v' : '^';
+	return col.asc ? '▲' : '▼';
 }
 
 export function sortIndex(columns: SortColumn[], key: string): number {

--- a/web/src/routes/issues/+page.svelte
+++ b/web/src/routes/issues/+page.svelte
@@ -203,9 +203,9 @@
 									<Tooltip.Root>
 										<Tooltip.Trigger>
 											{#snippet child({ props })}
-												<span {...props} class="flex items-center gap-1 truncate">
+												<span {...props} class="flex items-center gap-1 min-w-0">
 													{#each issue.labels.slice(0, 2) as label}
-														<Badge variant="outline" class="bg-primary/15 text-primary shrink-0">{label}</Badge>
+														<Badge variant="outline" class="bg-primary/15 text-primary min-w-0 shrink text-ellipsis">{label}</Badge>
 													{/each}
 													{#if issue.labels.length > 2}
 														<Badge variant="outline" class="text-muted-foreground shrink-0">+{issue.labels.length - 2}</Badge>

--- a/web/src/routes/search/+page.svelte
+++ b/web/src/routes/search/+page.svelte
@@ -195,7 +195,7 @@
 	</Card.Root>
 {:else}
 	<div class="w-full overflow-x-auto rounded-lg border">
-		<Table.Root class="w-full">
+		<Table.Root class="w-full table-fixed">
 			<Table.Header class="text-xs uppercase text-muted-foreground">
 				<Table.Row>
 					<Table.Head class="px-2 py-1.5 w-[80px]">Kind</Table.Head>


### PR DESCRIPTION
## Summary
Second round of fixes from a fresh UX/UI audit after the first cycle:

- **Sort-indicator headers** were rendering literal ASCII ('v'/'^') instead of real arrow glyphs — read as a stray version tag ("PRIORITY V1"). Now real ▲/▼.
- **Issues LABELS cell**: the first fix (tooltip) didn't address the actual clipping — badges all had `shrink-0`, so overflow just cut a badge raw mid-word past `overflow-hidden`. Now badges shrink and ellipsize their own text properly.
- **Search results table** lacked `table-fixed`, so its truncate() classes never bound to an actual width — relied on an easy-to-miss horizontal scroll instead of clipping cleanly like every other list page.
- **Merge-queue conflict penalty** (-25) could be outweighed by CI+age alone (25+10=35), letting an old conflicted PR outrank a clean one on age alone. Bumped to -35 so conflict always dominates.

## Test plan
- [x] `cargo build` + `cargo test --lib` (83 passed)
- [x] `npm run check` + `npm run build` — no new type errors vs baseline
- [ ] CI green