### PR TITLE
fix(web): round 4 UX fixes — changelog pagination, mobile repo table scroll

### DIFF
--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -109,6 +109,7 @@
 		</Card.Header>
 		<Card.Content>
 			{#if status && status.repos.length > 0}
+				<div class="w-full overflow-x-auto">
 				<Table.Root class="w-full">
 					<Table.Header class="text-xs uppercase text-muted-foreground">
 						<Table.Row>
@@ -143,6 +144,7 @@
 						{/each}
 					</Table.Body>
 				</Table.Root>
+				</div>
 			{:else}
 				<p class="text-sm text-muted-foreground">No repositories configured.</p>
 			{/if}

--- a/web/src/routes/changelog/+page.svelte
+++ b/web/src/routes/changelog/+page.svelte
@@ -43,6 +43,12 @@
 	let totalPrs: number = $derived(
 		result ? result.sections.reduce((sum: number, s: ChangelogSection) => sum + s.pull_requests.length, 0) : 0
 	);
+
+	// Each section starts capped so a large merged-PR history (hundreds of
+	// entries) doesn't render as one endless scroll — expand per section on
+	// demand instead of paginating the whole page.
+	const INITIAL_VISIBLE = 15;
+	let expanded: Record<string, boolean> = $state({});
 </script>
 
 <svelte:head>
@@ -73,7 +79,7 @@
 				</div>
 
 				<div class="space-y-2 ml-7">
-					{#each section.pull_requests as pr}
+					{#each (expanded[section.name] ? section.pull_requests : section.pull_requests.slice(0, INITIAL_VISIBLE)) as pr}
 						<div class="flex items-start gap-3 text-sm">
 							<span class="font-mono text-primary shrink-0">#{pr.number}</span>
 							<div class="flex-1">
@@ -85,6 +91,15 @@
 							<span class="text-xs text-muted-foreground shrink-0">{pr.merged_at?.slice(0, 10) ?? ''}</span>
 						</div>
 					{/each}
+					{#if section.pull_requests.length > INITIAL_VISIBLE}
+						<button
+							type="button"
+							class="text-xs text-primary hover:underline"
+							onclick={() => (expanded[section.name] = !expanded[section.name])}
+						>
+							{expanded[section.name] ? 'Show fewer' : `Show ${section.pull_requests.length - INITIAL_VISIBLE} more`}
+						</button>
+					{/if}
 				</div>
 			</div>
 		{/each}


### PR DESCRIPTION
## Summary
Two fixes from a fourth UX audit that covered previously-unreviewed pages:

- **Changelog** rendered every merged PR in every category as one flat unbounded list (hundreds of entries for an active repo). Each section now caps at 15 visible entries with a "Show N more" toggle.
- **Dashboard Repositories table** had no `overflow-x-auto` wrapper — on narrow viewports the Conflicts/Last sync/Mode columns (the highest-signal ones) scrolled off-screen with no way to reach them.

## Test plan
- [x] `cargo build` + `cargo test --lib` (83 passed)
- [x] `npm run check` + `npm run build` — no new type errors
- [ ] CI green