### PR TITLE
fix(web): round 6 UX fixes — dead RISK column, misleading pagination total

### DIFF
--- a/web/src/lib/components/PrDetail.svelte
+++ b/web/src/lib/components/PrDetail.svelte
@@ -13,11 +13,13 @@
 	const badgeGreen = 'border-green-500/30 bg-green-500/15 text-green-600 dark:text-green-400';
 	const badgeRed = 'border-red-500/30 bg-red-500/15 text-red-600 dark:text-red-400';
 	const badgeYellow = 'border-yellow-500/30 bg-yellow-500/15 text-yellow-600 dark:text-yellow-400';
+	const badgeGray = 'border-transparent bg-secondary text-secondary-foreground';
 
 	function riskClass(risk: string | null): string {
 		if (risk === 'high') return badgeRed;
 		if (risk === 'medium') return badgeYellow;
-		return badgeGreen;
+		if (risk === 'low') return badgeGreen;
+		return badgeGray;
 	}
 
 	// `pr.url` is built server-side from the configured forge — no

--- a/web/src/lib/components/TablePagination.svelte
+++ b/web/src/lib/components/TablePagination.svelte
@@ -8,9 +8,17 @@
 		offset: number;
 		storageKey?: string;
 		onChange: (next: { limit: number; offset: number }) => void;
+		/** Rows actually shown after client-side text/dropdown filters are
+		 * applied to the currently-loaded page. Filtering here only ever
+		 * narrows what's on THIS page — Prev/Next still page through the
+		 * unfiltered server total — so when this differs from the page's
+		 * loaded row count, the summary switches to an honest "N matching
+		 * (of M loaded, T total)" instead of implying the filtered set
+		 * spans the whole T. */
+		filteredCount?: number;
 	}
 
-	let { total, limit, offset, storageKey, onChange }: Props = $props();
+	let { total, limit, offset, storageKey, onChange, filteredCount }: Props = $props();
 
 	const sizes = [25, 50, 100, 250, 500];
 
@@ -38,6 +46,8 @@
 
 	const start = $derived(total === 0 ? 0 : offset + 1);
 	const end = $derived(Math.min(total, offset + limit));
+	const loadedOnPage = $derived(total === 0 ? 0 : end - offset);
+	const isFiltered = $derived(filteredCount !== undefined && filteredCount !== loadedOnPage);
 	const canPrev = $derived(offset > 0);
 	const canNext = $derived(offset + limit < total);
 </script>
@@ -62,6 +72,8 @@
 	<div>
 		{#if total === 0}
 			0 items
+		{:else if isFiltered}
+			{filteredCount} matching (of {loadedOnPage} loaded, {total} total)
 		{:else}
 			{start}–{end} of {total}
 		{/if}

--- a/web/src/routes/activity/+page.svelte
+++ b/web/src/routes/activity/+page.svelte
@@ -252,5 +252,5 @@
 		</Dialog.Content>
 	</Dialog.Root>
 
-	<TablePagination {total} limit={pageLimit} offset={pageOffset} storageKey={PAGE_KEY} onChange={onPageChange} />
+	<TablePagination {total} limit={pageLimit} offset={pageOffset} storageKey={PAGE_KEY} onChange={onPageChange} filteredCount={sorted.length} />
 {/if}

--- a/web/src/routes/issues/+page.svelte
+++ b/web/src/routes/issues/+page.svelte
@@ -251,5 +251,5 @@
 		</Dialog.Content>
 	</Dialog.Root>
 
-	<TablePagination {total} limit={pageLimit} offset={pageOffset} storageKey={PAGE_KEY} onChange={onPageChange} />
+	<TablePagination {total} limit={pageLimit} offset={pageOffset} storageKey={PAGE_KEY} onChange={onPageChange} filteredCount={sorted.length} />
 {/if}

--- a/web/src/routes/prs/+page.svelte
+++ b/web/src/routes/prs/+page.svelte
@@ -32,7 +32,7 @@
 	let loading = $state(true);
 	let sortColumns: SortColumn[] = $state([{ key: 'risk_level', asc: true }, { key: 'age', asc: false }]);
 	let filters: Record<string, string> = $state({
-		number: '', title: '', state: '', base_ref: '', risk: '', ci_status: '',
+		number: '', title: '', state: '', base_ref: '', risk_level: '', ci_status: '',
 		conflicts: $page.url.searchParams.get('conflicts') ?? '', age: ''
 	});
 
@@ -62,7 +62,7 @@
 		number: filters.number,
 		title: filters.title,
 		state: filters.state,
-		risk: filters.risk,
+		risk_level: filters.risk_level,
 		ci_status: filters.ci_status,
 		conflicts: filters.conflicts,
 		age: filters.age
@@ -71,7 +71,7 @@
 	let sorted = $derived(multiSort(filtered, sortColumns));
 
 	let stateOptions = $derived(distinctValues(enriched, 'state'));
-	let riskOptions = $derived(distinctValues(enriched, 'risk'));
+	let riskOptions = $derived(distinctValues(enriched, 'risk_level'));
 	let ciOptions = $derived(distinctValues(enriched, 'ci_status'));
 	let conflictsOptions = $derived(distinctValues(enriched, 'conflicts'));
 	let pageLimit = $state(readStoredLimit());
@@ -167,8 +167,8 @@
 					<Table.Head class="cursor-pointer select-none px-2 py-1.5 w-[90px]" onclick={(e: MouseEvent) => handleSort('base_ref', e)}>
 						Base <span class={sortArrowClass(sortColumns, 'base_ref')}>{sortArrow(sortColumns, 'base_ref')}</span>{#if sortIndex(sortColumns, 'base_ref') > 0}<span class="text-[0.625rem] text-primary ml-0.5">{sortIndex(sortColumns, 'base_ref')}</span>{/if}
 					</Table.Head>
-					<Table.Head class="cursor-pointer select-none px-2 py-1.5 w-[80px]" onclick={(e: MouseEvent) => handleSort('risk', e)}>
-						Risk <span class={sortArrowClass(sortColumns, 'risk')}>{sortArrow(sortColumns, 'risk')}</span>{#if sortIndex(sortColumns, 'risk') > 0}<span class="text-[0.625rem] text-primary ml-0.5">{sortIndex(sortColumns, 'risk')}</span>{/if}
+					<Table.Head class="cursor-pointer select-none px-2 py-1.5 w-[80px]" onclick={(e: MouseEvent) => handleSort('risk_level', e)}>
+						Risk <span class={sortArrowClass(sortColumns, 'risk_level')}>{sortArrow(sortColumns, 'risk_level')}</span>{#if sortIndex(sortColumns, 'risk_level') > 0}<span class="text-[0.625rem] text-primary ml-0.5">{sortIndex(sortColumns, 'risk_level')}</span>{/if}
 					</Table.Head>
 					<Table.Head class="cursor-pointer select-none px-2 py-1.5 w-[80px]" onclick={(e: MouseEvent) => handleSort('ci_status', e)}>
 						CI <span class={sortArrowClass(sortColumns, 'ci_status')}>{sortArrow(sortColumns, 'ci_status')}</span>{#if sortIndex(sortColumns, 'ci_status') > 0}<span class="text-[0.625rem] text-primary ml-0.5">{sortIndex(sortColumns, 'ci_status')}</span>{/if}
@@ -187,7 +187,7 @@
 					<Table.Cell class="px-2 py-1"><Input type="text" bind:value={filters.title} placeholder="filter..." class="h-8 px-2 text-xs" /></Table.Cell>
 					<Table.Cell class="px-2 py-1"><FilterSelect bind:value={filters.state} options={stateOptions} /></Table.Cell>
 					<Table.Cell class="px-2 py-1"><Input type="text" bind:value={filters.base_ref} placeholder="main..." class="h-8 px-2 text-xs" /></Table.Cell>
-					<Table.Cell class="px-2 py-1"><FilterSelect bind:value={filters.risk} options={riskOptions} /></Table.Cell>
+					<Table.Cell class="px-2 py-1"><FilterSelect bind:value={filters.risk_level} options={riskOptions} /></Table.Cell>
 					<Table.Cell class="px-2 py-1"><FilterSelect bind:value={filters.ci_status} options={ciOptions} /></Table.Cell>
 					<Table.Cell class="px-2 py-1"><FilterSelect bind:value={filters.conflicts} options={conflictsOptions} /></Table.Cell>
 					<Table.Cell class="px-2 py-1"><Input type="text" bind:value={filters.age} placeholder=">N" class="h-8 px-2 text-xs" /></Table.Cell>
@@ -212,8 +212,8 @@
 						</Table.Cell>
 						<Table.Cell class="px-2 py-1.5 text-xs mono text-muted-foreground">{pr.base_ref ?? '-'}</Table.Cell>
 						<Table.Cell class="px-2 py-1.5">
-							{#if pr.risk}
-								<Badge variant="outline" class={riskBadgeClass(pr.risk)}>{pr.risk}</Badge>
+							{#if pr.risk_level}
+								<Badge variant="outline" class={riskBadgeClass(pr.risk_level)}>{pr.risk_level}</Badge>
 							{:else}
 								<span class="text-muted-foreground">-</span>
 							{/if}
@@ -266,5 +266,5 @@
 		</Dialog.Content>
 	</Dialog.Root>
 
-	<TablePagination {total} limit={pageLimit} offset={pageOffset} storageKey={PAGE_KEY} onChange={onPageChange} />
+	<TablePagination {total} limit={pageLimit} offset={pageOffset} storageKey={PAGE_KEY} onChange={onPageChange} filteredCount={sorted.length} />
 {/if}

--- a/web/src/routes/queue/+page.svelte
+++ b/web/src/routes/queue/+page.svelte
@@ -248,5 +248,5 @@
 		</Dialog.Content>
 	</Dialog.Root>
 
-	<TablePagination {total} limit={pageLimit} offset={pageOffset} storageKey={PAGE_KEY} onChange={onPageChange} />
+	<TablePagination {total} limit={pageLimit} offset={pageOffset} storageKey={PAGE_KEY} onChange={onPageChange} filteredCount={sorted.length} />
 {/if}

--- a/web/src/routes/search/+page.svelte
+++ b/web/src/routes/search/+page.svelte
@@ -254,6 +254,7 @@
 		offset={pageOffset}
 		storageKey={PAGE_KEY}
 		onChange={onPageChange}
+		filteredCount={filtered.length}
 	/>
 {/if}
 

--- a/web/src/routes/triage/+page.svelte
+++ b/web/src/routes/triage/+page.svelte
@@ -197,5 +197,5 @@
 			</Table.Body>
 		</Table.Root>
 	</div>
-	<TablePagination {total} limit={pageLimit} offset={pageOffset} storageKey={PAGE_KEY} onChange={onPageChange} />
+	<TablePagination {total} limit={pageLimit} offset={pageOffset} storageKey={PAGE_KEY} onChange={onPageChange} filteredCount={sorted.length} />
 {/if}


### PR DESCRIPTION
## Summary
Two real bugs found by testing interactive workflows end-to-end (filtering, sorting, PR detail modal) rather than just loading pages:

- **`/prs` RISK column dead**: every reference used `pr.risk`, a field that doesn't exist on `PullRequest` (the real field is `risk_level`) — filter, sort, and cell display all silently no-op'd. The detail modal correctly showed risk because it referenced `risk_level` directly, which is what exposed the mismatch.
- **Pagination total ignores filters**: `TablePagination`'s "X–Y of TOTAL" always showed the server's unfiltered total even when client-side filters left few/zero matching rows on the current page (filters here only narrow the currently-loaded page, not the full server dataset — that's by design across the app, but the footer text didn't communicate it). Added an optional `filteredCount` prop; when it differs from the page's loaded row count, shows "N matching (of M loaded, T total)" instead. Wired into every page using this component.
- Also: `PrDetail`'s risk badge defaulted to green for any non-high/medium value including null — fixed to gray for unset.

## Test plan
- [x] `cargo build` + `cargo test --lib` (83 passed)
- [x] `npm run check` + `npm run build` — no new type errors
- [ ] CI green