### PR TITLE
fix(web): actually fix issues label truncation (round 3)

### DIFF
--- a/web/src/routes/issues/+page.svelte
+++ b/web/src/routes/issues/+page.svelte
@@ -205,7 +205,9 @@
 											{#snippet child({ props })}
 												<span {...props} class="flex items-center gap-1 min-w-0">
 													{#each issue.labels.slice(0, 2) as label}
-														<Badge variant="outline" class="bg-primary/15 text-primary min-w-0 shrink text-ellipsis">{label}</Badge>
+														<Badge variant="outline" class="bg-primary/15 text-primary min-w-0 shrink">
+															<span class="truncate min-w-0">{label}</span>
+														</Badge>
 													{/each}
 													{#if issue.labels.length > 2}
 														<Badge variant="outline" class="text-muted-foreground shrink-0">+{issue.labels.length - 2}</Badge>


### PR DESCRIPTION
## Summary
Round-2's fix (`min-w-0 shrink text-ellipsis` on the Badge) still didn't work: Badge's own base classes make it a flex container with `justify-content:center`, and `text-overflow:ellipsis` has no effect on a flex box — only on a block/inline-block text container. That's also why it clipped symmetrically from both sides (raw overflow around a centered flex item) instead of ellipsizing the end.

Moved the truncate behavior onto a plain `<span>` wrapping the label text inside the Badge, with `min-w-0` on both the Badge and the span so each can actually shrink below its content width in the flex row.

Verified with a standalone repro against the real compiled CSS before shipping (screenshot + computed-style check), since this was the second attempt at this specific bug.

## Test plan
- [x] `cargo build`
- [x] `npm run check` + `npm run build` — no new type errors
- [x] Standalone CSS repro confirms `overflow:hidden; white-space:nowrap; text-overflow:ellipsis; display:block` on the truncate span, screenshot shows real "…" clipping
- [ ] CI green